### PR TITLE
Deepen delay and frequency architecture

### DIFF
--- a/architecture_backlog_test.go
+++ b/architecture_backlog_test.go
@@ -1,0 +1,238 @@
+package controlsys
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func architectureTestSystem(t *testing.T, dt float64) *System {
+	t.Helper()
+	sys, err := NewFromSlices(2, 2, 2,
+		[]float64{0, 1, -2, -3},
+		[]float64{1, 0, 0, 1},
+		[]float64{1, 0, 1, 1},
+		[]float64{0.1, 0.2, -0.1, 0.3},
+		dt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sys
+}
+
+func TestEquivalentDelayFormsAgreeThroughPublicOperations(t *testing.T) {
+	base := architectureTestSystem(t, 0)
+
+	split := base.Copy()
+	if err := split.SetInputDelay([]float64{0.2, 0.4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := split.SetOutputDelay([]float64{0.1, 0.1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := split.SetDelay(mat.NewDense(2, 2, []float64{
+		0.0, 0.1,
+		0.2, 0.0,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	total := split.TotalDelay()
+	collapsed := base.Copy()
+	if err := collapsed.SetDelay(total); err != nil {
+		t.Fatal(err)
+	}
+
+	assertDenseApprox(t, split.TotalDelay(), collapsed.TotalDelay(), 0)
+
+	omega := []float64{0.2, 1.7, 6.0}
+	assertFreqResponseApprox(t, split, collapsed, omega, 1e-10)
+
+	right, err := NewGain(mat.NewDense(2, 2, []float64{1, 0, 0, 1}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seriesSplit, err := Series(split, right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seriesCollapsed, err := Series(collapsed, right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFreqResponseApprox(t, seriesSplit, seriesCollapsed, omega, 1e-10)
+}
+
+func TestFrequencyResponseEntryPointsAgreeForDelayedDiscreteMIMO(t *testing.T) {
+	sys := architectureTestSystem(t, 0.1)
+	if err := sys.SetInputDelay([]float64{1, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sys.SetOutputDelay([]float64{0, 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := sys.SetDelay(mat.NewDense(2, 2, []float64{0, 1, 2, 0})); err != nil {
+		t.Fatal(err)
+	}
+
+	omega := []float64{0.2, 1.1, 4.0}
+	resp, err := sys.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frd, err := sys.FRD(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frdResp := frd.FreqResponse()
+
+	for k, w := range omega {
+		z := cmplx.Exp(complex(0, w*sys.Dt))
+		eval, err := sys.EvalFr(z)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < resp.P; i++ {
+			for j := 0; j < resp.M; j++ {
+				assertComplexApprox(t, eval[i][j], resp.At(k, i, j), 1e-10)
+				assertComplexApprox(t, frd.At(k, i, j), resp.At(k, i, j), 1e-10)
+				assertComplexApprox(t, frdResp.At(k, i, j), resp.At(k, i, j), 1e-10)
+			}
+		}
+	}
+}
+
+func TestTransferFunctionPreservesRowRealizationBehavior(t *testing.T) {
+	sys, err := NewFromSlices(3, 2, 2,
+		[]float64{
+			0, 1, 0,
+			0, 0, 1,
+			-6, -11, -6,
+		},
+		[]float64{
+			0, 1,
+			1, 0,
+			1, 1,
+		},
+		[]float64{
+			1, 0, 1,
+			0, 1, 1,
+		},
+		[]float64{
+			0.2, -0.1,
+			0.3, 0.4,
+		},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sys.SetDelay(mat.NewDense(2, 2, []float64{0.1, 0.2, 0.3, 0.4})); err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"u1", "u2"}
+	sys.OutputName = []string{"y1", "y2"}
+
+	res, err := sys.TransferFunction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.MinimalOrder <= 0 {
+		t.Fatalf("MinimalOrder = %d, want positive", res.MinimalOrder)
+	}
+	if len(res.RowDegrees) != 2 {
+		t.Fatalf("len(RowDegrees) = %d, want 2", len(res.RowDegrees))
+	}
+	for i, degree := range res.RowDegrees {
+		if degree <= 0 {
+			t.Fatalf("RowDegrees[%d] = %d, want positive", i, degree)
+		}
+	}
+	if !stringSlicesEqual(res.TF.InputName, sys.InputName) {
+		t.Fatalf("InputName = %v, want %v", res.TF.InputName, sys.InputName)
+	}
+	if !stringSlicesEqual(res.TF.OutputName, sys.OutputName) {
+		t.Fatalf("OutputName = %v, want %v", res.TF.OutputName, sys.OutputName)
+	}
+	for i := 0; i < 2; i++ {
+		for j := 0; j < 2; j++ {
+			if res.TF.Delay[i][j] != sys.Delay.At(i, j) {
+				t.Fatalf("Delay[%d][%d] = %v, want %v", i, j, res.TF.Delay[i][j], sys.Delay.At(i, j))
+			}
+		}
+	}
+
+	omega := []float64{0.3, 1.4, 5.0}
+	resp, err := sys.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k, w := range omega {
+		tfEval := res.TF.Eval(complex(0, w))
+		for i := 0; i < 2; i++ {
+			for j := 0; j < 2; j++ {
+				assertComplexApprox(t, tfEval[i][j], resp.At(k, i, j), 1e-8)
+			}
+		}
+	}
+}
+
+func assertFreqResponseApprox(t *testing.T, a, b *System, omega []float64, tol float64) {
+	t.Helper()
+	ra, err := a.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rb, err := b.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ra.NFreq != rb.NFreq || ra.P != rb.P || ra.M != rb.M {
+		t.Fatalf("response dims = (%d,%d,%d), want (%d,%d,%d)", ra.NFreq, ra.P, ra.M, rb.NFreq, rb.P, rb.M)
+	}
+	for k := 0; k < ra.NFreq; k++ {
+		for i := 0; i < ra.P; i++ {
+			for j := 0; j < ra.M; j++ {
+				assertComplexApprox(t, ra.At(k, i, j), rb.At(k, i, j), tol)
+			}
+		}
+	}
+}
+
+func assertDenseApprox(t *testing.T, got, want *mat.Dense, tol float64) {
+	t.Helper()
+	gr, gc := got.Dims()
+	wr, wc := want.Dims()
+	if gr != wr || gc != wc {
+		t.Fatalf("dims = %dx%d, want %dx%d", gr, gc, wr, wc)
+	}
+	for i := 0; i < gr; i++ {
+		for j := 0; j < gc; j++ {
+			if math.Abs(got.At(i, j)-want.At(i, j)) > tol {
+				t.Fatalf("(%d,%d) = %v, want %v", i, j, got.At(i, j), want.At(i, j))
+			}
+		}
+	}
+}
+
+func assertComplexApprox(t *testing.T, got, want complex128, tol float64) {
+	t.Helper()
+	if cmplx.Abs(got-want) > tol {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/connect.go
+++ b/connect.go
@@ -29,53 +29,65 @@ func setBlock(dst *mat.Dense, r0, c0 int, src *mat.Dense) {
 	}
 }
 
+type interconnectionPlan struct {
+	sys1, sys2 *System
+	n1, m1, p1 int
+	n2, m2, p2 int
+}
+
+func newInterconnectionPlan(sys1, sys2 *System) interconnectionPlan {
+	n1, m1, p1 := sys1.Dims()
+	n2, m2, p2 := sys2.Dims()
+	return interconnectionPlan{
+		sys1: sys1, sys2: sys2,
+		n1: n1, m1: m1, p1: p1,
+		n2: n2, m2: m2, p2: p2,
+	}
+}
+
+func (plan interconnectionPlan) seriesNeedsLFT() bool {
+	if plan.sys1.HasInternalDelay() || plan.sys2.HasInternalDelay() {
+		return true
+	}
+	if !plan.sys1.HasDelay() && !plan.sys2.HasDelay() {
+		return false
+	}
+	ioCheck := seriesDelay(plan.sys1, plan.sys2)
+	if ioCheck == nil && (plan.sys1.Delay != nil || plan.sys2.Delay != nil) {
+		return true
+	}
+	if plan.sys1.OutputDelay == nil && plan.sys2.InputDelay == nil {
+		return false
+	}
+	for k := 1; k < plan.p1; k++ {
+		if math.Abs(plan.intermediateSeriesDelay(k)-plan.intermediateSeriesDelay(0)) > 1e-12 {
+			return true
+		}
+	}
+	return false
+}
+
+func (plan interconnectionPlan) intermediateSeriesDelay(k int) float64 {
+	var delay float64
+	if plan.sys1.OutputDelay != nil {
+		delay += plan.sys1.OutputDelay[k]
+	}
+	if plan.sys2.InputDelay != nil {
+		delay += plan.sys2.InputDelay[k]
+	}
+	return delay
+}
+
 func Series(sys1, sys2 *System) (*System, error) {
 	if err := domainMatch(sys1, sys2); err != nil {
 		return nil, err
 	}
-	_, _, p1 := sys1.Dims()
-	_, m2, _ := sys2.Dims()
-	if p1 != m2 {
-		return nil, fmt.Errorf("series: sys1 outputs %d != sys2 inputs %d: %w", p1, m2, ErrDimensionMismatch)
+	plan := newInterconnectionPlan(sys1, sys2)
+	if plan.p1 != plan.m2 {
+		return nil, fmt.Errorf("series: sys1 outputs %d != sys2 inputs %d: %w", plan.p1, plan.m2, ErrDimensionMismatch)
 	}
 
-	if sys1.HasInternalDelay() || sys2.HasInternalDelay() {
-		return seriesLFT(sys1, sys2)
-	}
-
-	needsLFT := false
-	if sys1.HasDelay() || sys2.HasDelay() {
-		ioCheck := seriesDelay(sys1, sys2)
-		if ioCheck == nil && (sys1.Delay != nil || sys2.Delay != nil) {
-			needsLFT = true
-		}
-		if !needsLFT && (sys1.OutputDelay != nil || sys2.InputDelay != nil) {
-			for k := 0; k < p1; k++ {
-				var od, id float64
-				if sys1.OutputDelay != nil {
-					od = sys1.OutputDelay[k]
-				}
-				if sys2.InputDelay != nil {
-					id = sys2.InputDelay[k]
-				}
-				if k > 0 {
-					var od0, id0 float64
-					if sys1.OutputDelay != nil {
-						od0 = sys1.OutputDelay[0]
-					}
-					if sys2.InputDelay != nil {
-						id0 = sys2.InputDelay[0]
-					}
-					if math.Abs((od+id)-(od0+id0)) > 1e-12 {
-						needsLFT = true
-						break
-					}
-				}
-			}
-		}
-	}
-
-	if needsLFT {
+	if plan.seriesNeedsLFT() {
 		return seriesLFT(sys1, sys2)
 	}
 
@@ -242,10 +254,9 @@ func Parallel(sys1, sys2 *System) (*System, error) {
 	if err := domainMatch(sys1, sys2); err != nil {
 		return nil, err
 	}
-	_, m1, p1 := sys1.Dims()
-	_, m2, p2 := sys2.Dims()
-	if m1 != m2 || p1 != p2 {
-		return nil, fmt.Errorf("parallel: dims (%d,%d) vs (%d,%d): %w", p1, m1, p2, m2, ErrDimensionMismatch)
+	plan := newInterconnectionPlan(sys1, sys2)
+	if plan.m1 != plan.m2 || plan.p1 != plan.p2 {
+		return nil, fmt.Errorf("parallel: dims (%d,%d) vs (%d,%d): %w", plan.p1, plan.m1, plan.p2, plan.m2, ErrDimensionMismatch)
 	}
 
 	if sys1.HasInternalDelay() || sys2.HasInternalDelay() {
@@ -280,31 +291,7 @@ func parallelNeedsLFT(sys1, sys2 *System) bool {
 }
 
 func totalDelayMatrix(sys *System, p, m int) *mat.Dense {
-	if sys.Delay == nil && sys.InputDelay == nil && sys.OutputDelay == nil {
-		return nil
-	}
-	data := make([]float64, p*m)
-	if sys.Delay != nil {
-		raw := sys.Delay.RawMatrix()
-		for i := 0; i < p; i++ {
-			copy(data[i*m:i*m+m], raw.Data[i*raw.Stride:i*raw.Stride+m])
-		}
-	}
-	if sys.InputDelay != nil {
-		for j := 0; j < m; j++ {
-			for i := 0; i < p; i++ {
-				data[i*m+j] += sys.InputDelay[j]
-			}
-		}
-	}
-	if sys.OutputDelay != nil {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
-				data[i*m+j] += sys.OutputDelay[i]
-			}
-		}
-	}
-	return mat.NewDense(p, m, data)
+	return effectiveIODelayMatrix(sys, p, m, true)
 }
 
 func parallelSimple(sys1, sys2 *System) (*System, error) {
@@ -792,6 +779,9 @@ func concatDelay(d1 []float64, n1 int, d2 []float64, n2 int) []float64 {
 func mulDense(a, b *mat.Dense) *mat.Dense {
 	ar, _ := a.Dims()
 	_, bc := b.Dims()
+	if ar == 0 || bc == 0 {
+		return &mat.Dense{}
+	}
 	r := mat.NewDense(ar, bc, nil)
 	r.Mul(a, b)
 	return r

--- a/delay.go
+++ b/delay.go
@@ -135,21 +135,27 @@ func validateSliceDelay(delay []float64, expected int, dt float64) error {
 
 func (sys *System) TotalDelay() *mat.Dense {
 	_, m, p := sys.Dims()
-	if sys.Delay == nil && sys.InputDelay == nil && sys.OutputDelay == nil {
+	return effectiveIODelayMatrix(sys, p, m, true)
+}
+
+func effectiveIODelayMatrix(sys *System, p, m int, includeDelayMatrix bool) *mat.Dense {
+	if !hasExternalDelay(sys, includeDelayMatrix) || p == 0 || m == 0 {
 		return nil
 	}
-	if p == 0 || m == 0 {
-		return nil
-	}
+	data := effectiveIODelayData(sys, p, m, includeDelayMatrix)
+	return mat.NewDense(p, m, data)
+}
+
+func effectiveIODelayData(sys *System, p, m int, includeDelayMatrix bool) []float64 {
 	data := make([]float64, p*m)
-	if sys.Delay != nil {
+	if includeDelayMatrix && sys.Delay != nil {
 		raw := sys.Delay.RawMatrix()
 		for i := 0; i < p; i++ {
 			copy(data[i*m:i*m+m], raw.Data[i*raw.Stride:i*raw.Stride+m])
 		}
 	}
-	for j := 0; j < m; j++ {
-		if sys.InputDelay != nil {
+	if sys.InputDelay != nil {
+		for j := 0; j < m; j++ {
 			for i := 0; i < p; i++ {
 				data[i*m+j] += sys.InputDelay[j]
 			}
@@ -162,7 +168,11 @@ func (sys *System) TotalDelay() *mat.Dense {
 			}
 		}
 	}
-	return mat.NewDense(p, m, data)
+	return data
+}
+
+func hasExternalDelay(sys *System, includeDelayMatrix bool) bool {
+	return sys.InputDelay != nil || sys.OutputDelay != nil || (includeDelayMatrix && sys.Delay != nil)
 }
 
 func (sys *System) HasDelay() bool {

--- a/frd.go
+++ b/frd.go
@@ -247,22 +247,7 @@ func (f *FRD) Bode() *BodeResult {
 			}
 		}
 	}
-
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
-			for k := 1; k < nw; k++ {
-				cur := k*pm + i*m + j
-				prev := (k-1)*pm + i*m + j
-				diff := phase[cur] - phase[prev]
-				if diff > 180 {
-					phase[cur] -= 360
-				}
-				if diff < -180 {
-					phase[cur] += 360
-				}
-			}
-		}
-	}
+	unwrapBodePhase(phase, p, m, nw)
 
 	omega := make([]float64, nw)
 	copy(omega, f.Omega)

--- a/frequency.go
+++ b/frequency.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"math/cmplx"
 
-	"gonum.org/v1/gonum/blas/blas64"
 	"gonum.org/v1/gonum/lapack"
+	"gonum.org/v1/gonum/mat"
 )
 
 type FreqResponseMatrix struct {
@@ -38,68 +38,56 @@ func (b *BodeResult) PhaseAt(freq, output, input int) float64 {
 	return b.phase[freq*b.p*b.m+output*b.m+input]
 }
 
-func (sys *System) FreqResponse(omega []float64) (*FreqResponseMatrix, error) {
-	if len(omega) == 0 {
-		return nil, nil
-	}
-
-	n, m, p := sys.Dims()
-
-	if sys.HasInternalDelay() {
-		resp, err := freqResponseLFT(sys, omega, p, m)
-		if err != nil {
-			return nil, err
-		}
-		applyIODelayPhase(sys, omega, resp.Data, p, m, true)
-		resp.InputName = copyStringSlice(sys.InputName)
-		resp.OutputName = copyStringSlice(sys.OutputName)
-		return resp, nil
-	}
-
+func bodeResultFromResponse(omega []float64, data []complex128, p, m int, inputName, outputName []string) *BodeResult {
 	nw := len(omega)
 	pm := p * m
-	data := make([]complex128, nw*pm)
-	if nw == 1 {
-		var s complex128
-		if sys.IsContinuous() {
-			s = complex(0, omega[0])
-		} else {
-			s = cmplx.Exp(complex(0, omega[0]*sys.Dt))
+	magDB := make([]float64, nw*pm)
+	phase := make([]float64, nw*pm)
+
+	for k := range omega {
+		for i := 0; i < p; i++ {
+			for j := 0; j < m; j++ {
+				off := (k*p+i)*m + j
+				h := data[off]
+				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
+				phase[off] = cmplx.Phase(h) * 180 / math.Pi
+			}
 		}
-		ws := newSSEvalWorkspace(n, p, m)
-		if err := evalFrSSInto(ws, sys, s, n, p, m); err != nil {
-			return nil, err
-		}
-		copy(data, ws.g[:pm])
-		applyIODelayAtS(sys, s, data, p, m, true)
-		return &FreqResponseMatrix{
-			Data: data, NFreq: nw, P: p, M: m,
-			InputName:  copyStringSlice(sys.InputName),
-			OutputName: copyStringSlice(sys.OutputName),
-		}, nil
 	}
 
-	res, err := sys.TransferFunction(nil)
-	if err != nil {
-		return nil, err
+	unwrapBodePhase(phase, p, m, nw)
+
+	return &BodeResult{
+		Omega:      omega,
+		magDB:      magDB,
+		phase:      phase,
+		p:          p,
+		m:          m,
+		InputName:  inputName,
+		OutputName: outputName,
 	}
-	for k, w := range omega {
-		var s complex128
-		if sys.IsContinuous() {
-			s = complex(0, w)
-		} else {
-			s = cmplx.Exp(complex(0, w*sys.Dt))
+}
+
+func unwrapBodePhase(phase []float64, p, m, nw int) {
+	for i := 0; i < p; i++ {
+		for j := 0; j < m; j++ {
+			for k := 1; k < nw; k++ {
+				cur := (k*p+i)*m + j
+				prev := ((k-1)*p+i)*m + j
+				diff := phase[cur] - phase[prev]
+				if diff > 180 {
+					phase[cur] -= 360
+				}
+				if diff < -180 {
+					phase[cur] += 360
+				}
+			}
 		}
-		res.TF.evalInto(s, data[k*pm:(k+1)*pm])
 	}
+}
 
-	applyIODelayPhase(sys, omega, data, p, m, false)
-
-	return &FreqResponseMatrix{
-		Data: data, NFreq: nw, P: p, M: m,
-		InputName:  copyStringSlice(sys.InputName),
-		OutputName: copyStringSlice(sys.OutputName),
-	}, nil
+func (sys *System) FreqResponse(omega []float64) (*FreqResponseMatrix, error) {
+	return newFrequencyEvaluator(sys).response(omega)
 }
 
 func (sys *System) Bode(omega []float64, nPoints int) (*BodeResult, error) {
@@ -116,65 +104,108 @@ func (sys *System) Bode(omega []float64, nPoints int) (*BodeResult, error) {
 		return nil, err
 	}
 
-	p, m := resp.P, resp.M
-	nw := len(omega)
-	pm := p * m
-	magDB := make([]float64, nw*pm)
-	phase := make([]float64, nw*pm)
-
-	for k := range omega {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
-				off := (k*p+i)*m + j
-				h := resp.Data[off]
-				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
-				phase[off] = cmplx.Phase(h) * 180 / math.Pi
-			}
-		}
-	}
-
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
-			for k := 1; k < nw; k++ {
-				cur := (k*p+i)*m + j
-				prev := ((k-1)*p+i)*m + j
-				diff := phase[cur] - phase[prev]
-				if diff > 180 {
-					phase[cur] -= 360
-				}
-				if diff < -180 {
-					phase[cur] += 360
-				}
-			}
-		}
-	}
-
-	return &BodeResult{
-		Omega: omega, magDB: magDB, phase: phase, p: p, m: m,
-		InputName:  copyStringSlice(sys.InputName),
-		OutputName: copyStringSlice(sys.OutputName),
-	}, nil
+	return bodeResultFromResponse(omega, resp.Data, resp.P, resp.M,
+		copyStringSlice(sys.InputName),
+		copyStringSlice(sys.OutputName),
+	), nil
 }
 
 func (sys *System) EvalFr(s complex128) ([][]complex128, error) {
-	n, m, p := sys.Dims()
-	pm := p * m
+	return newFrequencyEvaluator(sys).eval(s)
+}
 
-	if sys.HasInternalDelay() {
-		g, err := evalFrLFT(sys, s, p, m)
+type frequencyEvaluator struct {
+	sys *System
+	n   int
+	m   int
+	p   int
+}
+
+func newFrequencyEvaluator(sys *System) frequencyEvaluator {
+	n, m, p := sys.Dims()
+	return frequencyEvaluator{sys: sys, n: n, m: m, p: p}
+}
+
+func (e frequencyEvaluator) response(omega []float64) (*FreqResponseMatrix, error) {
+	if len(omega) == 0 {
+		return nil, nil
+	}
+	if e.sys.HasInternalDelay() {
+		resp, err := freqResponseLFT(e.sys, omega, e.p, e.m)
 		if err != nil {
 			return nil, err
 		}
-		applyIODelayAtS(sys, s, g, p, m, true)
-		return complexFlatToGrid(g, p, m), nil
+		applyIODelayPhase(e.sys, omega, resp.Data, e.p, e.m, true)
+		resp.InputName = copyStringSlice(e.sys.InputName)
+		resp.OutputName = copyStringSlice(e.sys.OutputName)
+		return resp, nil
 	}
 
-	ws := newSSEvalWorkspace(n, p, m)
-	if err := evalFrSSInto(ws, sys, s, n, p, m); err != nil {
+	nw := len(omega)
+	pm := e.p * e.m
+	data := make([]complex128, nw*pm)
+	if nw == 1 {
+		s := e.sAt(omega[0])
+		if err := e.evalStateSpaceInto(s, data); err != nil {
+			return nil, err
+		}
+		applyIODelayAtS(e.sys, s, data, e.p, e.m, true)
+		return e.matrix(data, nw), nil
+	}
+
+	res, err := e.sys.TransferFunction(nil)
+	if err != nil {
 		return nil, err
 	}
-	applyIODelayAtS(sys, s, ws.g[:pm], p, m, true)
-	return complexFlatToGrid(ws.g[:pm], p, m), nil
+	for k, w := range omega {
+		res.TF.evalInto(e.sAt(w), data[k*pm:(k+1)*pm])
+	}
+	applyIODelayPhase(e.sys, omega, data, e.p, e.m, false)
+	return e.matrix(data, nw), nil
+}
+
+func (e frequencyEvaluator) eval(s complex128) ([][]complex128, error) {
+	pm := e.p * e.m
+
+	if e.sys.HasInternalDelay() {
+		g, err := evalFrLFT(e.sys, s, e.p, e.m)
+		if err != nil {
+			return nil, err
+		}
+		applyIODelayAtS(e.sys, s, g, e.p, e.m, true)
+		return complexFlatToGrid(g, e.p, e.m), nil
+	}
+
+	data := make([]complex128, pm)
+	if err := e.evalStateSpaceInto(s, data); err != nil {
+		return nil, err
+	}
+	applyIODelayAtS(e.sys, s, data, e.p, e.m, true)
+	return complexFlatToGrid(data, e.p, e.m), nil
+}
+
+func (e frequencyEvaluator) sAt(w float64) complex128 {
+	if e.sys.IsContinuous() {
+		return complex(0, w)
+	}
+	return cmplx.Exp(complex(0, w*e.sys.Dt))
+}
+
+func (e frequencyEvaluator) evalStateSpaceInto(s complex128, dst []complex128) error {
+	ws := newSSEvalWorkspace(e.n, e.p, e.m)
+	if err := evalFrSSInto(ws, e.sys, s, e.n, e.p, e.m); err != nil {
+		return err
+	}
+	copy(dst, ws.g[:e.p*e.m])
+	return nil
+}
+
+func (e frequencyEvaluator) matrix(data []complex128, nw int) *FreqResponseMatrix {
+	return &FreqResponseMatrix{
+		Data: data, NFreq: nw, P: e.p, M: e.m,
+		InputName:  copyStringSlice(e.sys.InputName),
+		OutputName: copyStringSlice(e.sys.OutputName),
+	}
 }
 
 func autoBodeFreqs(sys *System, nPoints int) ([]float64, error) {
@@ -252,8 +283,8 @@ func ioDelayTotal(sys *System, i, j int) float64 {
 }
 
 func applyIODelayPhase(sys *System, omega []float64, data []complex128, p, m int, includeDelayMatrix bool) {
-	hasIODelay := sys.InputDelay != nil || sys.OutputDelay != nil || (includeDelayMatrix && sys.Delay != nil)
-	if !hasIODelay {
+	delay := effectiveIODelayMatrix(sys, p, m, includeDelayMatrix)
+	if delay == nil {
 		return
 	}
 
@@ -265,33 +296,23 @@ func applyIODelayPhase(sys *System, omega []float64, data []complex128, p, m int
 		} else {
 			s = cmplx.Exp(complex(0, w*sys.Dt))
 		}
-		applyIODelayAtS(sys, s, data[k*pm:(k+1)*pm], p, m, includeDelayMatrix)
+		applyIODelayMatrixAtS(sys, s, data[k*pm:(k+1)*pm], p, m, delay)
 	}
 }
 
 func applyIODelayAtS(sys *System, s complex128, data []complex128, p, m int, includeDelayMatrix bool) {
-	hasIODelay := sys.InputDelay != nil || sys.OutputDelay != nil || (includeDelayMatrix && sys.Delay != nil)
-	if !hasIODelay {
+	delay := effectiveIODelayMatrix(sys, p, m, includeDelayMatrix)
+	if delay == nil {
 		return
 	}
+	applyIODelayMatrixAtS(sys, s, data, p, m, delay)
+}
 
-	var dRaw blas64.General
-	if includeDelayMatrix && sys.Delay != nil {
-		dRaw = sys.Delay.RawMatrix()
-	}
-
+func applyIODelayMatrixAtS(sys *System, s complex128, data []complex128, p, m int, delay *mat.Dense) {
+	dRaw := delay.RawMatrix()
 	for i := 0; i < p; i++ {
 		for j := 0; j < m; j++ {
-			var tau float64
-			if sys.InputDelay != nil {
-				tau += sys.InputDelay[j]
-			}
-			if sys.OutputDelay != nil {
-				tau += sys.OutputDelay[i]
-			}
-			if includeDelayMatrix && sys.Delay != nil {
-				tau += dRaw.Data[i*dRaw.Stride+j]
-			}
+			tau := dRaw.Data[i*dRaw.Stride+j]
 			if tau == 0 {
 				continue
 			}

--- a/transfer.go
+++ b/transfer.go
@@ -98,93 +98,117 @@ type TransferFuncResult struct {
 }
 
 func (sys *System) TransferFunction(opts *TransferFuncOpts) (*TransferFuncResult, error) {
-	n, m, p := sys.Dims()
-
 	if opts == nil {
 		opts = &TransferFuncOpts{}
 	}
+	return newRowRealizationConverter(sys, opts).convert()
+}
+
+type rowRealizationConverter struct {
+	sys  *System
+	opts *TransferFuncOpts
+	n    int
+	m    int
+	p    int
+	tf   *TransferFunc
+	rows []int
+	dRaw blas64.General
+}
+
+func newRowRealizationConverter(sys *System, opts *TransferFuncOpts) rowRealizationConverter {
+	n, m, p := sys.Dims()
 
 	tf := &TransferFunc{
 		Num: make([][][]float64, p),
 		Den: make([][]float64, p),
 		Dt:  sys.Dt,
 	}
-	rowDeg := make([]int, p)
-
 	var dRaw blas64.General
 	if sys.D != nil {
 		dRaw = sys.D.RawMatrix()
 	}
+	return rowRealizationConverter{
+		sys:  sys,
+		opts: opts,
+		n:    n,
+		m:    m,
+		p:    p,
+		tf:   tf,
+		rows: make([]int, p),
+		dRaw: dRaw,
+	}
+}
 
-	if n == 0 || p == 0 || m == 0 {
-		for i := 0; i < p; i++ {
-			tf.Den[i] = []float64{1}
-			tf.Num[i] = make([][]float64, m)
-			for j := 0; j < m; j++ {
-				if p > 0 && m > 0 {
-					tf.Num[i][j] = []float64{dRaw.Data[i*dRaw.Stride+j]}
-				} else {
-					tf.Num[i][j] = []float64{0}
-				}
-			}
-		}
-		tf.InputName = copyStringSlice(sys.InputName)
-		tf.OutputName = copyStringSlice(sys.OutputName)
-		return &TransferFuncResult{TF: tf, MinimalOrder: 0, RowDegrees: rowDeg}, nil
+func (c rowRealizationConverter) convert() (*TransferFuncResult, error) {
+	if c.n == 0 || c.p == 0 || c.m == 0 {
+		c.fillStaticRows()
+		return c.result(0), nil
 	}
 
-	stair := ControllabilityStaircase(sys.A, sys.B, sys.C, opts.ControllabilityTol)
+	stair := ControllabilityStaircase(c.sys.A, c.sys.B, c.sys.C, c.opts.ControllabilityTol)
 	ncont := stair.NCont
 
 	if ncont == 0 {
-		for i := 0; i < p; i++ {
-			tf.Den[i] = []float64{1}
-			tf.Num[i] = make([][]float64, m)
-			for j := 0; j < m; j++ {
-				tf.Num[i][j] = []float64{dRaw.Data[i*dRaw.Stride+j]}
-			}
-		}
-		tf.InputName = copyStringSlice(sys.InputName)
-		tf.OutputName = copyStringSlice(sys.OutputName)
-		return &TransferFuncResult{TF: tf, MinimalOrder: 0, RowDegrees: rowDeg}, nil
+		c.fillStaticRows()
+		return c.result(0), nil
 	}
 
-	Ac := extractSubmatrix(stair.A, 0, ncont, 0, ncont)
-	Bc := extractSubmatrix(stair.B, 0, ncont, 0, m)
-	Cc := extractSubmatrix(stair.C, 0, p, 0, ncont)
+	totalOrder := c.convertDynamicRows(stair, ncont)
+	return c.result(totalOrder), nil
+}
 
+func (c rowRealizationConverter) convertDynamicRows(stair *StaircaseResult, ncont int) int {
+	Ac := extractSubmatrix(stair.A, 0, ncont, 0, ncont)
+	Bc := extractSubmatrix(stair.B, 0, ncont, 0, c.m)
+	Cc := extractSubmatrix(stair.C, 0, c.p, 0, ncont)
 	var ws *tfWorkspace
 	if ncont > 0 {
-		ws = newTFWorkspace(ncont, m)
+		ws = newTFWorkspace(ncont, c.m)
 	}
 
 	totalOrder := 0
-	for i := 0; i < p; i++ {
-		nobs, den, numCoeffs := ssToTFRow(Ac, Bc, Cc, i, ncont, m, opts.ObservabilityTol, ws)
-		rowDeg[i] = nobs
+	for i := 0; i < c.p; i++ {
+		nobs, den, numCoeffs := ssToTFRow(Ac, Bc, Cc, i, ncont, c.m, c.opts.ObservabilityTol, ws)
+		c.rows[i] = nobs
 		totalOrder += nobs
 
-		tf.Den[i] = den
-		tf.Num[i] = make([][]float64, m)
-		for j := 0; j < m; j++ {
+		c.tf.Den[i] = den
+		c.tf.Num[i] = make([][]float64, c.m)
+		for j := 0; j < c.m; j++ {
 			num := numCoeffs[j]
-			dij := dRaw.Data[i*dRaw.Stride+j]
+			dij := c.dRaw.Data[i*c.dRaw.Stride+j]
 			if dij != 0 {
 				numWithD := Poly(num).Add(Poly(den).Scale(dij))
-				tf.Num[i][j] = []float64(numWithD)
+				c.tf.Num[i][j] = []float64(numWithD)
 			} else {
-				tf.Num[i][j] = num
+				c.tf.Num[i][j] = num
 			}
 		}
 	}
+	return totalOrder
+}
 
-	if sys.Delay != nil {
-		tf.Delay = denseToSlice2D(sys.Delay)
+func (c rowRealizationConverter) fillStaticRows() {
+	for i := 0; i < c.p; i++ {
+		c.tf.Den[i] = []float64{1}
+		c.tf.Num[i] = make([][]float64, c.m)
+		for j := 0; j < c.m; j++ {
+			if c.p > 0 && c.m > 0 {
+				c.tf.Num[i][j] = []float64{c.dRaw.Data[i*c.dRaw.Stride+j]}
+			} else {
+				c.tf.Num[i][j] = []float64{0}
+			}
+		}
 	}
+}
 
-	tf.InputName = copyStringSlice(sys.InputName)
-	tf.OutputName = copyStringSlice(sys.OutputName)
-	return &TransferFuncResult{TF: tf, MinimalOrder: totalOrder, RowDegrees: rowDeg}, nil
+func (c rowRealizationConverter) result(order int) *TransferFuncResult {
+	if c.sys.Delay != nil {
+		c.tf.Delay = denseToSlice2D(c.sys.Delay)
+	}
+	c.tf.InputName = copyStringSlice(c.sys.InputName)
+	c.tf.OutputName = copyStringSlice(c.sys.OutputName)
+	return &TransferFuncResult{TF: c.tf, MinimalOrder: order, RowDegrees: c.rows}
 }
 
 type tfWorkspace struct {


### PR DESCRIPTION
## Summary

- Add public-behavior regression tests for delay-form equivalence, frequency-response entry-point equivalence, and transfer row-realization invariants.
- Centralize effective I/O delay arithmetic and reuse it from total-delay, interconnection, and frequency-response paths.
- Introduce internal interconnection planning, frequency evaluation, shared Bode result construction, and row-realization conversion modules without changing public APIs.

## Validation

- env GOCACHE=/tmp/qlx-go-build-cache go test -v -count=1

Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38