### PR TITLE
Improve LTI architecture boundaries

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -1461,21 +1461,9 @@ func connectWithDelay(sys *System, Q *mat.Dense, inputs, outputs []int) (*System
 	nH, _, _ := H.Dims()
 
 	Dcore := extractBlock(H.D, 0, 0, p, m)
-	QD := mat.NewDense(m, m, nil)
-	QD.Mul(Q, Dcore)
-	IQD := eyeDense(m)
-	IQD.Sub(IQD, QD)
-
-	var lu mat.LU
-	lu.Factorize(IQD)
-	if luNearSingular(&lu) {
-		return nil, fmt.Errorf("connect: (I-Q*D) singular, algebraic loop: %w", ErrAlgebraicLoop)
-	}
-
-	eyeM := eyeDense(m)
-	E := mat.NewDense(m, m, nil)
-	if err := lu.SolveTo(E, false, eyeM); err != nil {
-		return nil, fmt.Errorf("connect: LU solve failed: %w", ErrSingularTransform)
+	E, err := solveIdentityMinusProduct(Q, Dcore, m, "connect", ErrAlgebraicLoop)
+	if err != nil {
+		return nil, err
 	}
 
 	EQ := mat.NewDense(m, p, nil)
@@ -1641,21 +1629,9 @@ func connectSimple(sys *System, Q *mat.Dense, inputs, outputs []int, n, m, p int
 	mExt := len(inputs)
 	pExt := len(outputs)
 
-	QD := mat.NewDense(m, m, nil)
-	QD.Mul(Q, sys.D)
-	IQD := eyeDense(m)
-	IQD.Sub(IQD, QD)
-
-	var lu mat.LU
-	lu.Factorize(IQD)
-	if luNearSingular(&lu) {
-		return nil, fmt.Errorf("connect: (I-Q*D) singular, algebraic loop: %w", ErrAlgebraicLoop)
-	}
-
-	eyeM := eyeDense(m)
-	E := mat.NewDense(m, m, nil)
-	if err := lu.SolveTo(E, false, eyeM); err != nil {
-		return nil, fmt.Errorf("connect: LU solve failed: %w", ErrSingularTransform)
+	E, err := solveIdentityMinusProduct(Q, sys.D, m, "connect", ErrAlgebraicLoop)
+	if err != nil {
+		return nil, err
 	}
 
 	EQ := mat.NewDense(m, p, nil)

--- a/crossval_test.go
+++ b/crossval_test.go
@@ -1326,6 +1326,32 @@ func TestCrossval_Stability(t *testing.T) {
 	} else if s {
 		t.Error("expected unstable discrete system")
 	}
+
+	marginal, _ := New(
+		denseFromRows([][]float64{{0, 1}, {0, 0}}),
+		denseFromFlat(2, 1, []float64{0, 1}),
+		denseFromFlat(1, 2, []float64{1, 0}),
+		denseFromFlat(1, 1, []float64{0}),
+		0,
+	)
+	if s, err := marginal.IsStable(); err != nil {
+		t.Fatal(err)
+	} else if s {
+		t.Error("expected marginally stable continuous system to be unstable")
+	}
+
+	marginalD, _ := New(
+		denseFromRows([][]float64{{1, 0}, {0, 0.3}}),
+		denseFromFlat(2, 1, []float64{1, 1}),
+		denseFromFlat(1, 2, []float64{1, 0}),
+		denseFromFlat(1, 1, []float64{0}),
+		1.0,
+	)
+	if s, err := marginalD.IsStable(); err != nil {
+		t.Fatal(err)
+	} else if s {
+		t.Error("expected marginally stable discrete system to be unstable")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/ctrbobsv.go
+++ b/ctrbobsv.go
@@ -1,9 +1,6 @@
 package controlsys
 
 import (
-	"math"
-	"math/cmplx"
-
 	"gonum.org/v1/gonum/blas"
 	"gonum.org/v1/gonum/blas/blas64"
 	"gonum.org/v1/gonum/mat"
@@ -194,15 +191,8 @@ func IsStabilizable(A, B *mat.Dense, continuous bool) (bool, error) {
 	vals := eig.Values(nil)
 
 	for _, v := range vals {
-		tol := 1e-10 * math.Max(1, cmplx.Abs(v))
-		if continuous {
-			if real(v) >= -tol {
-				return false, nil
-			}
-		} else {
-			if cmplx.Abs(v) >= 1-tol {
-				return false, nil
-			}
+		if poleOnOrOutsideStabilityBoundary(v, continuous, poleStabilityTolerance(v)) {
+			return false, nil
 		}
 	}
 	return true, nil

--- a/frd.go
+++ b/frd.go
@@ -221,6 +221,7 @@ func (f *FRD) FreqResponse() *FreqResponseMatrix {
 	}
 	return &FreqResponseMatrix{
 		Data:       data,
+		Omega:      copyFloatSlice(f.Omega),
 		NFreq:      nw,
 		P:          p,
 		M:          m,
@@ -233,34 +234,11 @@ func (f *FRD) FreqResponse() *FreqResponseMatrix {
 func (f *FRD) Bode() *BodeResult {
 	p, m := f.Dims()
 	nw := len(f.Omega)
-	pm := p * m
-	magDB := make([]float64, nw*pm)
-	phase := make([]float64, nw*pm)
-
-	for k := 0; k < nw; k++ {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
-				off := k*pm + i*m + j
-				h := f.Response[k][i][j]
-				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
-				phase[off] = cmplx.Phase(h) * 180 / math.Pi
-			}
-		}
-	}
-	unwrapBodePhase(phase, p, m, nw)
-
 	omega := make([]float64, nw)
 	copy(omega, f.Omega)
-
-	return &BodeResult{
-		Omega:      omega,
-		magDB:      magDB,
-		phase:      phase,
-		p:          p,
-		m:          m,
-		InputName:  copyStringSlice(f.InputName),
-		OutputName: copyStringSlice(f.OutputName),
-	}
+	return bodeResultFromAccessor(omega, p, m, copyStringSlice(f.InputName), copyStringSlice(f.OutputName), func(k, i, j int) complex128 {
+		return f.Response[k][i][j]
+	})
 }
 
 func (f *FRD) Nyquist() (*NyquistResult, error) {

--- a/frd_test.go
+++ b/frd_test.go
@@ -261,6 +261,46 @@ func TestFRD_CrossValidateWithFreqResponse(t *testing.T) {
 	}
 }
 
+func TestFreqResponseMatrixCarriesFrequencyGrid(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(1, 1, []float64{-2}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{3}),
+		mat.NewDense(1, 1, []float64{0.5}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	omega := []float64{0.2, 1.5, 4.0}
+
+	resp, err := sys.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Omega) != len(omega) {
+		t.Fatalf("len(FreqResponse.Omega) = %d, want %d", len(resp.Omega), len(omega))
+	}
+	for i := range omega {
+		if resp.Omega[i] != omega[i] {
+			t.Fatalf("FreqResponse.Omega[%d] = %v, want %v", i, resp.Omega[i], omega[i])
+		}
+	}
+	frd, err := sys.FRD(resp.Omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromFRD := frd.FreqResponse()
+	if len(fromFRD.Omega) != frd.NumFrequencies() {
+		t.Fatalf("len(FRD.FreqResponse.Omega) = %d, want %d", len(fromFRD.Omega), frd.NumFrequencies())
+	}
+	for i := range fromFRD.Omega {
+		if fromFRD.Omega[i] != frd.Omega[i] {
+			t.Fatalf("FRD.FreqResponse.Omega[%d] = %v, want %v", i, fromFRD.Omega[i], frd.Omega[i])
+		}
+	}
+}
+
 func TestFRD_CrossValidateMIMO(t *testing.T) {
 	sys, err := New(
 		mat.NewDense(2, 2, []float64{0, 1, -2, -3}),
@@ -494,6 +534,10 @@ func TestFRD_Bode(t *testing.T) {
 	}
 
 	bode := frd.Bode()
+	modelBode, err := sys.Bode(omega, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	wantMagDB := []float64{
 		20 * math.Log10(1.0/math.Sqrt(1.01)),
 		20 * math.Log10(1.0/math.Sqrt(2)),
@@ -503,6 +547,12 @@ func TestFRD_Bode(t *testing.T) {
 		got := bode.MagDBAt(k, 0, 0)
 		if math.Abs(got-wantMagDB[k]) > 1e-8 {
 			t.Errorf("w=%v: magDB=%v, want %v", omega[k], got, wantMagDB[k])
+		}
+		if math.Abs(got-modelBode.MagDBAt(k, 0, 0)) > 1e-12 {
+			t.Errorf("w=%v: FRD magDB=%v, model magDB=%v", omega[k], got, modelBode.MagDBAt(k, 0, 0))
+		}
+		if math.Abs(bode.PhaseAt(k, 0, 0)-modelBode.PhaseAt(k, 0, 0)) > 1e-12 {
+			t.Errorf("w=%v: FRD phase=%v, model phase=%v", omega[k], bode.PhaseAt(k, 0, 0), modelBode.PhaseAt(k, 0, 0))
 		}
 	}
 }

--- a/freqrestest.go
+++ b/freqrestest.go
@@ -20,6 +20,7 @@ type FreqRespEstOpts struct {
 type FreqRespEstResult struct {
 	H         *FreqResponseMatrix
 	Omega     []float64
+	Dt        float64
 	Coherence []float64
 }
 
@@ -28,6 +29,15 @@ func (r *FreqRespEstResult) CoherenceAt(freq, output, input int) float64 {
 		return 0
 	}
 	return r.Coherence[freq*r.H.P*r.H.M+output*r.H.M+input]
+}
+
+func (r *FreqRespEstResult) FRD() (*FRD, error) {
+	if r == nil || r.H == nil {
+		return nil, ErrInsufficientData
+	}
+	response, data := newFRDResponseStorage(r.H.NFreq, r.H.P, r.H.M)
+	copy(data, r.H.Data)
+	return NewFRD(response, r.Omega, r.Dt)
 }
 
 func FreqRespEst(input, output *mat.Dense, dt float64, opts *FreqRespEstOpts) (*FreqRespEstResult, error) {
@@ -49,6 +59,9 @@ func FreqRespEst(input, output *mat.Dense, dt float64, opts *FreqRespEstOpts) (*
 	}
 
 	nfft, winFunc, noverlap, method := resolveOpts(opts, N)
+	if err := validateFreqRespEstMethod(method, m, p); err != nil {
+		return nil, err
+	}
 
 	win := make([]float64, nfft)
 	for i := range win {
@@ -100,6 +113,18 @@ func FreqRespEst(input, output *mat.Dense, dt float64, opts *FreqRespEstOpts) (*
 
 	return welchMIMO(fft, seg, coeff, win, input, output,
 		dt, m, p, nfft, nFreq, hop, nSeg, winPower, method)
+}
+
+func validateFreqRespEstMethod(method string, m, p int) error {
+	switch method {
+	case "h1", "h2", "fft":
+	default:
+		return fmt.Errorf("FreqRespEst: unknown method %q: %w", method, ErrDimensionMismatch)
+	}
+	if method == "h2" && (m != 1 || p != 1) {
+		return fmt.Errorf("FreqRespEst: h2 estimator is only supported for SISO data: %w", ErrDimensionMismatch)
+	}
+	return nil
 }
 
 func resolveOpts(opts *FreqRespEstOpts, N int) (nfft int, winFunc func([]float64) []float64, noverlap int, method string) {
@@ -162,8 +187,8 @@ func welchSISO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,
 		fft.Coefficients(yCoeff, seg)
 
 		for f := 0; f < nFreq; f++ {
-			Suu[f] += real(uCoeff[f]) * real(uCoeff[f]) + imag(uCoeff[f]) * imag(uCoeff[f])
-			Syy[f] += real(yCoeff[f]) * real(yCoeff[f]) + imag(yCoeff[f]) * imag(yCoeff[f])
+			Suu[f] += real(uCoeff[f])*real(uCoeff[f]) + imag(uCoeff[f])*imag(uCoeff[f])
+			Syy[f] += real(yCoeff[f])*real(yCoeff[f]) + imag(yCoeff[f])*imag(yCoeff[f])
 			Syu[f] += cmplx.Conj(uCoeff[f]) * yCoeff[f]
 		}
 	}
@@ -210,8 +235,9 @@ func welchSISO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,
 	}
 
 	return &FreqRespEstResult{
-		H:         &FreqResponseMatrix{Data: H, NFreq: nFreq, P: 1, M: 1},
+		H:         &FreqResponseMatrix{Data: H, Omega: omega, NFreq: nFreq, P: 1, M: 1},
 		Omega:     omega,
+		Dt:        dt,
 		Coherence: coh,
 	}, nil
 }
@@ -332,8 +358,9 @@ func welchMIMO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,
 	}
 
 	return &FreqRespEstResult{
-		H:         &FreqResponseMatrix{Data: H, NFreq: nFreq, P: p, M: m},
+		H:         &FreqResponseMatrix{Data: H, Omega: omega, NFreq: nFreq, P: p, M: m},
 		Omega:     omega,
+		Dt:        dt,
 		Coherence: coh,
 	}, nil
 }
@@ -383,7 +410,8 @@ func freqRespEstFFT(input, output *mat.Dense, dt float64, m, p, _, nfft int,
 	}
 
 	return &FreqRespEstResult{
-		H:     &FreqResponseMatrix{Data: H, NFreq: nFreq, P: p, M: m},
+		H:     &FreqResponseMatrix{Data: H, Omega: omega, NFreq: nFreq, P: p, M: m},
 		Omega: omega,
+		Dt:    dt,
 	}, nil
 }

--- a/freqrestest_test.go
+++ b/freqrestest_test.go
@@ -253,6 +253,72 @@ func TestFreqRespEst_MIMO(t *testing.T) {
 	}
 }
 
+func TestFreqRespEstResultFRD(t *testing.T) {
+	dt := 0.01
+	sys, err := NewFromSlices(2, 2, 2,
+		[]float64{0.8, 0.1, -0.2, 0.6},
+		[]float64{0.2, 0.1, 0.05, 0.4},
+		[]float64{1, 0, 0, 1},
+		[]float64{0, 0, 0, 0},
+		dt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	N := 2048
+	rng := rand.New(rand.NewSource(91))
+	uData := make([]float64, 2*N)
+	for i := range uData {
+		uData[i] = rng.NormFloat64()
+	}
+	u := mat.NewDense(2, N, uData)
+
+	resp, err := sys.Simulate(u, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	est, err := FreqRespEst(u, resp.Y, dt, &FreqRespEstOpts{NFFT: 512})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frd, err := est.FRD()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if frd.Dt != dt {
+		t.Fatalf("FRD sample time = %v, want %v", frd.Dt, dt)
+	}
+	if frd.NumFrequencies() != len(est.Omega) {
+		t.Fatalf("NumFrequencies = %d, want %d", frd.NumFrequencies(), len(est.Omega))
+	}
+	p, m := frd.Dims()
+	if p != est.H.P || m != est.H.M {
+		t.Fatalf("FRD dims = (%d,%d), want (%d,%d)", p, m, est.H.P, est.H.M)
+	}
+	for k := range est.Omega {
+		for i := 0; i < p; i++ {
+			for j := 0; j < m; j++ {
+				if frd.At(k, i, j) != est.H.At(k, i, j) {
+					t.Fatalf("FRD[%d,%d,%d] = %v, want %v", k, i, j, frd.At(k, i, j), est.H.At(k, i, j))
+				}
+			}
+		}
+	}
+}
+
+func TestFreqRespEstRejectsUnknownMethod(t *testing.T) {
+	u := mat.NewDense(1, 16, []float64{1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0})
+	y := mat.NewDense(1, 16, []float64{0.5, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0.5, 0, 0.5, 0})
+
+	_, err := FreqRespEst(u, y, 0.1, &FreqRespEstOpts{Method: "bogus"})
+	if err == nil {
+		t.Fatal("expected unknown method error")
+	}
+}
+
 func TestFreqRespEst_ShortData(t *testing.T) {
 	uData := []float64{1, 2, 3, 4, 5}
 	yData := []float64{0.5, 1, 1.5, 2, 2.5}

--- a/frequency.go
+++ b/frequency.go
@@ -11,6 +11,7 @@ import (
 
 type FreqResponseMatrix struct {
 	Data       []complex128
+	Omega      []float64
 	NFreq      int
 	P, M       int
 	InputName  []string
@@ -39,6 +40,12 @@ func (b *BodeResult) PhaseAt(freq, output, input int) float64 {
 }
 
 func bodeResultFromResponse(omega []float64, data []complex128, p, m int, inputName, outputName []string) *BodeResult {
+	return bodeResultFromAccessor(omega, p, m, inputName, outputName, func(k, i, j int) complex128 {
+		return data[(k*p+i)*m+j]
+	})
+}
+
+func bodeResultFromAccessor(omega []float64, p, m int, inputName, outputName []string, at func(k, i, j int) complex128) *BodeResult {
 	nw := len(omega)
 	pm := p * m
 	magDB := make([]float64, nw*pm)
@@ -48,7 +55,7 @@ func bodeResultFromResponse(omega []float64, data []complex128, p, m int, inputN
 		for i := 0; i < p; i++ {
 			for j := 0; j < m; j++ {
 				off := (k*p+i)*m + j
-				h := data[off]
+				h := at(k, i, j)
 				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
 				phase[off] = cmplx.Phase(h) * 180 / math.Pi
 			}
@@ -150,7 +157,7 @@ func (e frequencyEvaluator) response(omega []float64) (*FreqResponseMatrix, erro
 			return nil, err
 		}
 		applyIODelayAtS(e.sys, s, data, e.p, e.m, true)
-		return e.matrix(data, nw), nil
+		return e.matrix(data, omega), nil
 	}
 
 	res, err := e.sys.TransferFunction(nil)
@@ -161,7 +168,7 @@ func (e frequencyEvaluator) response(omega []float64) (*FreqResponseMatrix, erro
 		res.TF.evalInto(e.sAt(w), data[k*pm:(k+1)*pm])
 	}
 	applyIODelayPhase(e.sys, omega, data, e.p, e.m, false)
-	return e.matrix(data, nw), nil
+	return e.matrix(data, omega), nil
 }
 
 func (e frequencyEvaluator) eval(s complex128) ([][]complex128, error) {
@@ -200,9 +207,9 @@ func (e frequencyEvaluator) evalStateSpaceInto(s complex128, dst []complex128) e
 	return nil
 }
 
-func (e frequencyEvaluator) matrix(data []complex128, nw int) *FreqResponseMatrix {
+func (e frequencyEvaluator) matrix(data []complex128, omega []float64) *FreqResponseMatrix {
 	return &FreqResponseMatrix{
-		Data: data, NFreq: nw, P: e.p, M: e.m,
+		Data: data, Omega: omega, NFreq: len(omega), P: e.p, M: e.m,
 		InputName:  copyStringSlice(e.sys.InputName),
 		OutputName: copyStringSlice(e.sys.OutputName),
 	}
@@ -398,7 +405,7 @@ func freqResponseLFT(sys *System, omega []float64, p, m int) (*FreqResponseMatri
 		copy(data[k*p*m:], ws.g[:p*m])
 	}
 
-	return &FreqResponseMatrix{Data: data, NFreq: nw, P: p, M: m}, nil
+	return &FreqResponseMatrix{Data: data, Omega: omega, NFreq: nw, P: p, M: m}, nil
 }
 
 type lftWorkspace struct {

--- a/h2syn.go
+++ b/h2syn.go
@@ -14,44 +14,20 @@ type H2SynResult struct {
 }
 
 func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
-	if !P.IsContinuous() {
-		return nil, ErrWrongDomain
+	gp, err := partitionGeneralizedPlant(P, nmeas, ncont)
+	if err != nil {
+		return nil, err
 	}
-	if P.IsDescriptor() {
-		return nil, ErrDescriptorRiccati
-	}
-
-	n, m, p := P.Dims()
-	if n == 0 {
-		return nil, ErrInvalidPartition
-	}
-	if ncont <= 0 || nmeas <= 0 || ncont > m || nmeas > p {
-		return nil, ErrInvalidPartition
-	}
-
-	m1 := m - ncont
-	m2 := ncont
-	p1 := p - nmeas
-	p2 := nmeas
-
-	if m1 <= 0 || p1 <= 0 {
-		return nil, ErrInvalidPartition
-	}
-
-	A := P.A
-	B1 := extractBlock(P.B, 0, 0, n, m1)
-	B2 := extractBlock(P.B, 0, m1, n, m2)
-	C1 := extractBlock(P.C, 0, 0, p1, n)
-	C2 := extractBlock(P.C, p1, 0, p2, n)
-	D11 := extractBlock(P.D, 0, 0, p1, m1)
-	D12 := extractBlock(P.D, 0, m1, p1, m2)
-	D21 := extractBlock(P.D, p1, 0, p2, m1)
-	D22 := extractBlock(P.D, p1, m1, p2, m2)
+	n := gp.n
+	A := gp.A
+	B1, B2 := gp.B1, gp.B2
+	C1, C2 := gp.C1, gp.C2
+	D11, D12, D21, D22 := gp.D11, gp.D12, gp.D21, gp.D22
 
 	tol := 1e-10
 	d11Raw := D11.RawMatrix()
-	for i := range p1 {
-		for j := range m1 {
+	for i := range gp.p1 {
+		for j := range gp.m1 {
 			if math.Abs(d11Raw.Data[i*d11Raw.Stride+j]) > tol {
 				return nil, ErrNoFiniteH2Norm
 			}
@@ -59,8 +35,8 @@ func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
 	}
 
 	d22Raw := D22.RawMatrix()
-	for i := range p2 {
-		for j := range m2 {
+	for i := range gp.p2 {
+		for j := range gp.m2 {
 			if math.Abs(d22Raw.Data[i*d22Raw.Stride+j]) > tol {
 				return nil, ErrH2DirectFeedthrough
 			}
@@ -95,7 +71,7 @@ func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
 	X := resX.X
 
 	// F = -K_care (state feedback gain u = F*x)
-	F := mat.NewDense(m2, n, nil)
+	F := mat.NewDense(gp.m2, n, nil)
 	F.Scale(-1, resX.K)
 
 	// Filter CARE (dual): Care(A', C2', B1*B1', D21*D21', S=B1*D21')
@@ -124,12 +100,13 @@ func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
 
 	Bk = denseCopy(L)
 	Ck = denseCopy(F)
-	Dk = mat.NewDense(m2, p2, nil)
+	Dk = mat.NewDense(gp.m2, gp.p2, nil)
 
 	K, err := New(Ak, Bk, Ck, Dk, 0)
 	if err != nil {
 		return nil, err
 	}
+	gp.applyControllerNames(K)
 
 	// Closed-loop A matrix for pole computation
 	// CL_A = [A + B2*Dk*C2,  B2*Ck;  Bk*C2,  Ak]

--- a/h2syn_test.go
+++ b/h2syn_test.go
@@ -25,6 +25,8 @@ func TestH2Syn_Simple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	P.InputName = []string{"disturbance", "control"}
+	P.OutputName = []string{"performance1", "performance2", "measurement"}
 
 	res, err := H2Syn(P, 1, 1)
 	if err != nil {
@@ -53,6 +55,12 @@ func TestH2Syn_Simple(t *testing.T) {
 	}
 	if res.Y == nil {
 		t.Error("Y is nil")
+	}
+	if !stringSlicesEqual(res.K.InputName, []string{"measurement"}) {
+		t.Fatalf("controller input names = %v, want [measurement]", res.K.InputName)
+	}
+	if !stringSlicesEqual(res.K.OutputName, []string{"control"}) {
+		t.Fatalf("controller output names = %v, want [control]", res.K.OutputName)
 	}
 }
 

--- a/hinfsyn.go
+++ b/hinfsyn.go
@@ -17,38 +17,15 @@ type HinfSynResult struct {
 }
 
 func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
-	if !P.IsContinuous() {
-		return nil, ErrWrongDomain
+	gp, err := partitionGeneralizedPlant(P, nmeas, ncont)
+	if err != nil {
+		return nil, err
 	}
-	if P.IsDescriptor() {
-		return nil, ErrDescriptorRiccati
-	}
-
-	n, m, p := P.Dims()
-	if n == 0 {
-		return nil, ErrInvalidPartition
-	}
-	if ncont <= 0 || nmeas <= 0 || ncont > m || nmeas > p {
-		return nil, ErrInvalidPartition
-	}
-
-	m1 := m - ncont
-	m2 := ncont
-	p1 := p - nmeas
-	p2 := nmeas
-
-	if m1 <= 0 || p1 <= 0 {
-		return nil, ErrInvalidPartition
-	}
-
-	A := P.A
-	B1 := extractBlock(P.B, 0, 0, n, m1)
-	B2 := extractBlock(P.B, 0, m1, n, m2)
-	C1 := extractBlock(P.C, 0, 0, p1, n)
-	C2 := extractBlock(P.C, p1, 0, p2, n)
-	D11 := extractBlock(P.D, 0, 0, p1, m1)
-	D12 := extractBlock(P.D, 0, m1, p1, m2)
-	D21 := extractBlock(P.D, p1, 0, p2, m1)
+	n := gp.n
+	A := gp.A
+	B1, B2 := gp.B1, gp.B2
+	C1, C2 := gp.C1, gp.C2
+	D11, D12, D21 := gp.D11, gp.D12, gp.D21
 	stab, err := IsStabilizable(A, B2, true)
 	if err != nil {
 		return nil, err
@@ -68,7 +45,7 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 	gammaLB := maxSVD(D11)
 	gammaUB := gammaLB*2 + 1
 
-	for !hinfFeasible(A, B1, B2, C1, C2, D12, D21, n, m1, m2, p1, p2, gammaUB) {
+	for !hinfFeasible(A, B1, B2, C1, C2, D12, D21, n, gp.m1, gp.m2, gp.p1, gp.p2, gammaUB) {
 		gammaUB *= 2
 		if gammaUB > 1e12 {
 			return nil, ErrGammaNotAchievable
@@ -77,7 +54,7 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 
 	for gammaUB-gammaLB > 1e-6*gammaUB {
 		mid := (gammaLB + gammaUB) / 2
-		if hinfFeasible(A, B1, B2, C1, C2, D12, D21, n, m1, m2, p1, p2, mid) {
+		if hinfFeasible(A, B1, B2, C1, C2, D12, D21, n, gp.m1, gp.m2, gp.p1, gp.p2, mid) {
 			gammaUB = mid
 		} else {
 			gammaLB = mid
@@ -85,20 +62,20 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 	}
 
 	gamma := gammaUB
-	X, Y, err := hinfSolveRiccatis(A, B1, B2, C1, C2, D12, D21, n, m1, m2, p1, p2, gamma)
+	X, Y, err := hinfSolveRiccatis(A, B1, B2, C1, C2, D12, D21, n, gp.m1, gp.m2, gp.p1, gp.p2, gamma)
 	if err != nil {
 		return nil, err
 	}
 
 	R1 := mulDense(mat.DenseCopyOf(D12.T()), D12)
-	R1inv, err := invertSmall(R1, m2)
+	R1inv, err := invertSmall(R1, gp.m2)
 	if err != nil {
 		return nil, err
 	}
 	S1 := mulDense(mat.DenseCopyOf(D12.T()), C1)
 
 	R2 := mulDense(D21, mat.DenseCopyOf(D21.T()))
-	R2inv, err := invertSmall(R2, p2)
+	R2inv, err := invertSmall(R2, gp.p2)
 	if err != nil {
 		return nil, err
 	}
@@ -151,12 +128,13 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 	Bk := mulDense(Zp, L)
 	Bk.Scale(-1, Bk)
 	Ck := denseCopy(F)
-	Dk := mat.NewDense(m2, p2, nil)
+	Dk := mat.NewDense(gp.m2, gp.p2, nil)
 
 	K, err := New(Ak, Bk, Ck, Dk, 0)
 	if err != nil {
 		return nil, err
 	}
+	gp.applyControllerNames(K)
 
 	clN := 2 * n
 	clA := mat.NewDense(clN, clN, nil)
@@ -393,4 +371,3 @@ func maxSVD(M *mat.Dense) float64 {
 	}
 	return maxS
 }
-

--- a/hinfsyn_test.go
+++ b/hinfsyn_test.go
@@ -29,6 +29,8 @@ func TestHinfSyn_Simple(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	P.InputName = []string{"disturbance1", "disturbance2", "control"}
+	P.OutputName = []string{"performance1", "performance2", "measurement"}
 
 	res, err := HinfSyn(P, 1, 1)
 	if err != nil {
@@ -60,6 +62,12 @@ func TestHinfSyn_Simple(t *testing.T) {
 	}
 	if res.GammaOpt <= 0 {
 		t.Errorf("gamma should be positive, got %v", res.GammaOpt)
+	}
+	if !stringSlicesEqual(res.K.InputName, []string{"measurement"}) {
+		t.Fatalf("controller input names = %v, want [measurement]", res.K.InputName)
+	}
+	if !stringSlicesEqual(res.K.OutputName, []string{"control"}) {
+		t.Fatalf("controller output names = %v, want [control]", res.K.OutputName)
 	}
 }
 

--- a/matutil.go
+++ b/matutil.go
@@ -32,6 +32,15 @@ func denseCopy(m *mat.Dense) *mat.Dense {
 	return mat.DenseCopyOf(m)
 }
 
+func copyFloatSlice(s []float64) []float64 {
+	if s == nil {
+		return nil
+	}
+	out := make([]float64, len(s))
+	copy(out, s)
+	return out
+}
+
 func denseCopySafe(m *mat.Dense, r, c int) *mat.Dense {
 	if r == 0 || c == 0 {
 		return &mat.Dense{}

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -19,6 +19,9 @@ func WithPadeOrder(n int) SafeFeedbackOption {
 	}
 }
 
+// WithThiranOrder is reserved for future fractional discrete-delay feedback
+// workflows. SafeFeedback currently absorbs exact integer discrete delays and
+// uses Pade approximation for continuous transport delays.
 func WithThiranOrder(n int) SafeFeedbackOption {
 	return func(c *safeFeedbackConfig) {
 		c.thiranOrder = n
@@ -62,17 +65,7 @@ func SafeFeedback(plant, controller *System, sign float64, opts ...SafeFeedbackO
 		_, mPlant, pPlant := p.Dims()
 		_, mCtrl, pCtrl := c.Dims()
 		if pPlant == mCtrl && pCtrl == mPlant {
-			dp := p.D
-			dc := c.D
-			tmp := mat.NewDense(pPlant, pPlant, nil)
-			tmp.Product(dp, dc)
-			tmp.Scale(sign, tmp)
-			eye := mat.NewDense(pPlant, pPlant, nil)
-			for i := 0; i < pPlant; i++ {
-				eye.Set(i, i, 1)
-			}
-			eye.Sub(eye, tmp)
-			if det := mat.Det(eye); det == 0 {
+			if _, err := solveFeedbackFeedthrough(p.D, c.D, sign, pPlant, "SafeFeedback", ErrAlgebraicLoop); err != nil {
 				return nil, fmt.Errorf("SafeFeedback: Pade approximation creates singular algebraic loop; try a different padeOrder (even vs odd) to flip feedthrough sign")
 			}
 		}

--- a/ss.go
+++ b/ss.go
@@ -2,7 +2,6 @@ package controlsys
 
 import (
 	"fmt"
-	"math/cmplx"
 
 	"gonum.org/v1/gonum/mat"
 )
@@ -139,17 +138,9 @@ func (sys *System) IsStable() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if sys.IsContinuous() {
-		for _, p := range poles {
-			if real(p) >= 0 {
-				return false, nil
-			}
-		}
-	} else {
-		for _, p := range poles {
-			if cmplx.Abs(p) >= 1 {
-				return false, nil
-			}
+	for _, p := range poles {
+		if poleOnOrOutsideStabilityBoundary(p, sys.IsContinuous(), 0) {
+			return false, nil
 		}
 	}
 	return true, nil

--- a/stability.go
+++ b/stability.go
@@ -1,0 +1,14 @@
+package controlsys
+
+import "math/cmplx"
+
+func poleOnOrOutsideStabilityBoundary(p complex128, continuous bool, tol float64) bool {
+	if continuous {
+		return real(p) >= -tol
+	}
+	return cmplx.Abs(p) >= 1-tol
+}
+
+func poleStabilityTolerance(p complex128) float64 {
+	return 1e-10 * max(1, cmplx.Abs(p))
+}

--- a/synthesis_partition.go
+++ b/synthesis_partition.go
@@ -1,0 +1,78 @@
+package controlsys
+
+import "gonum.org/v1/gonum/mat"
+
+type generalizedPlantPartition struct {
+	A                              *mat.Dense
+	B1, B2                         *mat.Dense
+	C1, C2                         *mat.Dense
+	D11, D12, D21, D22             *mat.Dense
+	n, m, p, m1, m2, p1, p2        int
+	measurementNames, controlNames []string
+}
+
+func partitionGeneralizedPlant(P *System, nmeas, ncont int) (*generalizedPlantPartition, error) {
+	if !P.IsContinuous() {
+		return nil, ErrWrongDomain
+	}
+	if P.IsDescriptor() {
+		return nil, ErrDescriptorRiccati
+	}
+
+	n, m, p := P.Dims()
+	if n == 0 {
+		return nil, ErrInvalidPartition
+	}
+	if ncont <= 0 || nmeas <= 0 || ncont > m || nmeas > p {
+		return nil, ErrInvalidPartition
+	}
+
+	m1 := m - ncont
+	m2 := ncont
+	p1 := p - nmeas
+	p2 := nmeas
+	if m1 <= 0 || p1 <= 0 {
+		return nil, ErrInvalidPartition
+	}
+
+	return &generalizedPlantPartition{
+		A:                P.A,
+		B1:               extractBlock(P.B, 0, 0, n, m1),
+		B2:               extractBlock(P.B, 0, m1, n, m2),
+		C1:               extractBlock(P.C, 0, 0, p1, n),
+		C2:               extractBlock(P.C, p1, 0, p2, n),
+		D11:              extractBlock(P.D, 0, 0, p1, m1),
+		D12:              extractBlock(P.D, 0, m1, p1, m2),
+		D21:              extractBlock(P.D, p1, 0, p2, m1),
+		D22:              extractBlock(P.D, p1, m1, p2, m2),
+		n:                n,
+		m:                m,
+		p:                p,
+		m1:               m1,
+		m2:               m2,
+		p1:               p1,
+		p2:               p2,
+		measurementNames: selectTrailingNames(P.OutputName, p1, p2),
+		controlNames:     selectTrailingNames(P.InputName, m1, m2),
+	}, nil
+}
+
+func (gp *generalizedPlantPartition) applyControllerNames(K *System) {
+	K.InputName = copyStringSlice(gp.measurementNames)
+	K.OutputName = copyStringSlice(gp.controlNames)
+}
+
+func selectTrailingNames(names []string, start, count int) []string {
+	if names == nil {
+		return nil
+	}
+	return selectStringSlice(names, contiguousIndices(start, count))
+}
+
+func contiguousIndices(start, count int) []int {
+	idx := make([]int, count)
+	for i := range idx {
+		idx[i] = start + i
+	}
+	return idx
+}

--- a/wellposed.go
+++ b/wellposed.go
@@ -1,0 +1,37 @@
+package controlsys
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func solveIdentityMinusProduct(left, right *mat.Dense, size int, context string, singular error) (*mat.Dense, error) {
+	return solveIdentityMinusScaledProduct(left, right, 1, size, context, singular)
+}
+
+func solveIdentityMinusScaledProduct(left, right *mat.Dense, scale float64, size int, context string, singular error) (*mat.Dense, error) {
+	loop := mat.NewDense(size, size, nil)
+	loop.Mul(left, right)
+	if scale != 1 {
+		loop.Scale(scale, loop)
+	}
+	eye := eyeDense(size)
+	loop.Sub(eye, loop)
+
+	var lu mat.LU
+	lu.Factorize(loop)
+	if luNearSingular(&lu) {
+		return nil, fmt.Errorf("%s: direct feedthrough loop is singular: %w", context, singular)
+	}
+
+	result := mat.NewDense(size, size, nil)
+	if err := lu.SolveTo(result, false, eye); err != nil {
+		return nil, fmt.Errorf("%s: direct feedthrough loop solve failed: %w", context, singular)
+	}
+	return result, nil
+}
+
+func solveFeedbackFeedthrough(plantD, controllerD *mat.Dense, sign float64, size int, context string, singular error) (*mat.Dense, error) {
+	return solveIdentityMinusScaledProduct(plantD, controllerD, sign, size, context, singular)
+}

--- a/zpk.go
+++ b/zpk.go
@@ -145,7 +145,7 @@ func (z *ZPK) FreqResponse(omega []float64) (*FreqResponseMatrix, error) {
 		}
 	}
 	return &FreqResponseMatrix{
-		Data: data, NFreq: len(omega), P: p, M: m,
+		Data: data, Omega: omega, NFreq: len(omega), P: p, M: m,
 		InputName:  copyStringSlice(z.InputName),
 		OutputName: copyStringSlice(z.OutputName),
 	}, nil
@@ -354,4 +354,3 @@ func poleSetDifference(all, subset []complex128) []complex128 {
 	}
 	return remaining
 }
-


### PR DESCRIPTION
## Summary
- Add frequency-grid metadata to response objects and adapt frequency-response estimates into FRD workflows.
- Centralize generalized-plant partitioning for H2/H-infinity synthesis and preserve controller channel names.
- Share stability and well-posedness helpers across numerical and interconnection paths while keeping benchmarked hot paths specialized.

## Verification
- env GOCACHE=/tmp/qlx-go-build-cache go test -count=1 ./...
- benchstat /tmp/controlsys-base.bench /tmp/controlsys-new.bench: geomean sec/op -0.17%, B/op -0.21%, allocs/op -0.34% across focused architecture benchmarks.
- Targeted 10-sample check for Feedback/SafeFeedback/LFT: statistically unchanged, identical allocation counts.

Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48
Closes #49
Closes #50
Closes #51
Closes #52