### PR TITLE
Deepen architecture policy modules

### DIFF
--- a/architecture_runtime_test.go
+++ b/architecture_runtime_test.go
@@ -1,0 +1,210 @@
+package controlsys
+
+import (
+	"errors"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func runtimeArchitectureMIMO(t *testing.T) *System {
+	t.Helper()
+	sys, err := NewFromSlices(2, 2, 2,
+		[]float64{0, 1, -2, -3},
+		[]float64{1, 0, 0, 1},
+		[]float64{1, 0, 0, 1},
+		[]float64{0, 0, 0, 0},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sys
+}
+
+func TestRuntimeArchitectureSISOLoopAnalysisRejectsMIMOConsistently(t *testing.T) {
+	sys := runtimeArchitectureMIMO(t)
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "Margin", run: func() error {
+			_, err := Margin(sys)
+			return err
+		}},
+		{name: "AllMargin", run: func() error {
+			_, err := AllMargin(sys)
+			return err
+		}},
+		{name: "DiskMargin", run: func() error {
+			_, err := DiskMargin(sys)
+			return err
+		}},
+		{name: "Nyquist", run: func() error {
+			_, err := sys.Nyquist(nil, 0)
+			return err
+		}},
+		{name: "RootLocus", run: func() error {
+			_, err := RootLocus(sys, nil)
+			return err
+		}},
+		{name: "Pidtune", run: func() error {
+			_, err := Pidtune(sys, "PI")
+			return err
+		}},
+	}
+	for _, tc := range checks {
+		if err := tc.run(); !errors.Is(err, ErrNotSISO) {
+			t.Fatalf("%s error = %v, want ErrNotSISO", tc.name, err)
+		}
+	}
+}
+
+func TestRuntimeArchitectureSISOLoopAnalysisKeepsGainWorkflow(t *testing.T) {
+	sys, err := NewGain(mat.NewDense(1, 1, []float64{2}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mr, err := Margin(sys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mr.WgFreq == mr.WgFreq {
+		t.Fatalf("WgFreq = %v, want NaN for static gain without gain crossover", mr.WgFreq)
+	}
+}
+
+func TestRuntimeArchitectureCovarianceRejectsDescriptorWorkflows(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{-1, 2, 0, -3}),
+		mat.NewDense(2, 1, []float64{1, 0}),
+		mat.NewDense(1, 2, []float64{1, 0}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.E = mat.NewDense(2, 2, []float64{2, 0, 0, 1})
+
+	Qn := mat.NewDense(1, 1, []float64{1})
+	Rn := mat.NewDense(1, 1, []float64{1})
+	checks := []struct {
+		name string
+		want error
+		run  func() error
+	}{
+		{name: "Covar", want: ErrDescriptorUnsupported, run: func() error {
+			_, err := Covar(sys, Qn)
+			return err
+		}},
+		{name: "Kalmd", want: ErrDescriptorRiccati, run: func() error {
+			_, err := Kalmd(sys, Qn, Rn, 0.1, nil)
+			return err
+		}},
+	}
+	for _, tc := range checks {
+		if err := tc.run(); !errors.Is(err, tc.want) {
+			t.Fatalf("%s error = %v, want %v", tc.name, err, tc.want)
+		}
+	}
+}
+
+func TestRuntimeArchitectureTransformationsRejectDescriptorWorkflows(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{-1, 2, 0, -3}),
+		mat.NewDense(2, 1, []float64{1, 0}),
+		mat.NewDense(1, 2, []float64{1, 0}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.E = mat.NewDense(2, 2, []float64{2, 0, 0, 1})
+	T := mat.NewDiagDense(2, []float64{1, 2})
+
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "SS2SS", run: func() error {
+			_, err := SS2SS(sys, mat.DenseCopyOf(T))
+			return err
+		}},
+		{name: "Xperm", run: func() error {
+			_, err := Xperm(sys, []int{1, 0})
+			return err
+		}},
+		{name: "Reduce", run: func() error {
+			_, err := sys.Reduce(nil)
+			return err
+		}},
+		{name: "Sminreal", run: func() error {
+			_, err := Sminreal(sys)
+			return err
+		}},
+		{name: "Balreal", run: func() error {
+			_, err := Balreal(sys)
+			return err
+		}},
+		{name: "Ssbal", run: func() error {
+			_, err := Ssbal(sys)
+			return err
+		}},
+		{name: "Prescale", run: func() error {
+			_, err := Prescale(sys)
+			return err
+		}},
+		{name: "Canon", run: func() error {
+			_, err := Canon(sys, CanonModal)
+			return err
+		}},
+	}
+	for _, tc := range checks {
+		if err := tc.run(); !errors.Is(err, ErrDescriptorUnsupported) {
+			t.Fatalf("%s error = %v, want ErrDescriptorUnsupported", tc.name, err)
+		}
+	}
+}
+
+func TestRuntimeArchitectureEnergyAnalysisRejectsDescriptorWorkflows(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{-1, 2, 0, -3}),
+		mat.NewDense(2, 1, []float64{1, 0}),
+		mat.NewDense(1, 2, []float64{1, 0}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.E = mat.NewDense(2, 2, []float64{2, 0, 0, 1})
+
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "Gram", run: func() error {
+			_, err := Gram(sys, GramControllability)
+			return err
+		}},
+		{name: "H2Norm", run: func() error {
+			_, err := H2Norm(sys)
+			return err
+		}},
+		{name: "HSV", run: func() error {
+			_, err := HSV(sys)
+			return err
+		}},
+		{name: "HinfNorm", run: func() error {
+			_, _, err := HinfNorm(sys)
+			return err
+		}},
+	}
+	for _, tc := range checks {
+		if err := tc.run(); !errors.Is(err, ErrDescriptorUnsupported) {
+			t.Fatalf("%s error = %v, want ErrDescriptorUnsupported", tc.name, err)
+		}
+	}
+}

--- a/balance.go
+++ b/balance.go
@@ -12,7 +12,7 @@ import (
 type BalredMethod int
 
 const (
-	Truncate             BalredMethod = iota
+	Truncate BalredMethod = iota
 	SingularPerturbation
 )
 
@@ -28,10 +28,16 @@ type BalrealResult struct {
 // The returned system has equal controllability and observability gramians,
 // both equal to diag(σ₁, σ₂, …, σₙ) where σᵢ are the Hankel singular values.
 func Balreal(sys *System) (*BalrealResult, error) {
-	n, m, p := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Balreal"); err != nil {
+		return nil, err
+	}
+	if err := policy.requireDelayFree("Balreal"); err != nil {
+		return nil, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 	if n == 0 {
-		cp := sys.Copy()
-		return &BalrealResult{Sys: cp}, nil
+		return &BalrealResult{Sys: policy.zeroOrderCopy()}, nil
 	}
 
 	stable, err := sys.IsStable()
@@ -204,8 +210,7 @@ func Balreal(sys *System) (*BalrealResult, error) {
 	Cb := mat.NewDense(p, n, cbData)
 	Db := denseCopy(sys.D)
 
-	balSys, _ := newNoCopy(Ab, Bb, Cb, Db, sys.Dt)
-	propagateIONames(balSys, sys)
+	balSys, _ := policy.result(Ab, Bb, Cb, Db)
 
 	return &BalrealResult{
 		Sys:  balSys,
@@ -269,9 +274,16 @@ func Balred(sys *System, order int, method BalredMethod) (*System, []float64, er
 // elim contains 0-based indices of states to remove.
 // method selects Truncate or SingularPerturbation (DC-gain matching).
 func Modred(sys *System, elim []int, method BalredMethod) (*System, error) {
-	n, m, p := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Modred"); err != nil {
+		return nil, err
+	}
+	if err := policy.requireDelayFree("Modred"); err != nil {
+		return nil, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 	if n == 0 || len(elim) == 0 {
-		return sys.Copy(), nil
+		return policy.zeroOrderCopy(), nil
 	}
 
 	elimSet := make(map[int]bool, len(elim))
@@ -350,11 +362,10 @@ func Modred(sys *System, elim []int, method BalredMethod) (*System, error) {
 	C1 := extractSubmatrix(Cp, 0, p, 0, r)
 
 	if method == Truncate {
-		red, err := newNoCopy(A11, B1, C1, denseCopy(sys.D), sys.Dt)
+		red, err := policy.result(A11, B1, C1, denseCopy(sys.D))
 		if err != nil {
 			return nil, err
 		}
-		propagateIONames(red, sys)
 		return red, nil
 	}
 

--- a/canon.go
+++ b/canon.go
@@ -25,8 +25,12 @@ type CanonResult struct {
 }
 
 func Canon(sys *System, form CanonForm) (*CanonResult, error) {
-	if sys.HasDelay() {
-		return nil, fmt.Errorf("controlsys: Canon does not support delayed systems; use Pade/AbsorbDelay first")
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Canon"); err != nil {
+		return nil, err
+	}
+	if err := policy.requireDelayFree("Canon"); err != nil {
+		return nil, err
 	}
 	switch form {
 	case CanonModal:
@@ -46,10 +50,10 @@ type eigBlock struct {
 }
 
 func canonModal(sys *System) (*CanonResult, error) {
-	n, m, p := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	n, m, p := policy.n, policy.m, policy.p
 	if n == 0 {
-		cp := sys.Copy()
-		return &CanonResult{Sys: cp, T: &mat.Dense{}}, nil
+		return &CanonResult{Sys: policy.zeroOrderCopy(), T: &mat.Dense{}}, nil
 	}
 
 	res, err := canonModalEig(sys, n, m, p)
@@ -273,10 +277,10 @@ func schurSortByMagnitude(t, z []float64, n int) {
 }
 
 func canonCompanion(sys *System) (*CanonResult, error) {
-	n, m, p := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	n, m, p := policy.n, policy.m, policy.p
 	if n == 0 {
-		cp := sys.Copy()
-		return &CanonResult{Sys: cp, T: &mat.Dense{}}, nil
+		return &CanonResult{Sys: policy.zeroOrderCopy(), T: &mat.Dense{}}, nil
 	}
 	if m != 1 || p != 1 {
 		return nil, fmt.Errorf("controlsys: companion form requires SISO system: %w", ErrNotSISO)

--- a/covar.go
+++ b/covar.go
@@ -1,17 +1,15 @@
 package controlsys
 
-import (
-	"fmt"
-
-	"gonum.org/v1/gonum/mat"
-)
+import "gonum.org/v1/gonum/mat"
 
 func Covar(sys *System, W *mat.Dense) (*mat.Dense, error) {
 	n, m, p := sys.Dims()
 
-	wr, wc := W.Dims()
-	if wr != m || wc != m {
-		return nil, fmt.Errorf("W must be %d×%d, got %d×%d: %w", m, m, wr, wc, ErrDimensionMismatch)
+	if err := requireStandardCovarianceSystem(sys, "Covar"); err != nil {
+		return nil, err
+	}
+	if err := validateCovarianceRole("Covar", covarianceInputNoise, W, m); err != nil {
+		return nil, err
 	}
 
 	stable, err := sys.IsStable()
@@ -22,11 +20,7 @@ func Covar(sys *System, W *mat.Dense) (*mat.Dense, error) {
 		return nil, ErrUnstable
 	}
 
-	// Q = B*W*B'
-	var BW mat.Dense
-	BW.Mul(sys.B, W)
-	Q := mat.NewDense(n, n, nil)
-	Q.Mul(&BW, sys.B.T())
+	Q := inputNoiseIntensity(sys.B, W, n, m)
 
 	// symmetrize Q for Lyapunov solver
 	qRaw := Q.RawMatrix()

--- a/covariance_policy.go
+++ b/covariance_policy.go
@@ -1,0 +1,56 @@
+package controlsys
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/mat"
+)
+
+type covarianceRole string
+
+const (
+	covarianceInputNoise       covarianceRole = "input noise covariance"
+	covarianceProcessNoise     covarianceRole = "process noise covariance"
+	covarianceMeasurementNoise covarianceRole = "measurement noise covariance"
+	covarianceStateEstimate    covarianceRole = "state estimate covariance"
+)
+
+func validateCovarianceRole(context string, role covarianceRole, cov *mat.Dense, dim int) error {
+	if cov == nil {
+		return fmt.Errorf("%s: nil %s: %w", context, role, ErrDimensionMismatch)
+	}
+	r, c := cov.Dims()
+	if r != dim || c != dim {
+		return fmt.Errorf("%s: %s is %dx%d, want %dx%d: %w", context, role, r, c, dim, dim, ErrDimensionMismatch)
+	}
+	return nil
+}
+
+func requireStandardCovarianceSystem(sys *System, context string) error {
+	return newDescriptorPolicy(sys).requireStandard(context)
+}
+
+func requireStandardEstimatorSystem(sys *System, context string) error {
+	return newDescriptorPolicy(sys).requireRiccatiStandard(context)
+}
+
+func inputNoiseIntensity(B, W *mat.Dense, n, m int) *mat.Dense {
+	bRaw := B.RawMatrix()
+	wRaw := W.RawMatrix()
+
+	bwData := make([]float64, n*m)
+	blas64.Gemm(blas.NoTrans, blas.NoTrans,
+		1, blas64.General{Rows: n, Cols: m, Data: bRaw.Data, Stride: bRaw.Stride},
+		blas64.General{Rows: m, Cols: m, Data: wRaw.Data, Stride: wRaw.Stride},
+		0, blas64.General{Rows: n, Cols: m, Data: bwData, Stride: m})
+
+	qData := make([]float64, n*n)
+	blas64.Gemm(blas.NoTrans, blas.Trans,
+		1, blas64.General{Rows: n, Cols: m, Data: bwData, Stride: m},
+		blas64.General{Rows: n, Cols: m, Data: bRaw.Data, Stride: bRaw.Stride},
+		0, blas64.General{Rows: n, Cols: n, Data: qData, Stride: n})
+
+	return mat.NewDense(n, n, qData)
+}

--- a/ekf.go
+++ b/ekf.go
@@ -49,13 +49,11 @@ func NewEKF(model *EKFModel, x0 *mat.VecDense, P0 *mat.Dense) (*EKF, error) {
 		return nil, fmt.Errorf("NewEKF: zero-length state: %w", ErrDimensionMismatch)
 	}
 
-	pr, pc := P0.Dims()
-	if pr != n || pc != n {
-		return nil, fmt.Errorf("NewEKF: P0 is %dx%d, want %dx%d: %w", pr, pc, n, n, ErrDimensionMismatch)
+	if err := validateCovarianceRole("NewEKF", covarianceStateEstimate, P0, n); err != nil {
+		return nil, err
 	}
-	qr, qc := model.Q.Dims()
-	if qr != n || qc != n {
-		return nil, fmt.Errorf("NewEKF: Q is %dx%d, want %dx%d: %w", qr, qc, n, n, ErrDimensionMismatch)
+	if err := validateCovarianceRole("NewEKF", covarianceProcessNoise, model.Q, n); err != nil {
+		return nil, err
 	}
 	rr, rc := model.R.Dims()
 	if rr != rc {

--- a/energy_policy.go
+++ b/energy_policy.go
@@ -1,0 +1,86 @@
+package controlsys
+
+import (
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/blas/blas64"
+	"gonum.org/v1/gonum/mat"
+)
+
+type energyAnalysisPolicy struct {
+	sys     *System
+	n, m, p int
+}
+
+func newEnergyAnalysisPolicy(sys *System) energyAnalysisPolicy {
+	n, m, p := sys.Dims()
+	return energyAnalysisPolicy{sys: sys, n: n, m: m, p: p}
+}
+
+func (p energyAnalysisPolicy) requireStandard(context string) error {
+	return newDescriptorPolicy(p.sys).requireStandard(context)
+}
+
+func (p energyAnalysisPolicy) requireStable(errUnstable error) error {
+	stable, err := p.sys.IsStable()
+	if err != nil {
+		return err
+	}
+	if !stable {
+		return errUnstable
+	}
+	return nil
+}
+
+func (p energyAnalysisPolicy) gramianInputs(typ GramType) (Aarg, Q *mat.Dense, err error) {
+	aRaw := p.sys.A.RawMatrix()
+	aData := make([]float64, p.n*p.n)
+	copyStrided(aData, p.n, aRaw.Data, aRaw.Stride, p.n, p.n)
+
+	switch typ {
+	case GramControllability:
+		return mat.NewDense(p.n, p.n, aData), p.controllabilityEnergy(), nil
+	case GramObservability:
+		return mat.NewDense(p.n, p.n, transposeSquareData(aRaw.Data, aRaw.Stride, p.n)), p.observabilityEnergy(), nil
+	default:
+		return nil, nil, ErrDimensionMismatch
+	}
+}
+
+func (p energyAnalysisPolicy) controllabilityEnergy() *mat.Dense {
+	bRaw := p.sys.B.RawMatrix()
+	q := make([]float64, p.n*p.n)
+	blas64.Gemm(blas.NoTrans, blas.Trans, 1,
+		blas64.General{Rows: p.n, Cols: p.m, Stride: bRaw.Stride, Data: bRaw.Data},
+		blas64.General{Rows: p.n, Cols: p.m, Stride: bRaw.Stride, Data: bRaw.Data},
+		0, blas64.General{Rows: p.n, Cols: p.n, Stride: p.n, Data: q})
+	symmetrize(q, p.n, p.n)
+	return mat.NewDense(p.n, p.n, q)
+}
+
+func (p energyAnalysisPolicy) observabilityEnergy() *mat.Dense {
+	cRaw := p.sys.C.RawMatrix()
+	q := make([]float64, p.n*p.n)
+	blas64.Gemm(blas.Trans, blas.NoTrans, 1,
+		blas64.General{Rows: p.p, Cols: p.n, Stride: cRaw.Stride, Data: cRaw.Data},
+		blas64.General{Rows: p.p, Cols: p.n, Stride: cRaw.Stride, Data: cRaw.Data},
+		0, blas64.General{Rows: p.n, Cols: p.n, Stride: p.n, Data: q})
+	symmetrize(q, p.n, p.n)
+	return mat.NewDense(p.n, p.n, q)
+}
+
+func (p energyAnalysisPolicy) solveLyapunov(A, Q *mat.Dense) (*mat.Dense, error) {
+	if p.sys.IsContinuous() {
+		return Lyap(A, Q, nil)
+	}
+	return DLyap(A, Q, nil)
+}
+
+func transposeSquareData(data []float64, stride, n int) []float64 {
+	out := make([]float64, n*n)
+	for i := range n {
+		for j := range n {
+			out[i*n+j] = data[j*stride+i]
+		}
+	}
+	return out
+}

--- a/gramian.go
+++ b/gramian.go
@@ -2,7 +2,6 @@ package controlsys
 
 import (
 	"gonum.org/v1/gonum/blas"
-	"gonum.org/v1/gonum/blas/blas64"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -30,63 +29,23 @@ type GramResult struct {
 //	Continuous: A'·Wo + Wo·A + C'·C = 0
 //	Discrete:   A'·Wo·A - Wo + C'·C = 0
 func Gram(sys *System, typ GramType) (*GramResult, error) {
-	n, m, p := sys.Dims()
+	policy := newEnergyAnalysisPolicy(sys)
+	if err := policy.requireStandard("Gram"); err != nil {
+		return nil, err
+	}
+	n := policy.n
 	if n == 0 {
 		return &GramResult{X: &mat.Dense{}}, nil
 	}
 
-	stable, err := sys.IsStable()
+	if err := policy.requireStable(ErrUnstableGramian); err != nil {
+		return nil, err
+	}
+	Aarg, Q, err := policy.gramianInputs(typ)
 	if err != nil {
 		return nil, err
 	}
-	if !stable {
-		return nil, ErrUnstableGramian
-	}
-
-	aRaw := sys.A.RawMatrix()
-	aData := make([]float64, n*n)
-	copyStrided(aData, n, aRaw.Data, aRaw.Stride, n, n)
-
-	var q []float64
-	var solveA []float64
-
-	switch typ {
-	case GramControllability:
-		q = make([]float64, n*n)
-		bRaw := sys.B.RawMatrix()
-		bGen := blas64.General{Rows: n, Cols: m, Stride: bRaw.Stride, Data: bRaw.Data}
-		qGen := blas64.General{Rows: n, Cols: n, Stride: n, Data: q}
-		blas64.Gemm(blas.NoTrans, blas.Trans, 1, bGen, bGen, 0, qGen)
-		symmetrize(q, n, n)
-		solveA = aData
-
-	case GramObservability:
-		q = make([]float64, n*n)
-		cRaw := sys.C.RawMatrix()
-		cGen := blas64.General{Rows: p, Cols: n, Stride: cRaw.Stride, Data: cRaw.Data}
-		qGen := blas64.General{Rows: n, Cols: n, Stride: n, Data: q}
-		blas64.Gemm(blas.Trans, blas.NoTrans, 1, cGen, cGen, 0, qGen)
-		symmetrize(q, n, n)
-		solveA = make([]float64, n*n)
-		for i := range n {
-			for j := range n {
-				solveA[i*n+j] = aData[j*n+i]
-			}
-		}
-
-	default:
-		return nil, ErrDimensionMismatch
-	}
-
-	Q := mat.NewDense(n, n, q)
-	Aarg := mat.NewDense(n, n, solveA)
-
-	var X *mat.Dense
-	if sys.IsContinuous() {
-		X, err = Lyap(Aarg, Q, nil)
-	} else {
-		X, err = DLyap(Aarg, Q, nil)
-	}
+	X, err := policy.solveLyapunov(Aarg, Q)
 	if err != nil {
 		return nil, err
 	}

--- a/loop_analysis.go
+++ b/loop_analysis.go
@@ -1,0 +1,15 @@
+package controlsys
+
+import "fmt"
+
+type sisoLoopModel struct {
+	sys *System
+}
+
+func newSISOLoopModel(sys *System, context string) (*sisoLoopModel, error) {
+	_, m, p := sys.Dims()
+	if p != 1 || m != 1 {
+		return nil, fmt.Errorf("%s: SISO model required: %w", context, ErrNotSISO)
+	}
+	return &sisoLoopModel{sys: sys}, nil
+}

--- a/lqg.go
+++ b/lqg.go
@@ -22,7 +22,7 @@ func Lqg(sys *System, Q, R, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*LqgResult, e
 	if n == 0 {
 		return nil, fmt.Errorf("Lqg: system has no states: %w", ErrDimensionMismatch)
 	}
-	if err := newDescriptorPolicy(sys).requireRiccatiStandard("Lqg"); err != nil {
+	if err := requireStandardEstimatorSystem(sys, "Lqg"); err != nil {
 		return nil, err
 	}
 

--- a/margin.go
+++ b/margin.go
@@ -190,9 +190,8 @@ func evalSISOFreqResponse(sys *System, w float64) (complex128, error) {
 }
 
 func AllMargin(sys *System) (*AllMarginResult, error) {
-	_, m, p := sys.Dims()
-	if p != 1 || m != 1 {
-		return nil, fmt.Errorf("controlsys: AllMargin supports SISO only: %w", ErrDimensionMismatch)
+	if _, err := newSISOLoopModel(sys, "AllMargin"); err != nil {
+		return nil, err
 	}
 
 	omega, err := marginFreqs(sys, 1000)
@@ -402,9 +401,8 @@ func Bandwidth(sys *System, dbDrop float64) (float64, error) {
 }
 
 func DiskMargin(sys *System) (*DiskMarginResult, error) {
-	_, m, p := sys.Dims()
-	if p != 1 || m != 1 {
-		return nil, fmt.Errorf("controlsys: DiskMargin supports SISO only: %w", ErrDimensionMismatch)
+	if _, err := newSISOLoopModel(sys, "DiskMargin"); err != nil {
+		return nil, err
 	}
 
 	eye, err := NewGain(mat.NewDense(1, 1, []float64{1}), sys.Dt)

--- a/minimal.go
+++ b/minimal.go
@@ -9,7 +9,7 @@ import (
 type ReduceMode int
 
 const (
-	ReduceAll            ReduceMode = iota
+	ReduceAll ReduceMode = iota
 	ReduceUncontrollable
 	ReduceUnobservable
 )
@@ -31,10 +31,14 @@ func (sys *System) Reduce(opts *ReduceOpts) (*ReduceResult, error) {
 		opts = &ReduceOpts{}
 	}
 
-	n, m, p := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Reduce"); err != nil {
+		return nil, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 
 	if n == 0 {
-		return &ReduceResult{Sys: copySys(sys, n, m, p), Order: 0}, nil
+		return &ReduceResult{Sys: policy.zeroOrderCopy(), Order: 0}, nil
 	}
 
 	if m == 0 && (opts.Mode == ReduceAll || opts.Mode == ReduceUncontrollable) {
@@ -142,7 +146,6 @@ func copySys(sys *System, n, m, p int) *System {
 	propagateIONames(cp, sys)
 	return cp
 }
-
 
 func zeroOrderResult(sys *System, m, p int) *ReduceResult {
 	s := &System{

--- a/norms.go
+++ b/norms.go
@@ -29,7 +29,11 @@ func Norm(sys *System, normType float64) (float64, error) {
 //
 // For continuous systems with D ≠ 0, the H2 norm is infinite.
 func H2Norm(sys *System) (float64, error) {
-	n, m, p := sys.Dims()
+	policy := newEnergyAnalysisPolicy(sys)
+	if err := policy.requireStandard("H2Norm"); err != nil {
+		return 0, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 
 	if n == 0 {
 		if sys.IsContinuous() {
@@ -38,42 +42,19 @@ func H2Norm(sys *System) (float64, error) {
 		return frobNormD(sys.D, p, m), nil
 	}
 
-	stable, err := sys.IsStable()
-	if err != nil {
+	if err := policy.requireStable(ErrUnstable); err != nil {
 		return 0, err
-	}
-	if !stable {
-		return 0, ErrUnstable
 	}
 
 	if sys.IsContinuous() && !allZeroDense(sys.D) {
 		return math.Inf(1), nil
 	}
 
-	ctc := make([]float64, n*n)
-	cRaw := sys.C.RawMatrix()
-	blas64.Gemm(blas.Trans, blas.NoTrans, 1,
-		blas64.General{Rows: p, Cols: n, Stride: cRaw.Stride, Data: cRaw.Data},
-		blas64.General{Rows: p, Cols: n, Stride: cRaw.Stride, Data: cRaw.Data},
-		0, blas64.General{Rows: n, Cols: n, Stride: n, Data: ctc})
-	symmetrize(ctc, n, n)
-
-	aRaw := sys.A.RawMatrix()
-	at := make([]float64, n*n)
-	for i := range n {
-		for j := range n {
-			at[i*n+j] = aRaw.Data[j*aRaw.Stride+i]
-		}
+	At, Q, err := policy.gramianInputs(GramObservability)
+	if err != nil {
+		return 0, err
 	}
-	At := mat.NewDense(n, n, at)
-	Q := mat.NewDense(n, n, ctc)
-
-	var X *mat.Dense
-	if sys.IsContinuous() {
-		X, err = Lyap(At, Q, nil)
-	} else {
-		X, err = DLyap(At, Q, nil)
-	}
+	X, err := policy.solveLyapunov(At, Q)
 	if err != nil {
 		return 0, err
 	}
@@ -111,64 +92,32 @@ func H2Norm(sys *System) (float64, error) {
 
 // HSV computes the Hankel singular values of a stable LTI system in descending order.
 func HSV(sys *System) ([]float64, error) {
-	n, m, p := sys.Dims()
+	policy := newEnergyAnalysisPolicy(sys)
+	if err := policy.requireStandard("HSV"); err != nil {
+		return nil, err
+	}
+	n := policy.n
 	if n == 0 {
 		return nil, nil
 	}
 
-	stable, err := sys.IsStable()
+	if err := policy.requireStable(ErrUnstable); err != nil {
+		return nil, err
+	}
+
+	A, Qc, err := policy.gramianInputs(GramControllability)
 	if err != nil {
 		return nil, err
 	}
-	if !stable {
-		return nil, ErrUnstable
+	Wc, err := policy.solveLyapunov(A, Qc)
+	if err != nil {
+		return nil, err
 	}
-
-	aRaw := sys.A.RawMatrix()
-	bRaw := sys.B.RawMatrix()
-	cRaw := sys.C.RawMatrix()
-
-	bbt := make([]float64, n*n)
-	blas64.Gemm(blas.NoTrans, blas.Trans, 1,
-		blas64.General{Rows: n, Cols: m, Stride: bRaw.Stride, Data: bRaw.Data},
-		blas64.General{Rows: n, Cols: m, Stride: bRaw.Stride, Data: bRaw.Data},
-		0, blas64.General{Rows: n, Cols: n, Stride: n, Data: bbt})
-	symmetrize(bbt, n, n)
-
-	ctc := make([]float64, n*n)
-	blas64.Gemm(blas.Trans, blas.NoTrans, 1,
-		blas64.General{Rows: p, Cols: n, Stride: cRaw.Stride, Data: cRaw.Data},
-		blas64.General{Rows: p, Cols: n, Stride: cRaw.Stride, Data: cRaw.Data},
-		0, blas64.General{Rows: n, Cols: n, Stride: n, Data: ctc})
-	symmetrize(ctc, n, n)
-
-	aData := make([]float64, n*n)
-	at := aData[:0:0]
-	at = make([]float64, n*n)
-	copyStrided(aData, n, aRaw.Data, aRaw.Stride, n, n)
-	for i := range n {
-		for j := range n {
-			at[i*n+j] = aRaw.Data[j*aRaw.Stride+i]
-		}
+	At, Qo, err := policy.gramianInputs(GramObservability)
+	if err != nil {
+		return nil, err
 	}
-
-	A := mat.NewDense(n, n, aData)
-	At := mat.NewDense(n, n, at)
-
-	var Wc, Wo *mat.Dense
-	if sys.IsContinuous() {
-		Wc, err = Lyap(A, mat.NewDense(n, n, bbt), nil)
-		if err != nil {
-			return nil, err
-		}
-		Wo, err = Lyap(At, mat.NewDense(n, n, ctc), nil)
-	} else {
-		Wc, err = DLyap(A, mat.NewDense(n, n, bbt), nil)
-		if err != nil {
-			return nil, err
-		}
-		Wo, err = DLyap(At, mat.NewDense(n, n, ctc), nil)
-	}
+	Wo, err := policy.solveLyapunov(At, Qo)
 	if err != nil {
 		return nil, err
 	}
@@ -248,19 +197,19 @@ func eigenvalueHSV(Wc, Wo *mat.Dense, n int) []float64 {
 // HinfNorm computes the H∞ norm (peak gain) of a stable LTI system
 // and the frequency at which it occurs.
 func HinfNorm(sys *System) (norm float64, omega float64, err error) {
-	n, m, p := sys.Dims()
+	policy := newEnergyAnalysisPolicy(sys)
+	if err := policy.requireStandard("HinfNorm"); err != nil {
+		return 0, 0, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 
 	if n == 0 {
 		sv := maxSVDense(sys.D, p, m)
 		return sv, 0, nil
 	}
 
-	stable, err := sys.IsStable()
-	if err != nil {
+	if err := policy.requireStable(ErrUnstable); err != nil {
 		return 0, 0, err
-	}
-	if !stable {
-		return 0, 0, ErrUnstable
 	}
 
 	if sys.IsDiscrete() {
@@ -346,13 +295,13 @@ func newHamiltonianWS(sys *System, n, m, p int) *hamiltonianWS {
 		n: n, m: m, p: p, nn: nn,
 		dIsZero: allZeroDense(sys.D),
 		aData:   aRaw.Data, aStr: aRaw.Stride,
-		bData:   bRaw.Data, bStr: bRaw.Stride,
-		cData:   cRaw.Data, cStr: cRaw.Stride,
-		dData:   dRaw.Data, dStr: dRaw.Stride,
-		h:       make([]float64, nn*nn),
-		wr:      make([]float64, nn),
-		wi:      make([]float64, nn),
-		vs:      make([]float64, nn*nn),
+		bData: bRaw.Data, bStr: bRaw.Stride,
+		cData: cRaw.Data, cStr: cRaw.Stride,
+		dData: dRaw.Data, dStr: dRaw.Stride,
+		h:  make([]float64, nn*nn),
+		wr: make([]float64, nn),
+		wi: make([]float64, nn),
+		vs: make([]float64, nn*nn),
 	}
 
 	ws.bbt = make([]float64, n*n)

--- a/nyquist.go
+++ b/nyquist.go
@@ -1,7 +1,6 @@
 package controlsys
 
 import (
-	"fmt"
 	"math"
 	"math/cmplx"
 	"sort"
@@ -17,9 +16,8 @@ type NyquistResult struct {
 }
 
 func (sys *System) Nyquist(omega []float64, nPoints int) (*NyquistResult, error) {
-	_, m, p := sys.Dims()
-	if p != 1 || m != 1 {
-		return nil, fmt.Errorf("controlsys: Nyquist supports SISO systems only: %w", ErrDimensionMismatch)
+	if _, err := newSISOLoopModel(sys, "Nyquist"); err != nil {
+		return nil, err
 	}
 
 	poles, err := sys.Poles()

--- a/observer.go
+++ b/observer.go
@@ -3,8 +3,6 @@ package controlsys
 import (
 	"fmt"
 
-	"gonum.org/v1/gonum/blas"
-	"gonum.org/v1/gonum/blas/blas64"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -27,35 +25,18 @@ func Lqe(A, G, C, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) 
 	if cn != n {
 		return nil, ErrDimensionMismatch
 	}
-	qr, qc := Qn.Dims()
-	if qr != g || qc != g {
-		return nil, ErrDimensionMismatch
+	if err := validateCovarianceRole("Lqe", covarianceProcessNoise, Qn, g); err != nil {
+		return nil, err
 	}
-	rr, rc := Rn.Dims()
-	if rr != p || rc != p {
-		return nil, ErrDimensionMismatch
+	if err := validateCovarianceRole("Lqe", covarianceMeasurementNoise, Rn, p); err != nil {
+		return nil, err
 	}
 
 	if n == 0 {
 		return &RiccatiResult{X: &mat.Dense{}, K: &mat.Dense{}, Eig: nil}, nil
 	}
 
-	gRaw := G.RawMatrix()
-	qnRaw := Qn.RawMatrix()
-
-	// GQnGt = G * Qn * G' via BLAS: tmp = G*Qn, then GQnGt = tmp*G'
-	gqnData := make([]float64, n*g)
-	blas64.Gemm(blas.NoTrans, blas.NoTrans,
-		1, blas64.General{Rows: n, Cols: g, Data: gRaw.Data, Stride: gRaw.Stride},
-		blas64.General{Rows: g, Cols: g, Data: qnRaw.Data, Stride: qnRaw.Stride},
-		0, blas64.General{Rows: n, Cols: g, Data: gqnData, Stride: g})
-
-	gqngtData := make([]float64, n*n)
-	blas64.Gemm(blas.NoTrans, blas.Trans,
-		1, blas64.General{Rows: n, Cols: g, Data: gqnData, Stride: g},
-		blas64.General{Rows: n, Cols: g, Data: gRaw.Data, Stride: gRaw.Stride},
-		0, blas64.General{Rows: n, Cols: n, Data: gqngtData, Stride: n})
-	GQnGt := mat.NewDense(n, n, gqngtData)
+	GQnGt := inputNoiseIntensity(G, Qn, n, g)
 
 	// Transpose A and C into flat arrays for Care(A', C', ...)
 	atData := make([]float64, n*n)
@@ -97,16 +78,14 @@ func Kalman(sys *System, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, 
 	if n == 0 {
 		return nil, fmt.Errorf("Kalman: system has no states: %w", ErrDimensionMismatch)
 	}
-	if err := newDescriptorPolicy(sys).requireRiccatiStandard("Kalman"); err != nil {
+	if err := requireStandardEstimatorSystem(sys, "Kalman"); err != nil {
 		return nil, err
 	}
-	qr, qc := Qn.Dims()
-	if qr != m || qc != m {
-		return nil, ErrDimensionMismatch
+	if err := validateCovarianceRole("Kalman", covarianceProcessNoise, Qn, m); err != nil {
+		return nil, err
 	}
-	rr, rc := Rn.Dims()
-	if rr != p || rc != p {
-		return nil, ErrDimensionMismatch
+	if err := validateCovarianceRole("Kalman", covarianceMeasurementNoise, Rn, p); err != nil {
+		return nil, err
 	}
 
 	if sys.IsContinuous() {
@@ -140,20 +119,17 @@ func Kalmd(sys *System, Qn, Rn *mat.Dense, dt float64, opts *RiccatiOpts) (*Ricc
 	if n == 0 {
 		return nil, fmt.Errorf("Kalmd: system has no states: %w", ErrDimensionMismatch)
 	}
-	qr, qc := Qn.Dims()
-	if qr != m || qc != m {
-		return nil, ErrDimensionMismatch
+	if err := requireStandardEstimatorSystem(sys, "Kalmd"); err != nil {
+		return nil, err
 	}
-	rr, rc := Rn.Dims()
-	if rr != p || rc != p {
-		return nil, ErrDimensionMismatch
+	if err := validateCovarianceRole("Kalmd", covarianceProcessNoise, Qn, m); err != nil {
+		return nil, err
+	}
+	if err := validateCovarianceRole("Kalmd", covarianceMeasurementNoise, Rn, p); err != nil {
+		return nil, err
 	}
 
-	// GQnGt = B * Qn * B'
-	BQn := mat.NewDense(n, m, nil)
-	BQn.Mul(sys.B, Qn)
-	GQnGt := mat.NewDense(n, n, nil)
-	GQnGt.Mul(BQn, sys.B.T())
+	GQnGt := inputNoiseIntensity(sys.B, Qn, n, m)
 
 	// Van Loan augmented matrix: F = [[-A, GQnGt], [0, A']] * dt
 	nn := 2 * n
@@ -343,21 +319,7 @@ func transposeGain(K *mat.Dense) *mat.Dense {
 }
 
 func dualRiccatiSetup(A, B, C, Qn *mat.Dense, n, m, p int) (GQnGt, At, Ct *mat.Dense) {
-	bRaw := B.RawMatrix()
-	qnRaw := Qn.RawMatrix()
-
-	gqnData := make([]float64, n*m)
-	blas64.Gemm(blas.NoTrans, blas.NoTrans,
-		1, blas64.General{Rows: n, Cols: m, Data: bRaw.Data, Stride: bRaw.Stride},
-		blas64.General{Rows: m, Cols: m, Data: qnRaw.Data, Stride: qnRaw.Stride},
-		0, blas64.General{Rows: n, Cols: m, Data: gqnData, Stride: m})
-
-	gqngtData := make([]float64, n*n)
-	blas64.Gemm(blas.NoTrans, blas.Trans,
-		1, blas64.General{Rows: n, Cols: m, Data: gqnData, Stride: m},
-		blas64.General{Rows: n, Cols: m, Data: bRaw.Data, Stride: bRaw.Stride},
-		0, blas64.General{Rows: n, Cols: n, Data: gqngtData, Stride: n})
-	GQnGt = mat.NewDense(n, n, gqngtData)
+	GQnGt = inputNoiseIntensity(B, Qn, n, m)
 
 	aRaw := A.RawMatrix()
 	atData := make([]float64, n*n)

--- a/pid.go
+++ b/pid.go
@@ -119,14 +119,29 @@ func NewPID2(Kp, Ki, Kd, Tf, b, c float64, opts ...PIDOption) *PID2 {
 	return p2
 }
 
+type pidRealizationSpec struct {
+	hasI bool
+	hasD bool
+}
+
+func newPIDRealizationSpec(Ki, Kd, Tf float64, context string) (pidRealizationSpec, error) {
+	if Kd != 0 && Tf == 0 {
+		return pidRealizationSpec{}, fmt.Errorf("controlsys: %s without filter (Tf=0) is improper; set Tf > 0", context)
+	}
+	return pidRealizationSpec{
+		hasI: Ki != 0,
+		hasD: Kd != 0,
+	}, nil
+}
+
 // System converts the 2-DOF PID to a 2-input (r,y) 1-output (u) state-space.
 func (p *PID2) System() (*System, error) {
-	if p.Kd != 0 && p.Tf == 0 {
-		return nil, fmt.Errorf("controlsys: 2-DOF PD without filter (Tf=0) is improper; set Tf > 0")
+	spec, err := newPIDRealizationSpec(p.Ki, p.Kd, p.Tf, "2-DOF PID derivative term")
+	if err != nil {
+		return nil, err
 	}
-
-	hasI := p.Ki != 0
-	hasD := p.Kd != 0 && p.Tf != 0
+	hasI := spec.hasI
+	hasD := spec.hasD
 
 	n := 0
 	if hasI {
@@ -215,8 +230,8 @@ func (p *PID2) discrete2DOF(n int, hasI, hasD bool) (*System, error) {
 }
 
 func (p *PID) System() (*System, error) {
-	if p.Kd != 0 && p.Tf == 0 && p.Ki == 0 {
-		return nil, fmt.Errorf("controlsys: PD without filter (Tf=0) is improper; set Tf > 0")
+	if _, err := newPIDRealizationSpec(p.Ki, p.Kd, p.Tf, "PID derivative term"); err != nil {
+		return nil, err
 	}
 
 	if p.Dt > 0 {
@@ -226,8 +241,12 @@ func (p *PID) System() (*System, error) {
 }
 
 func (p *PID) continuousSystem() (*System, error) {
-	hasI := p.Ki != 0
-	hasD := p.Kd != 0 && p.Tf != 0
+	spec, err := newPIDRealizationSpec(p.Ki, p.Kd, p.Tf, "PID derivative term")
+	if err != nil {
+		return nil, err
+	}
+	hasI := spec.hasI
+	hasD := spec.hasD
 
 	switch {
 	case !hasI && !hasD:
@@ -265,8 +284,12 @@ func (p *PID) continuousSystem() (*System, error) {
 }
 
 func (p *PID) discreteSystem() (*System, error) {
-	hasI := p.Ki != 0
-	hasD := p.Kd != 0 && p.Tf != 0
+	spec, err := newPIDRealizationSpec(p.Ki, p.Kd, p.Tf, "PID derivative term")
+	if err != nil {
+		return nil, err
+	}
+	hasI := spec.hasI
+	hasD := spec.hasD
 	dt := p.Dt
 
 	switch {

--- a/pid_test.go
+++ b/pid_test.go
@@ -191,6 +191,14 @@ func TestPID_PDNoFilter_Error(t *testing.T) {
 	}
 }
 
+func TestPID_UnfilteredDerivativeWithIntegral_Error(t *testing.T) {
+	c := NewPID(1, 2, 3)
+	_, err := c.System()
+	if err == nil {
+		t.Fatal("expected error for unfiltered derivative term")
+	}
+}
+
 func TestPID_DiscretePI(t *testing.T) {
 	c := NewPID(1, 2, 0, WithTs(0.1))
 	sys, err := c.System()

--- a/pidtune.go
+++ b/pidtune.go
@@ -13,9 +13,8 @@ type PidtuneOptions struct {
 }
 
 func Pidtune(plant *System, pidType string, opts ...PidtuneOptions) (*PID, error) {
-	_, m, p := plant.Dims()
-	if p != 1 || m != 1 {
-		return nil, fmt.Errorf("pidtune: SISO plant required: %w", ErrDimensionMismatch)
+	if _, err := newSISOLoopModel(plant, "pidtune"); err != nil {
+		return nil, err
 	}
 
 	var opt PidtuneOptions

--- a/prescale.go
+++ b/prescale.go
@@ -1,7 +1,6 @@
 package controlsys
 
 import (
-	"fmt"
 	"math"
 
 	"gonum.org/v1/gonum/lapack"
@@ -18,13 +17,17 @@ type PrescaleResult struct {
 }
 
 func Prescale(sys *System) (*PrescaleResult, error) {
-	if sys.HasDelay() {
-		return nil, fmt.Errorf("controlsys: Prescale does not support delayed systems; use Pade/AbsorbDelay first")
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Prescale"); err != nil {
+		return nil, err
 	}
-	n, m, p := sys.Dims()
+	if err := policy.requireDelayFree("Prescale"); err != nil {
+		return nil, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 
 	if n == 0 {
-		result := &PrescaleResult{Sys: sys.Copy()}
+		result := &PrescaleResult{Sys: policy.zeroOrderCopy()}
 		result.Info.InputScale = ones(m)
 		result.Info.OutputScale = ones(p)
 		return result, nil
@@ -99,11 +102,10 @@ func Prescale(sys *System) (*PrescaleResult, error) {
 		}
 	}
 
-	scaled, err := newNoCopy(Ab, Bb, Cb, Db, sys.Dt)
+	scaled, err := policy.result(Ab, Bb, Cb, Db)
 	if err != nil {
 		return nil, err
 	}
-	propagateIONames(scaled, sys)
 
 	result := &PrescaleResult{Sys: scaled}
 	result.Info.StateScale = stateScale

--- a/random.go
+++ b/random.go
@@ -12,7 +12,7 @@ func Rss(n, p, m int) (*System, error) {
 	if n < 0 || p < 1 || m < 1 {
 		return nil, fmt.Errorf("controlsys: invalid dimensions n=%d p=%d m=%d", n, p, m)
 	}
-	return randomSS(n, p, m, 0, true)
+	return randomSS(randomStableModelSpec{states: n, outputs: p, inputs: m, dt: 0, continuous: true})
 }
 
 func Drss(n, p, m int, dt float64) (*System, error) {
@@ -22,53 +22,78 @@ func Drss(n, p, m int, dt float64) (*System, error) {
 	if dt <= 0 {
 		return nil, ErrInvalidSampleTime
 	}
-	return randomSS(n, p, m, dt, false)
+	return randomSS(randomStableModelSpec{states: n, outputs: p, inputs: m, dt: dt, continuous: false})
 }
 
-func randomSS(n, p, m int, dt float64, continuous bool) (*System, error) {
-	if n == 0 {
-		dData := make([]float64, p*m)
+type randomSource interface {
+	Float64() float64
+	NormFloat64() float64
+}
+
+type packageRandomSource struct{}
+
+func (packageRandomSource) Float64() float64     { return rand.Float64() }
+func (packageRandomSource) NormFloat64() float64 { return rand.NormFloat64() }
+
+type randomStableModelSpec struct {
+	states     int
+	outputs    int
+	inputs     int
+	dt         float64
+	continuous bool
+}
+
+func randomSS(spec randomStableModelSpec) (*System, error) {
+	return randomSSWithSource(spec, packageRandomSource{})
+}
+
+func randomSSWithSource(spec randomStableModelSpec, rng randomSource) (*System, error) {
+	if spec.states == 0 {
+		dData := make([]float64, spec.outputs*spec.inputs)
 		for i := range dData {
-			dData[i] = rand.NormFloat64()
+			dData[i] = rng.NormFloat64()
 		}
-		return NewGain(mat.NewDense(p, m, dData), dt)
+		return NewGain(mat.NewDense(spec.outputs, spec.inputs, dData), spec.dt)
 	}
 
-	A := randomStableA(n, continuous)
+	A := randomStableAWithSource(spec.states, spec.continuous, rng)
 
-	bData := make([]float64, n*m)
+	bData := make([]float64, spec.states*spec.inputs)
 	for i := range bData {
-		bData[i] = rand.NormFloat64()
+		bData[i] = rng.NormFloat64()
 	}
-	B := mat.NewDense(n, m, bData)
+	B := mat.NewDense(spec.states, spec.inputs, bData)
 
-	cData := make([]float64, p*n)
+	cData := make([]float64, spec.outputs*spec.states)
 	for i := range cData {
-		cData[i] = rand.NormFloat64()
+		cData[i] = rng.NormFloat64()
 	}
-	C := mat.NewDense(p, n, cData)
+	C := mat.NewDense(spec.outputs, spec.states, cData)
 
-	D := mat.NewDense(p, m, nil)
+	D := mat.NewDense(spec.outputs, spec.inputs, nil)
 
-	return newNoCopy(A, B, C, D, dt)
+	return newNoCopy(A, B, C, D, spec.dt)
 }
 
 func randomStableA(n int, continuous bool) *mat.Dense {
-	// Generate random eigenvalue structure with mix of real and complex pairs
+	return randomStableAWithSource(n, continuous, packageRandomSource{})
+}
+
+func randomStableAWithSource(n int, continuous bool, rng randomSource) *mat.Dense {
 	diagData := make([]float64, n*n)
 	i := 0
 	for i < n {
-		if i+1 < n && rand.Float64() < 0.5 {
+		if i+1 < n && rng.Float64() < 0.5 {
 			if continuous {
-				sigma := -rand.Float64()*4 - 0.1
-				omega := rand.Float64()*4 + 0.1
+				sigma := -rng.Float64()*4 - 0.1
+				omega := rng.Float64()*4 + 0.1
 				diagData[i*n+i] = sigma
 				diagData[i*n+i+1] = omega
 				diagData[(i+1)*n+i] = -omega
 				diagData[(i+1)*n+i+1] = sigma
 			} else {
-				r := rand.Float64()*0.9 + 0.01
-				theta := rand.Float64() * math.Pi
+				r := rng.Float64()*0.9 + 0.01
+				theta := rng.Float64() * math.Pi
 				diagData[i*n+i] = r * math.Cos(theta)
 				diagData[i*n+i+1] = r * math.Sin(theta)
 				diagData[(i+1)*n+i] = -r * math.Sin(theta)
@@ -77,16 +102,16 @@ func randomStableA(n int, continuous bool) *mat.Dense {
 			i += 2
 		} else {
 			if continuous {
-				diagData[i*n+i] = -rand.Float64()*4 - 0.1
+				diagData[i*n+i] = -rng.Float64()*4 - 0.1
 			} else {
-				diagData[i*n+i] = rand.Float64()*1.8 - 0.9
+				diagData[i*n+i] = rng.Float64()*1.8 - 0.9
 			}
 			i++
 		}
 	}
 	D := mat.NewDense(n, n, diagData)
 
-	Q := randomOrthogonal(n)
+	Q := randomOrthogonalWithSource(n, rng)
 
 	// A = Q * D * Q'
 	tmp := mat.NewDense(n, n, nil)
@@ -97,9 +122,13 @@ func randomStableA(n int, continuous bool) *mat.Dense {
 }
 
 func randomOrthogonal(n int) *mat.Dense {
+	return randomOrthogonalWithSource(n, packageRandomSource{})
+}
+
+func randomOrthogonalWithSource(n int, rng randomSource) *mat.Dense {
 	data := make([]float64, n*n)
 	for i := range data {
-		data[i] = rand.NormFloat64()
+		data[i] = rng.NormFloat64()
 	}
 	M := mat.NewDense(n, n, data)
 	var qr mat.QR

--- a/random_test.go
+++ b/random_test.go
@@ -2,6 +2,7 @@ package controlsys
 
 import (
 	"math/cmplx"
+	"math/rand"
 	"testing"
 )
 
@@ -117,6 +118,23 @@ func TestDrss_InvalidDt(t *testing.T) {
 	_, err = Drss(4, 1, 1, -1)
 	if err == nil {
 		t.Error("expected error for dt<0")
+	}
+}
+
+func TestRandomSS_DeterministicAdapter(t *testing.T) {
+	rng1 := rand.New(rand.NewSource(42))
+	rng2 := rand.New(rand.NewSource(42))
+
+	sys1, err := randomSSWithSource(randomStableModelSpec{states: 3, outputs: 1, inputs: 1, dt: 0, continuous: true}, rng1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys2, err := randomSSWithSource(randomStableModelSpec{states: 3, outputs: 1, inputs: 1, dt: 0, continuous: true}, rng2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matEqual(sys1.A, sys2.A, 0) || !matEqual(sys1.B, sys2.B, 0) || !matEqual(sys1.C, sys2.C, 0) {
+		t.Fatal("same seed produced different systems")
 	}
 }
 

--- a/realization_policy.go
+++ b/realization_policy.go
@@ -1,0 +1,41 @@
+package controlsys
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type realizationTransformPolicy struct {
+	sys     *System
+	n, m, p int
+}
+
+func newRealizationTransformPolicy(sys *System) realizationTransformPolicy {
+	n, m, p := sys.Dims()
+	return realizationTransformPolicy{sys: sys, n: n, m: m, p: p}
+}
+
+func (p realizationTransformPolicy) requireStandard(context string) error {
+	return newDescriptorPolicy(p.sys).requireStandard(context)
+}
+
+func (p realizationTransformPolicy) requireDelayFree(context string) error {
+	if p.sys.HasDelay() {
+		return fmt.Errorf("controlsys: %s does not support delayed systems; use Pade/AbsorbDelay first", context)
+	}
+	return nil
+}
+
+func (p realizationTransformPolicy) zeroOrderCopy() *System {
+	return p.sys.Copy()
+}
+
+func (p realizationTransformPolicy) result(A, B, C, D *mat.Dense) (*System, error) {
+	result, err := newNoCopy(A, B, C, D, p.sys.Dt)
+	if err != nil {
+		return nil, err
+	}
+	propagateIONames(result, p.sys)
+	return result, nil
+}

--- a/reference_fixture_test.go
+++ b/reference_fixture_test.go
@@ -1,0 +1,89 @@
+package controlsys
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type referenceSource string
+
+const (
+	ReferenceMATLAB        referenceSource = "MATLAB"
+	ReferencePythonControl referenceSource = "python-control"
+)
+
+type referenceTolerance float64
+
+const (
+	RefTolExact referenceTolerance = 1e-12
+	RefTolTight referenceTolerance = 1e-10
+	RefTolLoose referenceTolerance = 1e-6
+)
+
+type referenceFixture struct {
+	t      *testing.T
+	source referenceSource
+	caseID string
+	tol    float64
+}
+
+func matlabReference(t *testing.T, caseID string, tol referenceTolerance) referenceFixture {
+	t.Helper()
+	return newReferenceFixture(t, ReferenceMATLAB, caseID, tol)
+}
+
+func pythonControlReference(t *testing.T, caseID string, tol referenceTolerance) referenceFixture {
+	t.Helper()
+	return newReferenceFixture(t, ReferencePythonControl, caseID, tol)
+}
+
+func newReferenceFixture(t *testing.T, source referenceSource, caseID string, tol referenceTolerance) referenceFixture {
+	t.Helper()
+	return referenceFixture{
+		t:      t,
+		source: source,
+		caseID: caseID,
+		tol:    float64(tol),
+	}
+}
+
+func (f referenceFixture) Dense(r, c int, data []float64) *mat.Dense {
+	f.t.Helper()
+	return mat.NewDense(r, c, data)
+}
+
+func (f referenceFixture) StateSpace(n, m, p int, a, b, c, d []float64, dt float64) *System {
+	f.t.Helper()
+	sys, err := NewFromSlices(n, m, p, a, b, c, d, dt)
+	if err != nil {
+		f.t.Fatalf("%s reference %q state-space model: %v", f.source, f.caseID, err)
+	}
+	return sys
+}
+
+func (f referenceFixture) AssertDense(label string, got, want *mat.Dense) {
+	f.t.Helper()
+	gr, gc := got.Dims()
+	wr, wc := want.Dims()
+	if gr != wr || gc != wc {
+		f.t.Fatalf("%s reference %q %s dims = %dx%d, want %dx%d", f.source, f.caseID, label, gr, gc, wr, wc)
+	}
+	for i := range gr {
+		for j := range gc {
+			if diff := math.Abs(got.At(i, j) - want.At(i, j)); diff > f.tol {
+				f.t.Fatalf("%s reference %q %s[%d,%d] = %g, want %g (diff %g > tol %g)",
+					f.source, f.caseID, label, i, j, got.At(i, j), want.At(i, j), diff, f.tol)
+			}
+		}
+	}
+}
+
+func (f referenceFixture) AssertScalar(label string, got, want float64) {
+	f.t.Helper()
+	if diff := math.Abs(got - want); diff > f.tol {
+		f.t.Fatalf("%s reference %q %s = %g, want %g (diff %g > tol %g)",
+			f.source, f.caseID, label, got, want, diff, f.tol)
+	}
+}

--- a/reference_fixture_usage_test.go
+++ b/reference_fixture_usage_test.go
@@ -1,0 +1,21 @@
+package controlsys
+
+import "testing"
+
+func TestReferenceFixtureBuildsPythonControlStateSpaceModel(t *testing.T) {
+	ref := pythonControlReference(t, "state-space fixture smoke test", RefTolTight)
+	sys := ref.StateSpace(
+		2, 1, 1,
+		[]float64{0, 1, -2, -3},
+		[]float64{0, 1},
+		[]float64{1, 0},
+		[]float64{0},
+		0,
+	)
+
+	n, m, p := sys.Dims()
+	if n != 2 || m != 1 || p != 1 {
+		t.Fatalf("dims = (%d,%d,%d), want (2,1,1)", n, m, p)
+	}
+	ref.AssertDense("A", sys.A, ref.Dense(2, 2, []float64{0, 1, -2, -3}))
+}

--- a/rlocus.go
+++ b/rlocus.go
@@ -20,10 +20,10 @@ type RootLocusResult struct {
 }
 
 func RootLocus(sys *System, gains []float64) (*RootLocusResult, error) {
-	n, m, p := sys.Dims()
-	if m != 1 || p != 1 {
-		return nil, ErrNotSISO
+	if _, err := newSISOLoopModel(sys, "RootLocus"); err != nil {
+		return nil, err
 	}
+	n, _, _ := sys.Dims()
 
 	dRaw := sys.D.RawMatrix()
 	if dRaw.Data[0] != 0 {

--- a/rlocus_test.go
+++ b/rlocus_test.go
@@ -1,6 +1,7 @@
 package controlsys
 
 import (
+	"errors"
 	"math"
 	"math/cmplx"
 	"testing"
@@ -237,7 +238,7 @@ func TestRootLocus_NotSISO(t *testing.T) {
 	}
 
 	_, err = RootLocus(sys, nil)
-	if err != ErrNotSISO {
+	if !errors.Is(err, ErrNotSISO) {
 		t.Errorf("expected ErrNotSISO, got %v", err)
 	}
 }

--- a/sminreal.go
+++ b/sminreal.go
@@ -1,18 +1,18 @@
 package controlsys
 
-import (
-	"fmt"
-
-	"gonum.org/v1/gonum/mat"
-)
+import "gonum.org/v1/gonum/mat"
 
 func Sminreal(sys *System) (*System, error) {
-	if sys.HasDelay() {
-		return nil, fmt.Errorf("controlsys: Sminreal does not support delayed systems; use Pade/AbsorbDelay first")
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Sminreal"); err != nil {
+		return nil, err
 	}
-	n, m, p := sys.Dims()
+	if err := policy.requireDelayFree("Sminreal"); err != nil {
+		return nil, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 	if n == 0 {
-		return sys.Copy(), nil
+		return policy.zeroOrderCopy(), nil
 	}
 
 	aRaw := sys.A.RawMatrix()
@@ -111,10 +111,5 @@ func Sminreal(sys *System) (*System, error) {
 		}
 	}
 
-	result, err := newNoCopy(ar, br, cr, denseCopy(sys.D), sys.Dt)
-	if err != nil {
-		return nil, err
-	}
-	propagateIONames(result, sys)
-	return result, nil
+	return policy.result(ar, br, cr, denseCopy(sys.D))
 }

--- a/ssbal.go
+++ b/ssbal.go
@@ -1,7 +1,6 @@
 package controlsys
 
 import (
-	"fmt"
 	"math"
 
 	"gonum.org/v1/gonum/mat"
@@ -13,14 +12,17 @@ type SsbalResult struct {
 }
 
 func Ssbal(sys *System) (*SsbalResult, error) {
-	if sys.HasDelay() {
-		return nil, fmt.Errorf("controlsys: Ssbal does not support delayed systems; use Pade/AbsorbDelay first")
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Ssbal"); err != nil {
+		return nil, err
 	}
-	n, m, p := sys.Dims()
+	if err := policy.requireDelayFree("Ssbal"); err != nil {
+		return nil, err
+	}
+	n, m, p := policy.n, policy.m, policy.p
 	if n == 0 {
-		cp := sys.Copy()
 		eye := &mat.Dense{}
-		return &SsbalResult{Sys: cp, T: eye}, nil
+		return &SsbalResult{Sys: policy.zeroOrderCopy(), T: eye}, nil
 	}
 
 	aRaw := sys.A.RawMatrix()
@@ -110,11 +112,9 @@ func Ssbal(sys *System) (*SsbalResult, error) {
 		T.Set(i, i, d[i])
 	}
 
-	newSys, err := newNoCopy(Anew, Bnew, Cnew, Dnew, sys.Dt)
+	newSys, err := policy.result(Anew, Bnew, Cnew, Dnew)
 	if err != nil {
 		return nil, err
 	}
-	propagateIONames(newSys, sys)
-
 	return &SsbalResult{Sys: newSys, T: T}, nil
 }

--- a/sumblk.go
+++ b/sumblk.go
@@ -91,211 +91,213 @@ func tokenize(expr string) ([]token, error) {
 	return tokens, nil
 }
 
-func parseEquations(tokens []token) ([]equation, error) {
-	pos := 0
+type sumblkParser struct {
+	tokens []token
+	pos    int
+}
 
-	peek := func() token { return tokens[pos] }
-	advance := func() token {
-		t := tokens[pos]
-		pos++
-		return t
+func (p *sumblkParser) peek() token {
+	return p.tokens[p.pos]
+}
+
+func (p *sumblkParser) advance() token {
+	t := p.tokens[p.pos]
+	p.pos++
+	return t
+}
+
+func (p *sumblkParser) expect(k tokenKind) (token, error) {
+	t := p.peek()
+	if t.kind != k {
+		return t, fmt.Errorf("sumblk: expected %d, got %q: %w", k, t.text, ErrInvalidExpression)
 	}
-	expect := func(k tokenKind) (token, error) {
-		t := peek()
-		if t.kind != k {
-			return t, fmt.Errorf("sumblk: expected %d, got %q: %w", k, t.text, ErrInvalidExpression)
+	p.advance()
+	return t, nil
+}
+
+func (p *sumblkParser) parseTerm() (signalTerm, error) {
+	coeff := 1.0
+	sign := 1.0
+	for p.peek().kind == tokPlus || p.peek().kind == tokMinus {
+		if p.advance().kind == tokMinus {
+			sign = -sign
 		}
-		advance()
-		return t, nil
 	}
 
-	parseTerm := func(isFirst bool) (signalTerm, error) {
-		coeff := 1.0
-		neg := false
-
-		if isFirst {
-			if peek().kind == tokMinus {
-				advance()
-				neg = true
-			}
+	if p.peek().kind == tokNumber {
+		t := p.advance()
+		if _, err := p.expect(tokStar); err != nil {
+			return signalTerm{}, fmt.Errorf("sumblk: expected '*' after number: %w", ErrInvalidExpression)
 		}
+		coeff = t.num
+	}
 
-		if peek().kind == tokNumber {
-			t := advance()
-			if _, err := expect(tokStar); err != nil {
-				return signalTerm{}, fmt.Errorf("sumblk: expected '*' after number: %w", ErrInvalidExpression)
-			}
-			coeff = t.num
-		}
+	ident, err := p.expect(tokIdent)
+	if err != nil {
+		return signalTerm{}, fmt.Errorf("sumblk: expected signal name: %w", ErrInvalidExpression)
+	}
+	return signalTerm{name: ident.text, coeff: sign * coeff}, nil
+}
 
-		ident, err := expect(tokIdent)
+func (p *sumblkParser) parseEquation() (equation, error) {
+	out, err := p.expect(tokIdent)
+	if err != nil {
+		return equation{}, fmt.Errorf("sumblk: expected output name: %w", ErrInvalidExpression)
+	}
+	if _, err := p.expect(tokEquals); err != nil {
+		return equation{}, err
+	}
+
+	first, err := p.parseTerm()
+	if err != nil {
+		return equation{}, err
+	}
+	terms := []signalTerm{first}
+
+	for p.peek().kind == tokPlus || p.peek().kind == tokMinus {
+		t, err := p.parseTerm()
 		if err != nil {
-			return signalTerm{}, fmt.Errorf("sumblk: expected signal name: %w", ErrInvalidExpression)
-		}
-
-		if neg {
-			coeff = -coeff
-		}
-		return signalTerm{name: ident.text, coeff: coeff}, nil
-	}
-
-	parseEq := func() (equation, error) {
-		out, err := expect(tokIdent)
-		if err != nil {
-			return equation{}, fmt.Errorf("sumblk: expected output name: %w", ErrInvalidExpression)
-		}
-		if _, err := expect(tokEquals); err != nil {
 			return equation{}, err
 		}
-
-		first, err := parseTerm(true)
-		if err != nil {
-			return equation{}, err
-		}
-		terms := []signalTerm{first}
-
-		for peek().kind == tokPlus || peek().kind == tokMinus {
-			op := advance()
-			t, err := parseTerm(false)
-			if err != nil {
-				return equation{}, err
-			}
-			if op.kind == tokMinus {
-				t.coeff = -t.coeff
-			}
-			terms = append(terms, t)
-		}
-		return equation{output: out.text, terms: terms}, nil
+		terms = append(terms, t)
 	}
+	return equation{output: out.text, terms: terms}, nil
+}
 
+func (p *sumblkParser) parse() ([]equation, error) {
 	var eqs []equation
-	eq, err := parseEq()
+	eq, err := p.parseEquation()
 	if err != nil {
 		return nil, err
 	}
 	eqs = append(eqs, eq)
 
-	for peek().kind == tokSemicolon {
-		advance()
-		if peek().kind == tokEOF {
+	for p.peek().kind == tokSemicolon {
+		p.advance()
+		if p.peek().kind == tokEOF {
 			break
 		}
-		eq, err := parseEq()
+		eq, err := p.parseEquation()
 		if err != nil {
 			return nil, err
 		}
 		eqs = append(eqs, eq)
 	}
 
-	if peek().kind != tokEOF {
-		return nil, fmt.Errorf("sumblk: unexpected token %q: %w", peek().text, ErrInvalidExpression)
+	if p.peek().kind != tokEOF {
+		return nil, fmt.Errorf("sumblk: unexpected token %q: %w", p.peek().text, ErrInvalidExpression)
 	}
 	return eqs, nil
 }
 
-func SumBlk(expr string, widths ...int) (*System, error) {
+func parseEquations(tokens []token) ([]equation, error) {
+	return (&sumblkParser{tokens: tokens}).parse()
+}
+
+type parsedSumBlock struct {
+	equations []equation
+	outputs   []string
+	inputs    []string
+	signals   []string
+	widths    map[string]int
+}
+
+func parseSumBlock(expr string) (*parsedSumBlock, error) {
 	trimmed := strings.TrimSpace(expr)
 	if trimmed == "" {
 		return nil, fmt.Errorf("sumblk: empty expression: %w", ErrInvalidExpression)
 	}
-
 	tokens, err := tokenize(trimmed)
 	if err != nil {
 		return nil, err
 	}
-
 	eqs, err := parseEquations(tokens)
 	if err != nil {
 		return nil, err
 	}
+	parsed := &parsedSumBlock{equations: eqs}
+	if err := parsed.collectSignals(); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
 
+func (p *parsedSumBlock) collectSignals() error {
 	outputSet := make(map[string]bool)
-	var outputs []string
-	for _, eq := range eqs {
+	for _, eq := range p.equations {
 		if outputSet[eq.output] {
-			return nil, fmt.Errorf("sumblk: duplicate output %q: %w", eq.output, ErrInvalidExpression)
+			return fmt.Errorf("sumblk: duplicate output %q: %w", eq.output, ErrInvalidExpression)
 		}
 		outputSet[eq.output] = true
-		outputs = append(outputs, eq.output)
+		p.outputs = append(p.outputs, eq.output)
 	}
 
 	inputSet := make(map[string]bool)
-	var inputs []string
-	for _, eq := range eqs {
+	for _, eq := range p.equations {
 		for _, t := range eq.terms {
 			if !inputSet[t.name] {
 				inputSet[t.name] = true
-				inputs = append(inputs, t.name)
+				p.inputs = append(p.inputs, t.name)
 			}
 		}
 	}
 
-	signals := make([]string, 0, len(outputs)+len(inputs))
-	signals = append(signals, outputs...)
-	for _, inp := range inputs {
+	p.signals = make([]string, 0, len(p.outputs)+len(p.inputs))
+	p.signals = append(p.signals, p.outputs...)
+	for _, inp := range p.inputs {
 		if !outputSet[inp] {
-			signals = append(signals, inp)
+			p.signals = append(p.signals, inp)
 		}
 	}
+	return nil
+}
 
-	sigWidth := make(map[string]int, len(signals))
+func (p *parsedSumBlock) applyWidths(widths []int) error {
+	p.widths = make(map[string]int, len(p.signals))
 	switch len(widths) {
 	case 0:
-		for _, s := range signals {
-			sigWidth[s] = 1
-		}
-		for _, inp := range inputs {
-			if outputSet[inp] && sigWidth[inp] == 0 {
-				sigWidth[inp] = 1
-			}
+		for _, s := range p.signals {
+			p.widths[s] = 1
 		}
 	case 1:
-		for _, s := range signals {
-			sigWidth[s] = widths[0]
-		}
-		for _, inp := range inputs {
-			if outputSet[inp] {
-				sigWidth[inp] = widths[0]
-			}
+		for _, s := range p.signals {
+			p.widths[s] = widths[0]
 		}
 	default:
-		if len(widths) != len(signals) {
-			return nil, fmt.Errorf("sumblk: got %d widths for %d signals: %w", len(widths), len(signals), ErrInvalidExpression)
+		if len(widths) != len(p.signals) {
+			return fmt.Errorf("sumblk: got %d widths for %d signals: %w", len(widths), len(p.signals), ErrInvalidExpression)
 		}
-		for i, s := range signals {
-			sigWidth[s] = widths[i]
+		for i, s := range p.signals {
+			p.widths[s] = widths[i]
 		}
 	}
+	return nil
+}
 
+func (p *parsedSumBlock) directMatrix() *mat.Dense {
 	totalRows := 0
-	for _, o := range outputs {
-		totalRows += sigWidth[o]
-	}
-
-	allInputs := make([]string, 0, len(inputs))
-	for _, inp := range inputs {
-		allInputs = append(allInputs, inp)
+	for _, o := range p.outputs {
+		totalRows += p.widths[o]
 	}
 
 	totalCols := 0
-	inputColStart := make(map[string]int, len(allInputs))
-	for _, inp := range allInputs {
+	inputColStart := make(map[string]int, len(p.inputs))
+	for _, inp := range p.inputs {
 		inputColStart[inp] = totalCols
-		totalCols += sigWidth[inp]
+		totalCols += p.widths[inp]
 	}
 
 	D := mat.NewDense(totalRows, totalCols, nil)
-
 	rowOff := 0
-	for _, eq := range eqs {
-		w := sigWidth[eq.output]
+	for _, eq := range p.equations {
+		w := p.widths[eq.output]
 		merged := make(map[string]float64)
 		for _, t := range eq.terms {
 			merged[t.name] += t.coeff
 		}
 		for name, coeff := range merged {
 			col0 := inputColStart[name]
-			wIn := sigWidth[name]
+			wIn := p.widths[name]
 			diag := w
 			if wIn < diag {
 				diag = wIn
@@ -306,36 +308,38 @@ func SumBlk(expr string, widths ...int) (*System, error) {
 		}
 		rowOff += w
 	}
+	return D
+}
 
-	sys, err := NewGain(D, 0)
+func expandSignalNames(signals []string, widths map[string]int) []string {
+	var expanded []string
+	for _, signal := range signals {
+		w := widths[signal]
+		if w == 1 {
+			expanded = append(expanded, signal)
+			continue
+		}
+		for k := 1; k <= w; k++ {
+			expanded = append(expanded, fmt.Sprintf("%s(%d)", signal, k))
+		}
+	}
+	return expanded
+}
+
+func SumBlk(expr string, widths ...int) (*System, error) {
+	parsed, err := parseSumBlock(expr)
 	if err != nil {
 		return nil, err
 	}
-
-	var expandedOutputs []string
-	for _, o := range outputs {
-		w := sigWidth[o]
-		if w == 1 {
-			expandedOutputs = append(expandedOutputs, o)
-		} else {
-			for k := 1; k <= w; k++ {
-				expandedOutputs = append(expandedOutputs, fmt.Sprintf("%s(%d)", o, k))
-			}
-		}
+	if err := parsed.applyWidths(widths); err != nil {
+		return nil, err
 	}
-	var expandedInputs []string
-	for _, inp := range allInputs {
-		w := sigWidth[inp]
-		if w == 1 {
-			expandedInputs = append(expandedInputs, inp)
-		} else {
-			for k := 1; k <= w; k++ {
-				expandedInputs = append(expandedInputs, fmt.Sprintf("%s(%d)", inp, k))
-			}
-		}
-	}
-	sys.OutputName = expandedOutputs
-	sys.InputName = expandedInputs
 
+	sys, err := NewGain(parsed.directMatrix(), 0)
+	if err != nil {
+		return nil, err
+	}
+	sys.OutputName = expandSignalNames(parsed.outputs, parsed.widths)
+	sys.InputName = expandSignalNames(parsed.inputs, parsed.widths)
 	return sys, nil
 }

--- a/sumblk_test.go
+++ b/sumblk_test.go
@@ -52,6 +52,15 @@ func TestSumBlk_UnaryMinus(t *testing.T) {
 	checkD(t, sys, [][]float64{{-1}})
 }
 
+func TestSumBlk_SignedRepeatedTerms(t *testing.T) {
+	sys, err := SumBlk("e = r + -y + r")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkDims(t, sys, 0, 2, 1)
+	checkD(t, sys, [][]float64{{2, -1}})
+}
+
 func TestSumBlk_ThreeTermSum(t *testing.T) {
 	sys, err := SumBlk("e = r - y + d")
 	if err != nil {

--- a/transform.go
+++ b/transform.go
@@ -7,9 +7,13 @@ import (
 )
 
 func SS2SS(sys *System, T *mat.Dense) (*System, error) {
-	n, _, _ := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("SS2SS"); err != nil {
+		return nil, err
+	}
+	n := policy.n
 	if n == 0 {
-		return sys.Copy(), nil
+		return policy.zeroOrderCopy(), nil
 	}
 
 	tr, tc := T.Dims()
@@ -47,12 +51,16 @@ func SS2SS(sys *System, T *mat.Dense) (*System, error) {
 }
 
 func Xperm(sys *System, perm []int) (*System, error) {
-	n, _, _ := sys.Dims()
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("Xperm"); err != nil {
+		return nil, err
+	}
+	n := policy.n
 	if len(perm) != n {
 		return nil, fmt.Errorf("Xperm: perm length %d != state dim %d: %w", len(perm), n, ErrDimensionMismatch)
 	}
 	if n == 0 {
-		return sys.Copy(), nil
+		return policy.zeroOrderCopy(), nil
 	}
 
 	seen := make([]bool, n)


### PR DESCRIPTION
## Summary
- add package-private policy modules for PID realization, SISO loop analysis, covariance roles, realization transforms, energy analysis, random model generation, and reference-test fixtures
- tighten descriptor rejection around covariance, transformation, and energy workflows while preserving public entry points
- refactor SumBlk around a parsed expression model and support signed repeated terms

## Validation
- go test -v -count=1
- focused benchmarks for loop-analysis, covariance/estimator, transformation, random generation, and energy paths
- benchstat origin/main vs branch over focused benchmark suite: no statistically significant slowdown; sec/op geomean 41.35µs -> 41.57µs (+0.53%), allocs/op geomean 80.28 -> 80.52 (+0.31%)

Closes #75
Closes #76
Closes #77
Closes #78
Closes #79
Closes #80
Closes #81
Closes #82