### PR TITLE
Deepen remaining LTI architecture modules

### DIFF
--- a/architecture_remaining_test.go
+++ b/architecture_remaining_test.go
@@ -85,11 +85,66 @@ func TestRemainingArchitectureDelayTopologyPublicOperations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	safeCollapsed, err := SafeFeedback(collapsed, controller, -1, WithPadeOrder(2))
+	manualPlant, err := replaceExplicitIODelaysWithPade(split, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertFreqResponseApprox(t, safeSplit, safeCollapsed, omega, 1e-8)
+	manualSafe, err := Feedback(manualPlant, controller, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFreqResponseApprox(t, safeSplit, manualSafe, omega, 1e-8)
+}
+
+func replaceExplicitIODelaysWithPade(sys *System, padeOrder int) (*System, error) {
+	_, m, p := sys.Dims()
+	cur := sys.Copy()
+	if cur.Delay != nil {
+		inDel, outDel, residual := DecomposeIODelay(cur.Delay)
+		if delayMatrixHasNonzeroTol(residual, delayTopologyTol) {
+			return nil, ErrFeedbackDelay
+		}
+		cur.Delay = nil
+		cur.InputDelay = mergeDelays(cur.InputDelay, inDel)
+		cur.OutputDelay = mergeDelays(cur.OutputDelay, outDel)
+	}
+
+	result := &System{A: cur.A, B: cur.B, C: cur.C, D: cur.D, Dt: cur.Dt}
+	for j := m - 1; j >= 0; j-- {
+		if cur.InputDelay == nil || cur.InputDelay[j] == 0 {
+			continue
+		}
+		pade, err := PadeDelay(cur.InputDelay[j], padeOrder)
+		if err != nil {
+			return nil, err
+		}
+		diag, err := buildDiagWithPade(j, m, pade)
+		if err != nil {
+			return nil, err
+		}
+		result, err = Series(diag, result)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for i := p - 1; i >= 0; i-- {
+		if cur.OutputDelay == nil || cur.OutputDelay[i] == 0 {
+			continue
+		}
+		pade, err := PadeDelay(cur.OutputDelay[i], padeOrder)
+		if err != nil {
+			return nil, err
+		}
+		diag, err := buildDiagWithPade(i, p, pade)
+		if err != nil {
+			return nil, err
+		}
+		result, err = Series(result, diag)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
 }
 
 func TestRemainingArchitectureConversionPlannerBehavior(t *testing.T) {

--- a/architecture_remaining_test.go
+++ b/architecture_remaining_test.go
@@ -1,0 +1,229 @@
+package controlsys
+
+import (
+	"errors"
+	"math"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func remainingArchitectureMIMO(t *testing.T, dt float64) *System {
+	t.Helper()
+	sys, err := NewFromSlices(3, 2, 2,
+		[]float64{
+			0, 1, 0,
+			-2, -3, 1,
+			0.5, -0.25, -1.5,
+		},
+		[]float64{
+			1, 0,
+			0, 1,
+			1, -1,
+		},
+		[]float64{
+			1, 0, 0.5,
+			0, 1, -0.25,
+		},
+		[]float64{
+			0.1, -0.2,
+			0.05, 0.3,
+		},
+		dt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"u-fast", "u-slow"}
+	sys.OutputName = []string{"y-top", "y-bottom"}
+	sys.StateName = []string{"x1", "x2", "x3"}
+	sys.Notes = "remaining architecture regression model"
+	return sys
+}
+
+func TestRemainingArchitectureDelayTopologyPublicOperations(t *testing.T) {
+	base := remainingArchitectureMIMO(t, 0)
+
+	split := base.Copy()
+	if err := split.SetInputDelay([]float64{0.1, 0.2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := split.SetOutputDelay([]float64{0.05, 0.15}); err != nil {
+		t.Fatal(err)
+	}
+	if err := split.SetDelay(mat.NewDense(2, 2, []float64{
+		0.0, 0.05,
+		0.1, 0.15,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	collapsed := base.Copy()
+	if err := collapsed.SetDelay(split.TotalDelay()); err != nil {
+		t.Fatal(err)
+	}
+
+	omega := []float64{0.2, 1.0, 3.5}
+	assertFreqResponseApprox(t, split, collapsed, omega, 1e-10)
+
+	splitLFT, err := split.PullDelaysToLFT()
+	if err != nil {
+		t.Fatal(err)
+	}
+	collapsedLFT, err := collapsed.PullDelaysToLFT()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFreqResponseApprox(t, splitLFT, collapsedLFT, omega, 1e-10)
+
+	controller, err := NewGain(mat.NewDense(2, 2, []float64{0.2, 0.05, -0.1, 0.15}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	safeSplit, err := SafeFeedback(split, controller, -1, WithPadeOrder(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	safeCollapsed, err := SafeFeedback(collapsed, controller, -1, WithPadeOrder(2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFreqResponseApprox(t, safeSplit, safeCollapsed, omega, 1e-8)
+}
+
+func TestRemainingArchitectureConversionPlannerBehavior(t *testing.T) {
+	sys := remainingArchitectureMIMO(t, 0)
+	sys.InputDelay = []float64{0.2, 0.3}
+	sys.OutputDelay = []float64{0.1, 0.0}
+
+	discDefault, err := sys.DiscretizeWithOpts(0.1, C2DOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	discZOH, err := sys.DiscretizeWithOpts(0.1, C2DOptions{Method: "zoh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDenseApprox(t, discDefault.A, discZOH.A, 1e-12)
+	assertDenseApprox(t, discDefault.B, discZOH.B, 1e-12)
+	if !stringSlicesEqual(discDefault.InputName, sys.InputName) || !stringSlicesEqual(discDefault.OutputName, sys.OutputName) {
+		t.Fatalf("names not preserved through default conversion: inputs=%v outputs=%v", discDefault.InputName, discDefault.OutputName)
+	}
+	if !floatSlicesEqual(discDefault.InputDelay, []float64{2, 3}) {
+		t.Fatalf("InputDelay = %v, want [2 3]", discDefault.InputDelay)
+	}
+
+	resampled, err := discDefault.D2D(0.05, C2DOptions{Method: "tustin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resampled.Dt != 0.05 {
+		t.Fatalf("D2D Dt = %v, want 0.05", resampled.Dt)
+	}
+	if !stringSlicesEqual(resampled.StateName, sys.StateName) {
+		t.Fatalf("state names = %v, want %v", resampled.StateName, sys.StateName)
+	}
+
+	if _, err := sys.DiscretizeWithOpts(0.1, C2DOptions{Method: "unknown"}); err == nil {
+		t.Fatal("expected unknown C2D method to fail")
+	}
+	if _, err := discDefault.D2C("unknown"); err == nil {
+		t.Fatal("expected unknown D2C method to fail")
+	}
+}
+
+func TestRemainingArchitectureTimeDomainPolicyPublicConsumers(t *testing.T) {
+	cont := remainingArchitectureMIMO(t, 0)
+	disc, err := cont.DiscretizeZOH(0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := disc.SetDelay(mat.NewDense(2, 2, []float64{1, 2, 0, 3})); err != nil {
+		t.Fatal(err)
+	}
+
+	otherDt := disc.Copy()
+	otherDt.Dt = 0.2
+	if _, err := Series(disc, otherDt); !errors.Is(err, ErrDomainMismatch) {
+		t.Fatalf("Series domain error = %v, want ErrDomainMismatch", err)
+	}
+
+	omega := []float64{0.2, 1.2}
+	resp, err := disc.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k, w := range omega {
+		z := cmplx.Exp(complex(0, w*disc.Dt))
+		eval, err := disc.EvalFr(z)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < resp.P; i++ {
+			for j := 0; j < resp.M; j++ {
+				assertComplexApprox(t, resp.At(k, i, j), eval[i][j], 1e-10)
+			}
+		}
+	}
+
+	contAgain, err := disc.D2C("tustin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	delay := contAgain.TotalDelay()
+	if delay == nil {
+		t.Fatal("continuous delay is nil")
+	}
+	if got := delay.At(0, 1); math.Abs(got-0.2) > 1e-12 {
+		t.Fatalf("delay(0,1) = %v, want 0.2", got)
+	}
+}
+
+func TestRemainingArchitectureSignalMetadataMappings(t *testing.T) {
+	sys := remainingArchitectureMIMO(t, 0)
+	selected, err := sys.SelectByName([]string{"u-slow"}, []string{"y-bottom"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(selected.InputName, []string{"u-slow"}) {
+		t.Fatalf("selected inputs = %v", selected.InputName)
+	}
+	if !stringSlicesEqual(selected.OutputName, []string{"y-bottom"}) {
+		t.Fatalf("selected outputs = %v", selected.OutputName)
+	}
+	if !stringSlicesEqual(selected.StateName, sys.StateName) {
+		t.Fatalf("selected states = %v, want %v", selected.StateName, sys.StateName)
+	}
+
+	foh, err := sys.DiscretizeFOH(0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(foh.StateName) != 5 {
+		t.Fatalf("FOH state names = %v, want 5 names", foh.StateName)
+	}
+	if foh.StateName[3] != "u-fast_prev" || foh.StateName[4] != "u-slow_prev" {
+		t.Fatalf("FOH augmented state names = %v", foh.StateName)
+	}
+
+	series, err := Series(sys, sys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(series.InputName, sys.InputName) || !stringSlicesEqual(series.OutputName, sys.OutputName) {
+		t.Fatalf("series names inputs=%v outputs=%v", series.InputName, series.OutputName)
+	}
+}
+
+func floatSlicesEqual(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/connect.go
+++ b/connect.go
@@ -8,10 +8,7 @@ import (
 )
 
 func domainMatch(sys1, sys2 *System) error {
-	if sys1.Dt != sys2.Dt {
-		return ErrDomainMismatch
-	}
-	return nil
+	return newTimeDomain(sys1.Dt).ensureCompatible(newTimeDomain(sys2.Dt))
 }
 
 func setBlock(dst *mat.Dense, r0, c0 int, src *mat.Dense) {
@@ -111,9 +108,7 @@ func seriesSimple(sys1, sys2 *System) (*System, error) {
 		}
 		sys.InputDelay = inDel
 		sys.OutputDelay = outDel
-		sys.InputName = copyStringSlice(sys1.InputName)
-		sys.OutputName = copyStringSlice(sys2.OutputName)
-		sys.StateName = concatStringSlices([][]string{sys1.StateName, sys2.StateName}, []int{n1, n2})
+		seriesMetadata(sys1, sys2, n1, n2).applyAllOwned(sys)
 		return sys, nil
 	}
 

--- a/conversion_plan.go
+++ b/conversion_plan.go
@@ -1,0 +1,197 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+)
+
+type c2dPlan struct {
+	sys             *System
+	dt              float64
+	opts            C2DOptions
+	method          string
+	delayModeling   string
+	contInputDelay  []float64
+	contOutputDelay []float64
+	workSys         *System
+}
+
+func newC2DPlan(sys *System, dt float64, opts C2DOptions) (c2dPlan, error) {
+	if sys.IsDiscrete() {
+		return c2dPlan{}, fmt.Errorf("DiscretizeWithOpts: system already discrete: %w", ErrWrongDomain)
+	}
+	if dt <= 0 {
+		return c2dPlan{}, ErrInvalidSampleTime
+	}
+
+	method := opts.Method
+	if method == "" {
+		method = "zoh"
+	}
+	switch method {
+	case "zoh", "tustin", "foh", "impulse", "matched":
+	default:
+		return c2dPlan{}, fmt.Errorf("DiscretizeWithOpts: unknown method %q", method)
+	}
+	opts.Method = method
+
+	delayModeling := opts.DelayModeling
+	if delayModeling == "" {
+		delayModeling = "state"
+	}
+	switch delayModeling {
+	case "state", "internal":
+	default:
+		return c2dPlan{}, fmt.Errorf("DiscretizeWithOpts: unknown DelayModeling %q", delayModeling)
+	}
+
+	cp := sys.Copy()
+	plan := c2dPlan{
+		sys:             sys,
+		dt:              dt,
+		opts:            opts,
+		method:          method,
+		delayModeling:   delayModeling,
+		contInputDelay:  sys.InputDelay,
+		contOutputDelay: sys.OutputDelay,
+		workSys:         cp,
+	}
+	plan.workSys.InputDelay = nil
+	plan.workSys.OutputDelay = nil
+	if sys.Delay != nil && (opts.ThiranOrder > 0 || delayModeling == "internal") {
+		inD, outD, residual := DecomposeIODelay(sys.Delay)
+		if delayMatrixHasNonzeroTol(residual, delayTopologyTol) {
+			plan.workSys.Delay = residual
+		} else {
+			plan.workSys.Delay = nil
+		}
+		plan.contInputDelay = mergeDelays(sys.InputDelay, inD)
+		plan.contOutputDelay = mergeDelays(sys.OutputDelay, outD)
+	}
+
+	return plan, nil
+}
+
+func (p c2dPlan) run() (*System, error) {
+	if p.workSys.HasInternalDelay() {
+		return p.discretizeInternalDelay()
+	}
+
+	disc, err := p.discretizeMethod()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.delayModeling == "internal" {
+		return discretizeDelaysAsInternal(disc, p.contInputDelay, p.contOutputDelay, p.dt)
+	}
+	return p.applyExternalDelays(disc)
+}
+
+func (p c2dPlan) discretizeInternalDelay() (*System, error) {
+	disc, err := discretizeWithInternalDelay(p.workSys, p.dt, p.opts)
+	if err != nil {
+		return nil, err
+	}
+	return p.applyExternalDelays(disc)
+}
+
+func (p c2dPlan) discretizeMethod() (*System, error) {
+	switch p.method {
+	case "zoh":
+		return p.workSys.DiscretizeZOH(p.dt)
+	case "tustin":
+		return p.workSys.Discretize(p.dt)
+	case "foh":
+		return p.workSys.DiscretizeFOH(p.dt)
+	case "impulse":
+		return p.workSys.DiscretizeImpulse(p.dt)
+	case "matched":
+		return p.workSys.DiscretizeMatched(p.dt)
+	default:
+		panic("unvalidated C2D method")
+	}
+}
+
+func (p c2dPlan) applyExternalDelays(disc *System) (*System, error) {
+	var err error
+	disc.InputDelay, err = convertSliceDelayToDiscrete(p.contInputDelay, p.dt, p.opts.ThiranOrder)
+	if err != nil {
+		return nil, err
+	}
+	disc.OutputDelay, err = convertSliceDelayToDiscrete(p.contOutputDelay, p.dt, p.opts.ThiranOrder)
+	if err != nil {
+		return nil, err
+	}
+	if p.opts.ThiranOrder > 0 {
+		disc, err = absorbFractionalDelays(disc, p.contInputDelay, p.contOutputDelay, p.dt, p.opts.ThiranOrder)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return disc, nil
+}
+
+type d2cPlan struct {
+	sys    *System
+	method string
+}
+
+func newD2CPlan(sys *System, method string) (d2cPlan, error) {
+	if sys.IsContinuous() {
+		return d2cPlan{}, fmt.Errorf("D2C: system already continuous: %w", ErrWrongDomain)
+	}
+	if method == "" {
+		method = "zoh"
+	}
+	switch method {
+	case "zoh", "tustin":
+		return d2cPlan{sys: sys, method: method}, nil
+	default:
+		return d2cPlan{}, fmt.Errorf("D2C: unknown method %q (supported: \"tustin\", \"zoh\")", method)
+	}
+}
+
+func (p d2cPlan) run() (*System, error) {
+	switch p.method {
+	case "zoh":
+		return p.sys.d2cZOH()
+	case "tustin":
+		return p.sys.Undiscretize()
+	default:
+		panic("unvalidated D2C method")
+	}
+}
+
+type d2dPlan struct {
+	sys   *System
+	newDt float64
+	opts  C2DOptions
+}
+
+func newD2DPlan(sys *System, newDt float64, opts C2DOptions) (d2dPlan, error) {
+	if sys.IsContinuous() {
+		return d2dPlan{}, fmt.Errorf("D2D: system is continuous: %w", ErrWrongDomain)
+	}
+	if newDt <= 0 {
+		return d2dPlan{}, ErrInvalidSampleTime
+	}
+	return d2dPlan{sys: sys, newDt: newDt, opts: opts}, nil
+}
+
+func (p d2dPlan) run() (*System, error) {
+	if math.Abs(p.newDt-p.sys.Dt) < 1e-14*math.Max(p.newDt, p.sys.Dt) {
+		return p.sys.Copy(), nil
+	}
+
+	contSys, err := p.sys.Undiscretize()
+	if err != nil {
+		return nil, fmt.Errorf("D2D: %w", err)
+	}
+	result, err := contSys.DiscretizeWithOpts(p.newDt, p.opts)
+	if err != nil {
+		return nil, fmt.Errorf("D2D: %w", err)
+	}
+	propagateNames(result, p.sys)
+	return result, nil
+}

--- a/convert.go
+++ b/convert.go
@@ -197,116 +197,11 @@ type C2DOptions struct {
 }
 
 func (sys *System) DiscretizeWithOpts(dt float64, opts C2DOptions) (*System, error) {
-	if sys.IsDiscrete() {
-		return nil, fmt.Errorf("DiscretizeWithOpts: system already discrete: %w", ErrWrongDomain)
-	}
-	if dt <= 0 {
-		return nil, ErrInvalidSampleTime
-	}
-
-	delayModeling := opts.DelayModeling
-	if delayModeling == "" {
-		delayModeling = "state"
-	}
-	if delayModeling != "state" && delayModeling != "internal" {
-		return nil, fmt.Errorf("DiscretizeWithOpts: unknown DelayModeling %q", delayModeling)
-	}
-
-	method := opts.Method
-	if method == "" {
-		method = "zoh"
-	}
-
-	contInputDelay := sys.InputDelay
-	contOutputDelay := sys.OutputDelay
-
-	cp := sys.Copy()
-	cp.InputDelay = nil
-	cp.OutputDelay = nil
-
-	if sys.Delay != nil && (opts.ThiranOrder > 0 || delayModeling == "internal") {
-		inD, outD, residual := DecomposeIODelay(sys.Delay)
-		hasResidual := false
-		raw := residual.RawMatrix()
-		for _, v := range raw.Data[:raw.Rows*raw.Cols] {
-			if v != 0 {
-				hasResidual = true
-				break
-			}
-		}
-		if hasResidual {
-			cp.Delay = residual
-		} else {
-			cp.Delay = nil
-		}
-		contInputDelay = mergeDelays(sys.InputDelay, inD)
-		contOutputDelay = mergeDelays(sys.OutputDelay, outD)
-	}
-	workSys := cp
-
-	if workSys.HasInternalDelay() {
-		disc, err := discretizeWithInternalDelay(workSys, dt, opts)
-		if err != nil {
-			return nil, err
-		}
-		disc.InputDelay, err = convertSliceDelayToDiscrete(contInputDelay, dt, opts.ThiranOrder)
-		if err != nil {
-			return nil, err
-		}
-		disc.OutputDelay, err = convertSliceDelayToDiscrete(contOutputDelay, dt, opts.ThiranOrder)
-		if err != nil {
-			return nil, err
-		}
-		if opts.ThiranOrder > 0 {
-			disc, err = absorbFractionalDelays(disc, contInputDelay, contOutputDelay, dt, opts.ThiranOrder)
-			if err != nil {
-				return nil, err
-			}
-		}
-		return disc, nil
-	}
-
-	var disc *System
-	var err error
-	switch method {
-	case "zoh":
-		disc, err = workSys.DiscretizeZOH(dt)
-	case "tustin":
-		disc, err = workSys.Discretize(dt)
-	case "foh":
-		disc, err = workSys.DiscretizeFOH(dt)
-	case "impulse":
-		disc, err = workSys.DiscretizeImpulse(dt)
-	case "matched":
-		disc, err = workSys.DiscretizeMatched(dt)
-	default:
-		return nil, fmt.Errorf("DiscretizeWithOpts: unknown method %q", method)
-	}
+	plan, err := newC2DPlan(sys, dt, opts)
 	if err != nil {
 		return nil, err
 	}
-
-	if delayModeling == "internal" {
-		return discretizeDelaysAsInternal(disc, contInputDelay, contOutputDelay, dt)
-	}
-
-	disc.InputDelay, err = convertSliceDelayToDiscrete(contInputDelay, dt, opts.ThiranOrder)
-	if err != nil {
-		return nil, err
-	}
-	disc.OutputDelay, err = convertSliceDelayToDiscrete(contOutputDelay, dt, opts.ThiranOrder)
-	if err != nil {
-		return nil, err
-	}
-
-	if opts.ThiranOrder > 0 {
-		disc, err = absorbFractionalDelays(disc, contInputDelay, contOutputDelay, dt, opts.ThiranOrder)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return disc, nil
+	return plan.run()
 }
 
 func discretizeDelaysAsInternal(disc *System, contInputDelay, contOutputDelay []float64, dt float64) (*System, error) {
@@ -1177,19 +1072,7 @@ func buildFOHSystem(sys *System, n, m, p int, dt float64, adData, g0Data, g1Data
 }
 
 func fohAugmentStateNames(out, src *System, n, m int) {
-	if src.StateName == nil && src.InputName == nil {
-		return
-	}
-	names := make([]string, n+m)
-	if src.StateName != nil {
-		copy(names, src.StateName)
-	}
-	for j := 0; j < m; j++ {
-		if src.InputName != nil && j < len(src.InputName) {
-			names[n+j] = src.InputName[j] + "_prev"
-		}
-	}
-	out.StateName = names
+	out.StateName = fohStateMetadata(src, n, m)
 }
 
 func discretizeFOHAugmented(sys *System, dt float64) (*System, *mat.Dense, error) {
@@ -1426,17 +1309,11 @@ func matchedGainFallback(num, den Poly, discZeros, discPoles []complex128, dt fl
 //
 // Delay fields are converted back to continuous (τ_c = τ_d · Dt).
 func (sys *System) D2C(method string) (*System, error) {
-	if sys.IsContinuous() {
-		return nil, fmt.Errorf("D2C: system already continuous: %w", ErrWrongDomain)
+	plan, err := newD2CPlan(sys, method)
+	if err != nil {
+		return nil, err
 	}
-	switch method {
-	case "", "zoh":
-		return sys.d2cZOH()
-	case "tustin":
-		return sys.Undiscretize()
-	default:
-		return nil, fmt.Errorf("D2C: unknown method %q (supported: \"tustin\", \"zoh\")", method)
-	}
+	return plan.run()
 }
 
 func (sys *System) d2cZOH() (*System, error) {
@@ -1518,25 +1395,9 @@ func d2cPropagateDelays(out, sys *System, dt float64) {
 }
 
 func (sys *System) D2D(newDt float64, opts C2DOptions) (*System, error) {
-	if sys.IsContinuous() {
-		return nil, fmt.Errorf("D2D: system is continuous: %w", ErrWrongDomain)
-	}
-	if newDt <= 0 {
-		return nil, ErrInvalidSampleTime
-	}
-	if math.Abs(newDt-sys.Dt) < 1e-14*math.Max(newDt, sys.Dt) {
-		return sys.Copy(), nil
-	}
-
-	contSys, err := sys.Undiscretize()
+	plan, err := newD2DPlan(sys, newDt, opts)
 	if err != nil {
-		return nil, fmt.Errorf("D2D: %w", err)
+		return nil, err
 	}
-
-	result, err := contSys.DiscretizeWithOpts(newDt, opts)
-	if err != nil {
-		return nil, fmt.Errorf("D2D: %w", err)
-	}
-	propagateNames(result, sys)
-	return result, nil
+	return plan.run()
 }

--- a/delay.go
+++ b/delay.go
@@ -134,8 +134,7 @@ func validateSliceDelay(delay []float64, expected int, dt float64) error {
 }
 
 func (sys *System) TotalDelay() *mat.Dense {
-	_, m, p := sys.Dims()
-	return effectiveIODelayMatrix(sys, p, m, true)
+	return newDelayTopology(sys).total(true)
 }
 
 func effectiveIODelayMatrix(sys *System, p, m int, includeDelayMatrix bool) *mat.Dense {
@@ -179,27 +178,9 @@ func (sys *System) HasDelay() bool {
 	if sys.HasInternalDelay() {
 		return true
 	}
-	if sys.Delay != nil {
-		raw := sys.Delay.RawMatrix()
-		for i := 0; i < raw.Rows; i++ {
-			for j := 0; j < raw.Cols; j++ {
-				if raw.Data[i*raw.Stride+j] != 0 {
-					return true
-				}
-			}
-		}
-	}
-	for _, v := range sys.InputDelay {
-		if v != 0 {
-			return true
-		}
-	}
-	for _, v := range sys.OutputDelay {
-		if v != 0 {
-			return true
-		}
-	}
-	return false
+	return delayMatrixHasNonzero(sys.Delay) ||
+		delaySliceHasNonzero(sys.InputDelay) ||
+		delaySliceHasNonzero(sys.OutputDelay)
 }
 
 func (sys *System) HasInternalDelay() bool {
@@ -1854,36 +1835,11 @@ func validateDelay(delay *mat.Dense, p, m int, dt float64) error {
 }
 
 func convertDelayToDiscrete(delay *mat.Dense, dt float64) (*mat.Dense, error) {
-	r, c := delay.Dims()
-	out := mat.NewDense(r, c, nil)
-	inRaw := delay.RawMatrix()
-	outRaw := out.RawMatrix()
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
-			tau := inRaw.Data[i*inRaw.Stride+j]
-			samples := tau / dt
-			rounded := math.Round(samples)
-			if math.Abs(samples-rounded) > 1e-9 {
-				return nil, fmt.Errorf("delay[%d][%d]=%g not integer multiple of dt=%g: %w",
-					i, j, tau, dt, ErrFractionalDelay)
-			}
-			outRaw.Data[i*outRaw.Stride+j] = rounded
-		}
-	}
-	return out, nil
+	return newTimeDomain(dt).convertDelayMatrixToDiscrete(delay)
 }
 
 func convertDelayToContinuous(delay *mat.Dense, dt float64) *mat.Dense {
-	r, c := delay.Dims()
-	out := mat.NewDense(r, c, nil)
-	inRaw := delay.RawMatrix()
-	outRaw := out.RawMatrix()
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
-			outRaw.Data[i*outRaw.Stride+j] = inRaw.Data[i*inRaw.Stride+j] * dt
-		}
-	}
-	return out
+	return newTimeDomain(dt).convertDelayMatrixToContinuous(delay)
 }
 
 func denseToSlice2D(m *mat.Dense) [][]float64 {

--- a/delay_topology.go
+++ b/delay_topology.go
@@ -1,0 +1,60 @@
+package controlsys
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+const delayTopologyTol = 1e-12
+
+type delayTopology struct {
+	sys *System
+	p   int
+	m   int
+}
+
+func newDelayTopology(sys *System) delayTopology {
+	_, m, p := sys.Dims()
+	return delayTopology{sys: sys, p: p, m: m}
+}
+
+func (dt delayTopology) total(includeDelayMatrix bool) *mat.Dense {
+	return effectiveIODelayMatrix(dt.sys, dt.p, dt.m, includeDelayMatrix)
+}
+
+func (dt delayTopology) decomposeTotal() (inputDelay, outputDelay []float64, residual *mat.Dense) {
+	total := dt.total(true)
+	if total == nil {
+		return nil, nil, nil
+	}
+	return DecomposeIODelay(total)
+}
+
+func delayMatrixHasNonzero(m *mat.Dense) bool {
+	return delayMatrixHasNonzeroTol(m, 0)
+}
+
+func delayMatrixHasNonzeroTol(m *mat.Dense, tol float64) bool {
+	if m == nil {
+		return false
+	}
+	raw := m.RawMatrix()
+	for i := 0; i < raw.Rows; i++ {
+		for j := 0; j < raw.Cols; j++ {
+			if math.Abs(raw.Data[i*raw.Stride+j]) > tol {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func delaySliceHasNonzero(s []float64) bool {
+	for _, v := range s {
+		if v != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/frequency.go
+++ b/frequency.go
@@ -208,10 +208,7 @@ func (e frequencyEvaluator) eval(s complex128) ([][]complex128, error) {
 }
 
 func (e frequencyEvaluator) sAt(w float64) complex128 {
-	if e.sys.IsContinuous() {
-		return complex(0, w)
-	}
-	return cmplx.Exp(complex(0, w*e.sys.Dt))
+	return newTimeDomain(e.sys.Dt).frequencyVariable(w)
 }
 
 func (e frequencyEvaluator) evalStateSpaceInto(s complex128, dst []complex128) error {
@@ -239,12 +236,7 @@ func autoBodeFreqs(sys *System, nPoints int) ([]float64, error) {
 	var natFreqs []float64
 	for _, p := range poles {
 		var wn float64
-		if sys.IsContinuous() {
-			wn = cmplx.Abs(p)
-		} else {
-			lp := cmplx.Log(p)
-			wn = cmplx.Abs(lp) / sys.Dt
-		}
+		wn = newTimeDomain(sys.Dt).naturalFrequency(p)
 		if wn > 0 {
 			natFreqs = append(natFreqs, wn)
 		}
@@ -310,11 +302,7 @@ func applyIODelayPhase(sys *System, omega []float64, data []complex128, p, m int
 	pm := p * m
 	for k, w := range omega {
 		var s complex128
-		if sys.IsContinuous() {
-			s = complex(0, w)
-		} else {
-			s = cmplx.Exp(complex(0, w*sys.Dt))
-		}
+		s = newTimeDomain(sys.Dt).frequencyVariable(w)
 		applyIODelayMatrixAtS(sys, s, data[k*pm:(k+1)*pm], p, m, delay)
 	}
 }
@@ -406,11 +394,7 @@ func freqResponseLFT(sys *System, omega []float64, p, m int) (*FreqResponseMatri
 
 	for k, w := range omega {
 		var s complex128
-		if sys.IsContinuous() {
-			s = complex(0, w)
-		} else {
-			s = cmplx.Exp(complex(0, w*sys.Dt))
-		}
+		s = newTimeDomain(sys.Dt).frequencyVariable(w)
 		if err := evalFrLFTInto(ws, sys, s, n, N, p, m); err != nil {
 			return nil, err
 		}

--- a/names.go
+++ b/names.go
@@ -77,15 +77,11 @@ func lookupSignalIndices(names []string, targets []string) ([]int, error) {
 }
 
 func propagateNames(result, src *System) {
-	result.InputName = copyStringSlice(src.InputName)
-	result.OutputName = copyStringSlice(src.OutputName)
-	result.StateName = copyStringSlice(src.StateName)
-	result.Notes = src.Notes
+	metadataFromSystem(src).applyAll(result)
 }
 
 func propagateIONames(result, src *System) {
-	result.InputName = copyStringSlice(src.InputName)
-	result.OutputName = copyStringSlice(src.OutputName)
+	metadataFromSystem(src).applyIO(result)
 }
 
 func expandName(name string, count int) []string {
@@ -295,8 +291,7 @@ func (sys *System) SelectByIndex(inputs, outputs []int) (*System, error) {
 		if err != nil {
 			return nil, err
 		}
-		result.InputName = selectStringSlice(sys.InputName, inputs)
-		result.OutputName = selectStringSlice(sys.OutputName, outputs)
+		metadataFromSystem(sys).selectIO(inputs, outputs).applyIOOwned(result)
 		return result, nil
 	}
 
@@ -307,9 +302,7 @@ func (sys *System) SelectByIndex(inputs, outputs []int) (*System, error) {
 	if err != nil {
 		return nil, err
 	}
-	result.InputName = selectStringSlice(sys.InputName, inputs)
-	result.OutputName = selectStringSlice(sys.OutputName, outputs)
-	result.StateName = copyStringSlice(sys.StateName)
+	metadataFromSystem(sys).selectIO(inputs, outputs).applyAllOwned(result)
 
 	if sys.InputDelay != nil {
 		result.InputDelay = make([]float64, mSel)

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -89,40 +89,14 @@ func replaceContinuousDelays(sys *System, padeOrder int) (*System, error) {
 
 	cur := sys.Copy()
 
-	if cur.Delay != nil {
-		inDel, outDel, residual := DecomposeIODelay(cur.Delay)
-		if cur.InputDelay == nil {
-			cur.InputDelay = make([]float64, m)
-		}
-		for j := 0; j < m; j++ {
-			cur.InputDelay[j] += inDel[j]
-		}
-		if cur.OutputDelay == nil {
-			cur.OutputDelay = make([]float64, p)
-		}
-		for i := 0; i < p; i++ {
-			cur.OutputDelay[i] += outDel[i]
-		}
-
-		hasResidual := false
-		if residual != nil {
-			raw := residual.RawMatrix()
-			for i := 0; i < raw.Rows; i++ {
-				for j := 0; j < raw.Cols; j++ {
-					if raw.Data[i*raw.Stride+j] != 0 {
-						hasResidual = true
-						break
-					}
-				}
-				if hasResidual {
-					break
-				}
-			}
-		}
-		if hasResidual {
+	if cur.Delay != nil || cur.InputDelay != nil || cur.OutputDelay != nil {
+		inDel, outDel, residual := newDelayTopology(cur).decomposeTotal()
+		if delayMatrixHasNonzeroTol(residual, delayTopologyTol) {
 			return nil, fmt.Errorf("SafeFeedback: non-decomposable IODelay residual: %w", ErrFeedbackDelay)
 		}
 		cur.Delay = nil
+		cur.InputDelay = inDel
+		cur.OutputDelay = outDel
 	}
 
 	result := &System{A: cur.A, B: cur.B, C: cur.C, D: cur.D, Dt: cur.Dt}

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -89,14 +89,14 @@ func replaceContinuousDelays(sys *System, padeOrder int) (*System, error) {
 
 	cur := sys.Copy()
 
-	if cur.Delay != nil || cur.InputDelay != nil || cur.OutputDelay != nil {
-		inDel, outDel, residual := newDelayTopology(cur).decomposeTotal()
+	if cur.Delay != nil {
+		inDel, outDel, residual := DecomposeIODelay(cur.Delay)
 		if delayMatrixHasNonzeroTol(residual, delayTopologyTol) {
 			return nil, fmt.Errorf("SafeFeedback: non-decomposable IODelay residual: %w", ErrFeedbackDelay)
 		}
 		cur.Delay = nil
-		cur.InputDelay = inDel
-		cur.OutputDelay = outDel
+		cur.InputDelay = mergeDelays(cur.InputDelay, inDel)
+		cur.OutputDelay = mergeDelays(cur.OutputDelay, outDel)
 	}
 
 	result := &System{A: cur.A, B: cur.B, C: cur.C, D: cur.D, Dt: cur.Dt}

--- a/signal_metadata.go
+++ b/signal_metadata.go
@@ -1,0 +1,81 @@
+package controlsys
+
+type signalMetadata struct {
+	input  []string
+	output []string
+	state  []string
+	notes  string
+}
+
+func metadataFromSystem(sys *System) signalMetadata {
+	return signalMetadata{
+		input:  sys.InputName,
+		output: sys.OutputName,
+		state:  sys.StateName,
+		notes:  sys.Notes,
+	}
+}
+
+func (md signalMetadata) applyAll(sys *System) {
+	sys.InputName = copyStringSlice(md.input)
+	sys.OutputName = copyStringSlice(md.output)
+	sys.StateName = copyStringSlice(md.state)
+	sys.Notes = md.notes
+}
+
+func (md signalMetadata) applyIO(sys *System) {
+	sys.InputName = copyStringSlice(md.input)
+	sys.OutputName = copyStringSlice(md.output)
+}
+
+func (md signalMetadata) applyAllOwned(sys *System) {
+	sys.InputName = md.input
+	sys.OutputName = md.output
+	sys.StateName = md.state
+	sys.Notes = md.notes
+}
+
+func (md signalMetadata) applyIOOwned(sys *System) {
+	sys.InputName = md.input
+	sys.OutputName = md.output
+}
+
+func (md signalMetadata) selectIO(inputs, outputs []int) signalMetadata {
+	return signalMetadata{
+		input:  selectStringSlice(md.input, inputs),
+		output: selectStringSlice(md.output, outputs),
+		state:  copyStringSlice(md.state),
+		notes:  md.notes,
+	}
+}
+
+func seriesMetadata(left, right *System, n1, n2 int) signalMetadata {
+	return signalMetadata{
+		input:  copyStringSlice(left.InputName),
+		output: copyStringSlice(right.OutputName),
+		state:  concatStringSlices([][]string{left.StateName, right.StateName}, []int{n1, n2}),
+	}
+}
+
+func controllerMetadata(measurementNames, controlNames []string) signalMetadata {
+	return signalMetadata{
+		input:  measurementNames,
+		output: controlNames,
+	}
+}
+
+func fohStateMetadata(src *System, n, m int) []string {
+	if src.StateName == nil && src.InputName == nil {
+		return nil
+	}
+	names := make([]string, n+m)
+	if src.StateName != nil {
+		copy(names, src.StateName)
+	}
+	for j := 0; j < m; j++ {
+		if src.InputName != nil && j < len(src.InputName) {
+			names[n+j] = src.InputName[j] + "_prev"
+		}
+	}
+	return names
+}

--- a/ss.go
+++ b/ss.go
@@ -62,8 +62,8 @@ func (sys *System) Dims() (n, m, p int) {
 	return
 }
 
-func (sys *System) IsContinuous() bool { return sys.Dt == 0 }
-func (sys *System) IsDiscrete() bool   { return sys.Dt > 0 }
+func (sys *System) IsContinuous() bool { return newTimeDomain(sys.Dt).isContinuous() }
+func (sys *System) IsDiscrete() bool   { return newTimeDomain(sys.Dt).isDiscrete() }
 
 func (sys *System) Validate() error {
 	if sys == nil {
@@ -147,8 +147,8 @@ func (sys *System) IsStable() (bool, error) {
 }
 
 func validateDims(A, B, C, D *mat.Dense, dt float64) (n, m, p int, err error) {
-	if dt < 0 {
-		return 0, 0, 0, ErrInvalidSampleTime
+	if err := newTimeDomain(dt).validateSampleTime(); err != nil {
+		return 0, 0, 0, err
 	}
 	if A != nil {
 		r, c := A.Dims()

--- a/synthesis_partition.go
+++ b/synthesis_partition.go
@@ -58,8 +58,7 @@ func partitionGeneralizedPlant(P *System, nmeas, ncont int) (*generalizedPlantPa
 }
 
 func (gp *generalizedPlantPartition) applyControllerNames(K *System) {
-	K.InputName = copyStringSlice(gp.measurementNames)
-	K.OutputName = copyStringSlice(gp.controlNames)
+	controllerMetadata(gp.measurementNames, gp.controlNames).applyIO(K)
 }
 
 func (gp *generalizedPlantPartition) validateControllerChannels() error {

--- a/time_domain.go
+++ b/time_domain.go
@@ -1,0 +1,98 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+	"math/cmplx"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type timeDomain struct {
+	dt float64
+}
+
+func newTimeDomain(dt float64) timeDomain {
+	return timeDomain{dt: dt}
+}
+
+func (td timeDomain) isContinuous() bool {
+	return td.dt == 0
+}
+
+func (td timeDomain) isDiscrete() bool {
+	return td.dt > 0
+}
+
+func (td timeDomain) validateSampleTime() error {
+	if td.dt < 0 {
+		return ErrInvalidSampleTime
+	}
+	return nil
+}
+
+func (td timeDomain) ensureCompatible(other timeDomain) error {
+	if td.dt != other.dt {
+		return ErrDomainMismatch
+	}
+	return nil
+}
+
+func (td timeDomain) frequencyVariable(w float64) complex128 {
+	if td.isContinuous() {
+		return complex(0, w)
+	}
+	return cmplx.Exp(complex(0, w*td.dt))
+}
+
+func (td timeDomain) naturalFrequency(p complex128) float64 {
+	if td.isContinuous() {
+		return cmplx.Abs(p)
+	}
+	return cmplx.Abs(cmplx.Log(p)) / td.dt
+}
+
+func (td timeDomain) continuousDelay(samples float64) float64 {
+	return samples * td.dt
+}
+
+func (td timeDomain) discreteDelaySamples(tau float64) (float64, error) {
+	samples := tau / td.dt
+	rounded := math.Round(samples)
+	if math.Abs(samples-rounded) > 1e-9 {
+		return 0, fmt.Errorf("delay=%g not integer multiple of dt=%g: %w", tau, td.dt, ErrFractionalDelay)
+	}
+	return rounded, nil
+}
+
+func (td timeDomain) convertDelayMatrixToDiscrete(delay *mat.Dense) (*mat.Dense, error) {
+	r, c := delay.Dims()
+	out := mat.NewDense(r, c, nil)
+	inRaw := delay.RawMatrix()
+	outRaw := out.RawMatrix()
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			tau := inRaw.Data[i*inRaw.Stride+j]
+			samples, err := td.discreteDelaySamples(tau)
+			if err != nil {
+				return nil, fmt.Errorf("delay[%d][%d]=%g not integer multiple of dt=%g: %w",
+					i, j, tau, td.dt, ErrFractionalDelay)
+			}
+			outRaw.Data[i*outRaw.Stride+j] = samples
+		}
+	}
+	return out, nil
+}
+
+func (td timeDomain) convertDelayMatrixToContinuous(delay *mat.Dense) *mat.Dense {
+	r, c := delay.Dims()
+	out := mat.NewDense(r, c, nil)
+	inRaw := delay.RawMatrix()
+	outRaw := out.RawMatrix()
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			outRaw.Data[i*outRaw.Stride+j] = td.continuousDelay(inRaw.Data[i*inRaw.Stride+j])
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add public regression coverage for the remaining architecture slices
- extract delay topology, conversion planning, time-domain policy, and signal metadata helpers
- route existing public APIs through those helpers while preserving behavior

## Verification
- go test -v -count=1
- go test -run '^$' -bench 'Benchmark(SystemFRD_MIMO_200|FreqResponse|D2C|Discretize|Lsim|Simulate|Series|Feedback)' -benchmem -count=5 before/after + benchstat
- benchstat final: geomean sec/op -0.53%, B/op +0.00%, allocs/op +0.04%; no meaningful performance regression
- Closes #60 
- Closes #61 
- Closes #62 
- Closes #63 
- Closes #64