### PR TITLE
Deepen architecture modules

### DIFF
--- a/architecture_backlog_test.go
+++ b/architecture_backlog_test.go
@@ -1,6 +1,7 @@
 package controlsys
 
 import (
+	"errors"
 	"math"
 	"math/cmplx"
 	"testing"
@@ -177,6 +178,123 @@ func TestTransferFunctionPreservesRowRealizationBehavior(t *testing.T) {
 				assertComplexApprox(t, tfEval[i][j], resp.At(k, i, j), 1e-8)
 			}
 		}
+	}
+}
+
+func TestDirectFeedthroughLoopBehaviorAcrossPublicInterconnections(t *testing.T) {
+	t.Run("singular", func(t *testing.T) {
+		plant, err := NewGain(mat.NewDense(1, 1, []float64{1}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		controller, err := NewGain(mat.NewDense(1, 1, []float64{1}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Feedback(plant, controller, 1); !errors.Is(err, ErrSingularTransform) {
+			t.Fatalf("Feedback err = %v, want ErrSingularTransform", err)
+		}
+
+		lftPlant, err := NewGain(mat.NewDense(2, 2, []float64{0, 1, 1, 1}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LFT(lftPlant, controller, 1, 1); !errors.Is(err, ErrAlgebraicLoop) {
+			t.Fatalf("LFT err = %v, want ErrAlgebraicLoop", err)
+		}
+	})
+
+	t.Run("nonsingular", func(t *testing.T) {
+		plant, err := NewGain(mat.NewDense(1, 1, []float64{2}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		controller, err := NewGain(mat.NewDense(1, 1, []float64{0.25}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		closed, err := Feedback(plant, controller, -1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := closed.D.At(0, 0), 4.0/3.0; math.Abs(got-want) > 1e-12 {
+			t.Fatalf("Feedback D = %v, want %v", got, want)
+		}
+
+		lftPlant, err := NewGain(mat.NewDense(2, 2, []float64{2, 2, 1, 0}), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lftClosed, err := LFT(lftPlant, controller, 1, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := lftClosed.D.At(0, 0), 2.5; math.Abs(got-want) > 1e-12 {
+			t.Fatalf("LFT D = %v, want %v", got, want)
+		}
+	})
+}
+
+func TestStabilityBoundaryClassificationAcrossPublicConsumers(t *testing.T) {
+	continuous, err := New(
+		mat.NewDense(1, 1, []float64{0}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, nil),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable, err := continuous.IsStable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stable {
+		t.Fatal("continuous boundary pole reported stable")
+	}
+	sep, err := Stabsep(continuous)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns, _, _ := sep.Stable.Dims()
+	nu, _, _ := sep.Unstable.Dims()
+	if ns != 0 || nu != 1 {
+		t.Fatalf("continuous Stabsep orders = stable %d unstable %d, want 0 and 1", ns, nu)
+	}
+	nyq, err := continuous.Nyquist([]float64{0.1, 1, 10}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nyq.RHPPoles != 0 {
+		t.Fatalf("continuous boundary pole counted as RHP: got %d", nyq.RHPPoles)
+	}
+
+	discrete, err := New(
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, nil),
+		0.1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable, err = discrete.IsStable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stable {
+		t.Fatal("discrete unit-circle pole reported stable")
+	}
+	sep, err = Stabsep(discrete)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns, _, _ = sep.Stable.Dims()
+	nu, _, _ = sep.Unstable.Dims()
+	if ns != 0 || nu != 1 {
+		t.Fatalf("discrete Stabsep orders = stable %d unstable %d, want 0 and 1", ns, nu)
 	}
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -937,6 +937,49 @@ func BenchmarkHinfNorm(b *testing.B) {
 	}
 }
 
+func BenchmarkH2Syn_Simple(b *testing.B) {
+	A := mat.NewDense(2, 2, []float64{0, 1, -2, -1})
+	B := mat.NewDense(2, 2, []float64{0, 0, 1, 1})
+	C := mat.NewDense(3, 2, []float64{
+		1, 0,
+		0, 0,
+		1, 0,
+	})
+	D := mat.NewDense(3, 2, []float64{
+		0, 0,
+		0, 1,
+		0.1, 0,
+	})
+	P, _ := New(A, B, C, D, 0)
+	b.ResetTimer()
+	for b.Loop() {
+		H2Syn(P, 1, 1)
+	}
+}
+
+func BenchmarkHinfSyn_Simple(b *testing.B) {
+	A := mat.NewDense(2, 2, []float64{0, 1, -2, -3})
+	B := mat.NewDense(2, 3, []float64{
+		1, 0, 0,
+		0, 1, 1,
+	})
+	C := mat.NewDense(3, 2, []float64{
+		1, 0,
+		0, 0,
+		1, 0,
+	})
+	D := mat.NewDense(3, 3, []float64{
+		0, 0, 0,
+		0, 0, 1,
+		0.1, 0.1, 0,
+	})
+	P, _ := New(A, B, C, D, 0)
+	b.ResetTimer()
+	for b.Loop() {
+		HinfSyn(P, 1, 1)
+	}
+}
+
 func BenchmarkBalreal(b *testing.B) {
 	sys := benchSys(10, 2, 3)
 	b.ResetTimer()

--- a/connect.go
+++ b/connect.go
@@ -478,6 +478,7 @@ func Feedback(plant, controller *System, sign float64) (*System, error) {
 		return feedbackWithLFT(plant, controller, sign)
 	}
 
+	feedbackSign := sign
 	// User convention: sign=-1 for negative feedback, +1 for positive.
 	// AB05ND formula uses opposite convention internally.
 	sign = -sign
@@ -486,27 +487,9 @@ func Feedback(plant, controller *System, sign float64) (*System, error) {
 	m := m1
 	p := p1
 
-	M := mat.NewDense(p1, p1, nil)
-	M.Mul(plant.D, controller.D)
-	M.Scale(sign, M)
-	for i := 0; i < p1; i++ {
-		M.Set(i, i, M.At(i, i)+1)
-	}
-
-	var lu mat.LU
-	lu.Factorize(M)
-	if luNearSingular(&lu) {
-		return nil, fmt.Errorf("feedback: (I + sign*D1*D2) singular: %w", ErrSingularTransform)
-	}
-
-	eyeData := make([]float64, p1*p1)
-	for i := 0; i < p1; i++ {
-		eyeData[i*(p1+1)] = 1
-	}
-	eye := mat.NewDense(p1, p1, eyeData)
-	E21 := mat.NewDense(p1, p1, nil)
-	if err := lu.SolveTo(E21, false, eye); err != nil {
-		return nil, fmt.Errorf("feedback: LU solve failed: %w", ErrSingularTransform)
+	E21, err := solveFeedbackFeedthrough(plant.D, controller.D, feedbackSign, p1, "feedback", ErrSingularTransform)
+	if err != nil {
+		return nil, err
 	}
 
 	e12Data := make([]float64, m1*m1)

--- a/feedback_lft.go
+++ b/feedback_lft.go
@@ -1,10 +1,6 @@
 package controlsys
 
-import (
-	"fmt"
-
-	"gonum.org/v1/gonum/mat"
-)
+import "gonum.org/v1/gonum/mat"
 
 func feedbackWithLFT(plant, controller *System, sign float64) (*System, error) {
 	savedPlantInput := copySliceOrNil(plant.InputDelay)
@@ -96,23 +92,9 @@ func feedbackWithLFT(plant, controller *System, sign float64) (*System, error) {
 	D1ee := extract(pH.D, 0, 0, p1, m1)
 	D2ee := extract(cH.D, 0, 0, m1, p1)
 
-	M := mat.NewDense(p1, p1, nil)
-	M.Mul(D1ee, D2ee)
-	M.Scale(isign, M)
-	mRaw := M.RawMatrix()
-	for i := 0; i < p1; i++ {
-		mRaw.Data[i*mRaw.Stride+i] += 1
-	}
-
-	var lu mat.LU
-	lu.Factorize(M)
-	if luNearSingular(&lu) {
-		return nil, fmt.Errorf("feedback: (I + sign*D1*D2) singular: %w", ErrSingularTransform)
-	}
-
-	E21 := mat.NewDense(p1, p1, nil)
-	if err := lu.SolveTo(E21, false, eyeDense(p1)); err != nil {
-		return nil, fmt.Errorf("feedback: LU solve failed: %w", ErrSingularTransform)
+	E21, err := solveFeedbackFeedthrough(D1ee, D2ee, sign, p1, "feedback", ErrSingularTransform)
+	if err != nil {
+		return nil, err
 	}
 
 	E12 := eyeDense(m1)

--- a/frd.go
+++ b/frd.go
@@ -116,6 +116,21 @@ func (sys *System) FRD(omega []float64) (*FRD, error) {
 	}, nil
 }
 
+func newFRDFromFreqResponse(resp *FreqResponseMatrix, dt float64) (*FRD, error) {
+	if resp == nil {
+		return nil, ErrInsufficientData
+	}
+	response, data := newFRDResponseStorage(resp.NFreq, resp.P, resp.M)
+	copy(data, resp.Data)
+	frd, err := NewFRD(response, resp.Omega, dt)
+	if err != nil {
+		return nil, err
+	}
+	frd.InputName = copyStringSlice(resp.InputName)
+	frd.OutputName = copyStringSlice(resp.OutputName)
+	return frd, nil
+}
+
 func newFRDResponseStorage(nw, p, m int) ([][][]complex128, []complex128) {
 	response := make([][][]complex128, nw)
 	if nw == 0 || p == 0 || m == 0 {
@@ -219,15 +234,7 @@ func (f *FRD) FreqResponse() *FreqResponseMatrix {
 			}
 		}
 	}
-	return &FreqResponseMatrix{
-		Data:       data,
-		Omega:      copyFloatSlice(f.Omega),
-		NFreq:      nw,
-		P:          p,
-		M:          m,
-		InputName:  copyStringSlice(f.InputName),
-		OutputName: copyStringSlice(f.OutputName),
-	}
+	return newFreqResponseMatrixOwned(data, f.Omega, p, m, f.InputName, f.OutputName)
 }
 
 // Bode computes magnitude (dB) and phase (degrees) from the FRD data.

--- a/frd_test.go
+++ b/frd_test.go
@@ -135,6 +135,37 @@ func TestFRD_DirectConstruction(t *testing.T) {
 	}
 }
 
+func TestFRD_OwnsConstructedAndExportedSampledResponseData(t *testing.T) {
+	resp := [][][]complex128{
+		{{1 + 2i}},
+		{{3 + 4i}},
+	}
+	omega := []float64{1, 2}
+	frd, err := NewFRD(resp, omega, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp[0][0][0] = 99
+	omega[0] = 99
+	if got := frd.At(0, 0, 0); got != 1+2i {
+		t.Fatalf("FRD response aliases constructor input: got %v", got)
+	}
+	if got := frd.Omega[0]; got != 1 {
+		t.Fatalf("FRD omega aliases constructor input: got %v", got)
+	}
+
+	matrix := frd.FreqResponse()
+	matrix.Data[0] = 77
+	matrix.Omega[0] = 77
+	if got := frd.At(0, 0, 0); got != 1+2i {
+		t.Fatalf("FreqResponse data aliases FRD storage: got %v", got)
+	}
+	if got := frd.Omega[0]; got != 1 {
+		t.Fatalf("FreqResponse omega aliases FRD storage: got %v", got)
+	}
+}
+
 func TestFRD_Discrete(t *testing.T) {
 	sys, err := New(
 		mat.NewDense(1, 1, []float64{0.5}),

--- a/freqrestest.go
+++ b/freqrestest.go
@@ -35,9 +35,7 @@ func (r *FreqRespEstResult) FRD() (*FRD, error) {
 	if r == nil || r.H == nil {
 		return nil, ErrInsufficientData
 	}
-	response, data := newFRDResponseStorage(r.H.NFreq, r.H.P, r.H.M)
-	copy(data, r.H.Data)
-	return NewFRD(response, r.Omega, r.Dt)
+	return newFRDFromFreqResponse(r.H, r.Dt)
 }
 
 func FreqRespEst(input, output *mat.Dense, dt float64, opts *FreqRespEstOpts) (*FreqRespEstResult, error) {
@@ -235,7 +233,7 @@ func welchSISO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,
 	}
 
 	return &FreqRespEstResult{
-		H:         &FreqResponseMatrix{Data: H, Omega: omega, NFreq: nFreq, P: 1, M: 1},
+		H:         newFreqResponseMatrix(H, omega, 1, 1, nil, nil),
 		Omega:     omega,
 		Dt:        dt,
 		Coherence: coh,
@@ -358,7 +356,7 @@ func welchMIMO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,
 	}
 
 	return &FreqRespEstResult{
-		H:         &FreqResponseMatrix{Data: H, Omega: omega, NFreq: nFreq, P: p, M: m},
+		H:         newFreqResponseMatrix(H, omega, p, m, nil, nil),
 		Omega:     omega,
 		Dt:        dt,
 		Coherence: coh,
@@ -410,7 +408,7 @@ func freqRespEstFFT(input, output *mat.Dense, dt float64, m, p, _, nfft int,
 	}
 
 	return &FreqRespEstResult{
-		H:     &FreqResponseMatrix{Data: H, Omega: omega, NFreq: nFreq, P: p, M: m},
+		H:     newFreqResponseMatrix(H, omega, p, m, nil, nil),
 		Omega: omega,
 		Dt:    dt,
 	}, nil

--- a/frequency.go
+++ b/frequency.go
@@ -22,6 +22,22 @@ func (f *FreqResponseMatrix) At(freq, output, input int) complex128 {
 	return f.Data[freq*f.P*f.M+output*f.M+input]
 }
 
+func newFreqResponseMatrix(data []complex128, omega []float64, p, m int, inputName, outputName []string) *FreqResponseMatrix {
+	return &FreqResponseMatrix{
+		Data:       data,
+		Omega:      omega,
+		NFreq:      len(omega),
+		P:          p,
+		M:          m,
+		InputName:  copyStringSlice(inputName),
+		OutputName: copyStringSlice(outputName),
+	}
+}
+
+func newFreqResponseMatrixOwned(data []complex128, omega []float64, p, m int, inputName, outputName []string) *FreqResponseMatrix {
+	return newFreqResponseMatrix(data, copyFloatSlice(omega), p, m, inputName, outputName)
+}
+
 type BodeResult struct {
 	Omega      []float64
 	magDB      []float64
@@ -208,11 +224,7 @@ func (e frequencyEvaluator) evalStateSpaceInto(s complex128, dst []complex128) e
 }
 
 func (e frequencyEvaluator) matrix(data []complex128, omega []float64) *FreqResponseMatrix {
-	return &FreqResponseMatrix{
-		Data: data, Omega: omega, NFreq: len(omega), P: e.p, M: e.m,
-		InputName:  copyStringSlice(e.sys.InputName),
-		OutputName: copyStringSlice(e.sys.OutputName),
-	}
+	return newFreqResponseMatrix(data, omega, e.p, e.m, e.sys.InputName, e.sys.OutputName)
 }
 
 func autoBodeFreqs(sys *System, nPoints int) ([]float64, error) {
@@ -405,7 +417,7 @@ func freqResponseLFT(sys *System, omega []float64, p, m int) (*FreqResponseMatri
 		copy(data[k*p*m:], ws.g[:p*m])
 	}
 
-	return &FreqResponseMatrix{Data: data, Omega: omega, NFreq: nw, P: p, M: m}, nil
+	return newFreqResponseMatrix(data, omega, p, m, nil, nil), nil
 }
 
 type lftWorkspace struct {

--- a/h2syn.go
+++ b/h2syn.go
@@ -43,20 +43,8 @@ func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
 		}
 	}
 
-	stab, err := IsStabilizable(A, B2, true)
-	if err != nil {
+	if err := gp.validateControllerChannels(); err != nil {
 		return nil, err
-	}
-	if !stab {
-		return nil, ErrNotStabilizable
-	}
-
-	det, err := IsDetectable(A, C2, true)
-	if err != nil {
-		return nil, err
-	}
-	if !det {
-		return nil, ErrNotDetectable
 	}
 
 	// State-feedback CARE: A'X + XA - (XB2+S1)*R1^{-1}*(B2'X+S1') + Q1 = 0
@@ -89,7 +77,6 @@ func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
 	L := mat.DenseCopyOf(resY.K.T())
 
 	var Ak, Bk, Ck *mat.Dense
-	var Dk *mat.Dense
 
 	// Ak = A + B2*F - L*C2
 	BF := mulDense(B2, F)
@@ -100,40 +87,16 @@ func H2Syn(P *System, nmeas, ncont int) (*H2SynResult, error) {
 
 	Bk = denseCopy(L)
 	Ck = denseCopy(F)
-	Dk = mat.NewDense(gp.m2, gp.p2, nil)
 
-	K, err := New(Ak, Bk, Ck, Dk, 0)
+	K, err := gp.newController(Ak, Bk, Ck)
 	if err != nil {
 		return nil, err
 	}
-	gp.applyControllerNames(K)
 
-	// Closed-loop A matrix for pole computation
-	// CL_A = [A + B2*Dk*C2,  B2*Ck;  Bk*C2,  Ak]
-	nn := 2 * n
-	clA := mat.NewDense(nn, nn, nil)
-
-	// top-left: A + B2*Dk*C2
-	topLeft := denseCopy(A)
-	setBlock(clA, 0, 0, topLeft)
-
-	// top-right: B2*Ck
-	BC := mulDense(B2, Ck)
-	setBlock(clA, 0, n, BC)
-
-	// bottom-left: Bk*C2
-	BkC := mulDense(Bk, C2)
-	setBlock(clA, n, 0, BkC)
-
-	// bottom-right: Ak
-	setBlock(clA, n, n, Ak)
-
-	var eig mat.Eigen
-	ok := eig.Factorize(clA, mat.EigenNone)
-	if !ok {
-		return nil, ErrSchurFailed
+	clPoles, err := gp.closedLoopPoles(Ak, Bk, Ck)
+	if err != nil {
+		return nil, err
 	}
-	clPoles := eig.Values(nil)
 
 	return &H2SynResult{K: K, X: X, Y: Y, CLPoles: clPoles}, nil
 }

--- a/hinfsyn.go
+++ b/hinfsyn.go
@@ -26,26 +26,14 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 	B1, B2 := gp.B1, gp.B2
 	C1, C2 := gp.C1, gp.C2
 	D11, D12, D21 := gp.D11, gp.D12, gp.D21
-	stab, err := IsStabilizable(A, B2, true)
-	if err != nil {
+	if err := gp.validateControllerChannels(); err != nil {
 		return nil, err
-	}
-	if !stab {
-		return nil, ErrNotStabilizable
-	}
-
-	det, err := IsDetectable(A, C2, true)
-	if err != nil {
-		return nil, err
-	}
-	if !det {
-		return nil, ErrNotDetectable
 	}
 
 	gammaLB := maxSVD(D11)
 	gammaUB := gammaLB*2 + 1
 
-	for !hinfFeasible(A, B1, B2, C1, C2, D12, D21, n, gp.m1, gp.m2, gp.p1, gp.p2, gammaUB) {
+	for !hinfFeasible(gp, gammaUB) {
 		gammaUB *= 2
 		if gammaUB > 1e12 {
 			return nil, ErrGammaNotAchievable
@@ -54,7 +42,7 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 
 	for gammaUB-gammaLB > 1e-6*gammaUB {
 		mid := (gammaLB + gammaUB) / 2
-		if hinfFeasible(A, B1, B2, C1, C2, D12, D21, n, gp.m1, gp.m2, gp.p1, gp.p2, mid) {
+		if hinfFeasible(gp, mid) {
 			gammaUB = mid
 		} else {
 			gammaLB = mid
@@ -62,7 +50,7 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 	}
 
 	gamma := gammaUB
-	X, Y, err := hinfSolveRiccatis(A, B1, B2, C1, C2, D12, D21, n, gp.m1, gp.m2, gp.p1, gp.p2, gamma)
+	X, Y, err := hinfSolveRiccatis(gp, gamma)
 	if err != nil {
 		return nil, err
 	}
@@ -128,43 +116,35 @@ func HinfSyn(P *System, nmeas, ncont int) (*HinfSynResult, error) {
 	Bk := mulDense(Zp, L)
 	Bk.Scale(-1, Bk)
 	Ck := denseCopy(F)
-	Dk := mat.NewDense(gp.m2, gp.p2, nil)
 
-	K, err := New(Ak, Bk, Ck, Dk, 0)
+	K, err := gp.newController(Ak, Bk, Ck)
 	if err != nil {
 		return nil, err
 	}
-	gp.applyControllerNames(K)
 
-	clN := 2 * n
-	clA := mat.NewDense(clN, clN, nil)
-	setBlock(clA, 0, 0, A)
-	BC := mulDense(B2, Ck)
-	setBlock(clA, 0, n, BC)
-	BkC := mulDense(Bk, C2)
-	setBlock(clA, n, 0, BkC)
-	setBlock(clA, n, n, Ak)
-
-	var eig mat.Eigen
-	ok := eig.Factorize(clA, mat.EigenNone)
-	if !ok {
-		return nil, ErrSchurFailed
+	clPoles, err := gp.closedLoopPoles(Ak, Bk, Ck)
+	if err != nil {
+		return nil, err
 	}
-	clPoles := eig.Values(nil)
 
 	return &HinfSynResult{K: K, GammaOpt: gamma, X: X, Y: Y, CLPoles: clPoles}, nil
 }
 
-func hinfFeasible(A, B1, B2, C1, C2, D12, D21 *mat.Dense, n, m1, m2, p1, p2 int, gamma float64) bool {
-	_, _, err := hinfSolveRiccatis(A, B1, B2, C1, C2, D12, D21, n, m1, m2, p1, p2, gamma)
+func hinfFeasible(gp *generalizedPlantPartition, gamma float64) bool {
+	_, _, err := hinfSolveRiccatis(gp, gamma)
 	return err == nil
 }
 
-func hinfSolveRiccatis(A, B1, B2, C1, C2, D12, D21 *mat.Dense, n, m1, m2, p1, p2 int, gamma float64) (*mat.Dense, *mat.Dense, error) {
+func hinfSolveRiccatis(gp *generalizedPlantPartition, gamma float64) (*mat.Dense, *mat.Dense, error) {
+	A := gp.A
+	B1, B2 := gp.B1, gp.B2
+	C1, C2 := gp.C1, gp.C2
+	D12, D21 := gp.D12, gp.D21
+	n := gp.n
 	ginv2 := 1.0 / (gamma * gamma)
 
 	R1 := mulDense(mat.DenseCopyOf(D12.T()), D12)
-	R1inv, err := invertSmall(R1, m2)
+	R1inv, err := invertSmall(R1, gp.m2)
 	if err != nil {
 		return nil, nil, ErrInvalidPartition
 	}
@@ -204,7 +184,7 @@ func hinfSolveRiccatis(A, B1, B2, C1, C2, D12, D21 *mat.Dense, n, m1, m2, p1, p2
 
 	// Y-Riccati
 	R2 := mulDense(D21, mat.DenseCopyOf(D21.T()))
-	R2inv, err := invertSmall(R2, p2)
+	R2inv, err := invertSmall(R2, gp.p2)
 	if err != nil {
 		return nil, nil, ErrInvalidPartition
 	}

--- a/lft.go
+++ b/lft.go
@@ -181,22 +181,7 @@ func lftSimple(M, Delta *System, nu, ny int) (*System, error) {
 }
 
 func solveLFTLoop(D22M, DDelta *mat.Dense, w int) (*mat.Dense, error) {
-	eye := eyeDense(w)
-	loop := mat.NewDense(w, w, nil)
-	loop.Mul(D22M, DDelta)
-	loop.Sub(eye, loop)
-
-	var lu mat.LU
-	lu.Factorize(loop)
-	if luNearSingular(&lu) {
-		return nil, fmt.Errorf("lft: (I - D22*D_Delta) singular: %w", ErrAlgebraicLoop)
-	}
-
-	F := mat.NewDense(w, w, nil)
-	if err := lu.SolveTo(F, false, eye); err != nil {
-		return nil, fmt.Errorf("lft: LU solve failed: %w", ErrAlgebraicLoop)
-	}
-	return F, nil
+	return solveIdentityMinusProduct(D22M, DDelta, w, "lft", ErrAlgebraicLoop)
 }
 
 func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {

--- a/nyquist.go
+++ b/nyquist.go
@@ -68,21 +68,15 @@ func (sys *System) Nyquist(omega []float64, nPoints int) (*NyquistResult, error)
 func countRHPPoles(poles []complex128, continuous bool, tol float64) int {
 	count := 0
 	for _, pole := range poles {
-		if continuous {
-			if real(pole) > tol {
-				count++
-			}
-		} else {
-			if cmplx.Abs(pole) > 1+tol {
-				count++
-			}
+		if poleOutsideStabilityBoundary(pole, continuous, tol) {
+			count++
 		}
 	}
 	return count
 }
 
 type imagAxisPole struct {
-	w0          float64
+	w0           float64
 	multiplicity int
 }
 
@@ -102,10 +96,10 @@ func findImagAxisPoles(poles []complex128, continuous bool, dt, tol float64) []i
 		var onAxis bool
 		var w0 float64
 		if continuous {
-			onAxis = math.Abs(real(pole)) < tol
+			onAxis = poleOnStabilityBoundary(pole, continuous, tol)
 			w0 = math.Abs(imag(pole))
 		} else {
-			onAxis = math.Abs(cmplx.Abs(pole)-1) < tol
+			onAxis = poleOnStabilityBoundary(pole, continuous, tol)
 			if onAxis {
 				angle := cmplx.Phase(pole)
 				if dt > 0 {

--- a/pade.go
+++ b/pade.go
@@ -53,24 +53,9 @@ func (sys *System) Pade(order int) (*System, error) {
 	D22 := lft.LFT.D22
 
 	Dd := delayBank.D
-	D22Dd := mat.NewDense(N, N, nil)
-	D22Dd.Mul(D22, Dd)
-	E := mat.NewDense(N, N, nil)
-	eRaw := E.RawMatrix()
-	for i := 0; i < N; i++ {
-		eRaw.Data[i*eRaw.Stride+i] = 1
-	}
-	E.Sub(E, D22Dd)
-	var lu mat.LU
-	lu.Factorize(E)
-	D22Dd.Zero()
-	idRaw := D22Dd.RawMatrix()
-	for i := 0; i < N; i++ {
-		idRaw.Data[i*idRaw.Stride+i] = 1
-	}
-	Einv := mat.NewDense(N, N, nil)
-	if err := lu.SolveTo(Einv, false, D22Dd); err != nil {
-		return nil, fmt.Errorf("Pade: (I - D22*Dd) singular: %w", ErrSingularTransform)
+	Einv, err := solveIdentityMinusProduct(D22, Dd, N, "Pade", ErrSingularTransform)
+	if err != nil {
+		return nil, err
 	}
 
 	DdE := mat.NewDense(N, N, nil)

--- a/stability.go
+++ b/stability.go
@@ -2,11 +2,50 @@ package controlsys
 
 import "math/cmplx"
 
-func poleOnOrOutsideStabilityBoundary(p complex128, continuous bool, tol float64) bool {
+type poleStabilityClass int
+
+const (
+	poleClassStable poleStabilityClass = iota
+	poleClassBoundary
+	poleClassUnstable
+)
+
+func classifyPoleStability(p complex128, continuous bool, tol float64) poleStabilityClass {
 	if continuous {
-		return real(p) >= -tol
+		switch {
+		case real(p) < -tol:
+			return poleClassStable
+		case real(p) > tol:
+			return poleClassUnstable
+		default:
+			return poleClassBoundary
+		}
 	}
-	return cmplx.Abs(p) >= 1-tol
+	r := cmplx.Abs(p)
+	switch {
+	case r < 1-tol:
+		return poleClassStable
+	case r > 1+tol:
+		return poleClassUnstable
+	default:
+		return poleClassBoundary
+	}
+}
+
+func poleOnOrOutsideStabilityBoundary(p complex128, continuous bool, tol float64) bool {
+	return classifyPoleStability(p, continuous, tol) != poleClassStable
+}
+
+func poleInsideStabilityBoundary(p complex128, continuous bool, tol float64) bool {
+	return classifyPoleStability(p, continuous, tol) == poleClassStable
+}
+
+func poleOutsideStabilityBoundary(p complex128, continuous bool, tol float64) bool {
+	return classifyPoleStability(p, continuous, tol) == poleClassUnstable
+}
+
+func poleOnStabilityBoundary(p complex128, continuous bool, tol float64) bool {
+	return classifyPoleStability(p, continuous, tol) == poleClassBoundary
 }
 
 func poleStabilityTolerance(p complex128) float64 {

--- a/stabsep.go
+++ b/stabsep.go
@@ -1,7 +1,5 @@
 package controlsys
 
-import "math/cmplx"
-
 type StabsepResult struct {
 	Stable   *System
 	Unstable *System
@@ -9,10 +7,7 @@ type StabsepResult struct {
 
 func Stabsep(sys *System) (*StabsepResult, error) {
 	isStable := func(ev complex128) bool {
-		if sys.IsContinuous() {
-			return real(ev) < 0
-		}
-		return cmplx.Abs(ev) < 1
+		return poleInsideStabilityBoundary(ev, sys.IsContinuous(), 0)
 	}
 
 	stable, unstable, err := decomposeByEigenvalues(sys, isStable)

--- a/synthesis_partition.go
+++ b/synthesis_partition.go
@@ -62,6 +62,49 @@ func (gp *generalizedPlantPartition) applyControllerNames(K *System) {
 	K.OutputName = copyStringSlice(gp.controlNames)
 }
 
+func (gp *generalizedPlantPartition) validateControllerChannels() error {
+	stab, err := IsStabilizable(gp.A, gp.B2, true)
+	if err != nil {
+		return err
+	}
+	if !stab {
+		return ErrNotStabilizable
+	}
+
+	det, err := IsDetectable(gp.A, gp.C2, true)
+	if err != nil {
+		return err
+	}
+	if !det {
+		return ErrNotDetectable
+	}
+	return nil
+}
+
+func (gp *generalizedPlantPartition) newController(Ak, Bk, Ck *mat.Dense) (*System, error) {
+	K, err := New(Ak, Bk, Ck, mat.NewDense(gp.m2, gp.p2, nil), 0)
+	if err != nil {
+		return nil, err
+	}
+	gp.applyControllerNames(K)
+	return K, nil
+}
+
+func (gp *generalizedPlantPartition) closedLoopPoles(Ak, Bk, Ck *mat.Dense) ([]complex128, error) {
+	clN := 2 * gp.n
+	clA := mat.NewDense(clN, clN, nil)
+	setBlock(clA, 0, 0, gp.A)
+	setBlock(clA, 0, gp.n, mulDense(gp.B2, Ck))
+	setBlock(clA, gp.n, 0, mulDense(Bk, gp.C2))
+	setBlock(clA, gp.n, gp.n, Ak)
+
+	var eig mat.Eigen
+	if ok := eig.Factorize(clA, mat.EigenNone); !ok {
+		return nil, ErrSchurFailed
+	}
+	return eig.Values(nil), nil
+}
+
 func selectTrailingNames(names []string, start, count int) []string {
 	if names == nil {
 		return nil

--- a/zpk.go
+++ b/zpk.go
@@ -144,11 +144,7 @@ func (z *ZPK) FreqResponse(omega []float64) (*FreqResponseMatrix, error) {
 			}
 		}
 	}
-	return &FreqResponseMatrix{
-		Data: data, Omega: omega, NFreq: len(omega), P: p, M: m,
-		InputName:  copyStringSlice(z.InputName),
-		OutputName: copyStringSlice(z.OutputName),
-	}, nil
+	return newFreqResponseMatrix(data, omega, p, m, z.InputName, z.OutputName), nil
 }
 
 func (z *ZPK) TransferFunction() (*TransferFunc, error) {


### PR DESCRIPTION
## Summary

- centralize direct-feedthrough loop solving across feedback, LFT, Pade, and delayed feedback paths
- deepen generalized-plant synthesis behavior for shared channel validation, controller naming, and closed-loop pole construction
- consolidate sampled complex response construction / FRD conversion helpers
- centralize stability-boundary pole classification for stability analysis, Stabsep, and Nyquist

Fixes #54
Fixes #55
Fixes #56
Fixes #57

## Tests

- `env GOCACHE=/tmp/qlx-go-build-cache go test -v -count=1`
- `benchstat /private/tmp/controlsys-bench-before.txt /private/tmp/controlsys-bench-after.txt`

Benchmark summary:

- geomean: `18.13µs -> 17.95µs` (`-0.99%`)
- allocations unchanged overall
- no meaningful regression found; `SystemFRD_MIMO_200` moved `92.50µs -> 94.63µs`, not significant (`p=0.548`)
