### PR TITLE
Deepen remaining architecture modules

### DIFF
--- a/architecture_deepening_test.go
+++ b/architecture_deepening_test.go
@@ -1,0 +1,315 @@
+package controlsys
+
+import (
+	"errors"
+	"math"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestArchitectureLocalApproximationJacobiansDriveLinearizeAndEKF(t *testing.T) {
+	x0 := mat.NewVecDense(2, []float64{0.4, -0.2})
+	u0 := mat.NewVecDense(1, []float64{0.3})
+
+	state := func(x, u *mat.VecDense) *mat.VecDense {
+		x1, x2, u1 := x.AtVec(0), x.AtVec(1), u.AtVec(0)
+		return mat.NewVecDense(2, []float64{
+			math.Sin(x1) + x2*u1,
+			x1*x1 - 0.5*x2 + u1,
+		})
+	}
+	output := func(x, u *mat.VecDense) *mat.VecDense {
+		return mat.NewVecDense(1, []float64{x.AtVec(0)*x.AtVec(1) + 2*u.AtVec(0)})
+	}
+
+	lin, err := Linearize(&NonlinearModel{F: state, H: output, N: 2, M: 1, P: 1}, x0, u0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	explicitA := mat.NewDense(2, 2, []float64{
+		math.Cos(x0.AtVec(0)), u0.AtVec(0),
+		2 * x0.AtVec(0), -0.5,
+	})
+	explicitC := mat.NewDense(1, 2, []float64{x0.AtVec(1), x0.AtVec(0)})
+	assertDenseApprox(t, lin.A, explicitA, 1e-7)
+	assertDenseApprox(t, lin.C, explicitC, 1e-7)
+
+	P0 := mat.NewDense(2, 2, []float64{1, 0.2, 0.2, 2})
+	Q := mat.NewDense(2, 2, []float64{0.01, 0, 0, 0.02})
+	R := mat.NewDense(1, 1, []float64{0.1})
+	ekf, err := NewEKF(&EKFModel{
+		F: func(x, u *mat.VecDense) *mat.VecDense { return state(x, u) },
+		H: func(x *mat.VecDense) *mat.VecDense { return output(x, u0) },
+		FJac: func(x, u *mat.VecDense) *mat.Dense {
+			return mat.NewDense(2, 2, []float64{
+				math.Cos(x.AtVec(0)), u.AtVec(0),
+				2 * x.AtVec(0), -0.5,
+			})
+		},
+		HJac: func(x *mat.VecDense) *mat.Dense {
+			return mat.NewDense(1, 2, []float64{x.AtVec(1), x.AtVec(0)})
+		},
+		Q: Q,
+		R: R,
+	}, x0, P0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ekf.Predict(u0); err != nil {
+		t.Fatal(err)
+	}
+
+	var ap, want mat.Dense
+	ap.Mul(lin.A, P0)
+	want.Mul(&ap, lin.A.T())
+	want.Add(&want, Q)
+	assertDenseApprox(t, ekf.P, &want, 1e-7)
+}
+
+func TestArchitectureLocalApproximationRejectsBadCallbackShapes(t *testing.T) {
+	x0 := mat.NewVecDense(2, nil)
+	u0 := mat.NewVecDense(1, nil)
+	if _, err := Linearize(&NonlinearModel{
+		F: func(x, u *mat.VecDense) *mat.VecDense { return nil },
+		H: func(x, u *mat.VecDense) *mat.VecDense { return mat.NewVecDense(1, nil) },
+		N: 2, M: 1, P: 1,
+	}, x0, u0); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("Linearize nil state callback error = %v, want ErrDimensionMismatch", err)
+	}
+
+	P0 := mat.NewDense(2, 2, nil)
+	Q := mat.NewDense(2, 2, nil)
+	R := mat.NewDense(1, 1, nil)
+	ekf, err := NewEKF(&EKFModel{
+		F:    func(x, u *mat.VecDense) *mat.VecDense { return mat.NewVecDense(2, nil) },
+		H:    func(x *mat.VecDense) *mat.VecDense { return mat.NewVecDense(1, nil) },
+		FJac: func(x, u *mat.VecDense) *mat.Dense { return mat.NewDense(1, 2, nil) },
+		HJac: func(x *mat.VecDense) *mat.Dense { return mat.NewDense(1, 2, nil) },
+		Q:    Q,
+		R:    R,
+	}, x0, P0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ekf.Predict(u0); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("EKF wrong Jacobian error = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestArchitectureFreqRespEstHandlesStridedSISOInput(t *testing.T) {
+	dt := 0.01
+	sys, err := New(
+		mat.NewDense(1, 1, []float64{0.8}),
+		mat.NewDense(1, 1, []float64{0.2}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{0}),
+		dt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n := 2048
+	uData := make([]float64, n)
+	backingU := mat.NewDense(2, n, nil)
+	uRow := backingU.Slice(1, 2, 0, n).(*mat.Dense)
+	uRaw := uRow.RawMatrix()
+	for k := range n {
+		uData[k] = math.Sin(0.17*float64(k)) + 0.5*math.Sin(0.43*float64(k))
+		uRaw.Data[k] = uData[k]
+	}
+	uContig := mat.NewDense(1, n, uData)
+	resp, err := sys.Simulate(uContig, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backingY := mat.NewDense(2, n, nil)
+	yRow := backingY.Slice(1, 2, 0, n).(*mat.Dense)
+	yRow.Copy(resp.Y)
+
+	contig, err := FreqRespEst(uContig, resp.Y, dt, &FreqRespEstOpts{NFFT: 512})
+	if err != nil {
+		t.Fatal(err)
+	}
+	strided, err := FreqRespEst(uRow, yRow, dt, &FreqRespEstOpts{NFFT: 512})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(contig.Omega) != len(strided.Omega) {
+		t.Fatalf("strided frequency count = %d, want %d", len(strided.Omega), len(contig.Omega))
+	}
+	for f := range contig.Omega {
+		want := contig.H.At(f, 0, 0)
+		got := strided.H.At(f, 0, 0)
+		if cmplx.Abs(got-want) > 1e-12 {
+			t.Fatalf("freq %d: strided estimate = %v, want %v", f, got, want)
+		}
+	}
+}
+
+func TestArchitecturePolynomialChannelAlgebraCoversLeadingZerosAndZeroGain(t *testing.T) {
+	tf := &TransferFunc{
+		Num: [][][]float64{
+			{{0, 0, 1, 2}, {0}},
+		},
+		Den: [][]float64{{1, 3, 2}},
+		Dt:  0,
+	}
+	z, err := tf.ZPK()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(z.Zeros[0][0]) != 1 || cmplx.Abs(z.Zeros[0][0][0]+2) > 1e-12 {
+		t.Fatalf("leading-zero channel zeros = %v, want [-2]", z.Zeros[0][0])
+	}
+	if len(z.Zeros[0][1]) != 0 || z.Gain[0][1] != 0 {
+		t.Fatalf("zero-gain channel = zeros %v gain %v, want no zeros and zero gain", z.Zeros[0][1], z.Gain[0][1])
+	}
+
+	roundtrip, err := z.TransferFunction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []complex128{1i, 2 + 0.5i} {
+		want := tf.Eval(s)
+		got := roundtrip.Eval(s)
+		for j := range want[0] {
+			if cmplx.Abs(got[0][j]-want[0][j]) > 1e-10 {
+				t.Fatalf("channel %d at %v = %v, want %v", j, s, got[0][j], want[0][j])
+			}
+		}
+	}
+}
+
+func TestArchitectureZerosUsePolynomialRootSemantics(t *testing.T) {
+	sys, err := NewFromSlices(2, 1, 1,
+		[]float64{
+			0, 1,
+			-6, -5,
+		},
+		[]float64{0, 1},
+		[]float64{2, 1},
+		[]float64{0},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tf, err := sys.TransferFunction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := Poly(tf.TF.Num[0][0]).Roots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := sys.Zeros()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !complexSetsApprox(got, want, 1e-10) {
+		t.Fatalf("zeros = %v, want polynomial roots %v", got, want)
+	}
+}
+
+func complexSetsApprox(got, want []complex128, tol float64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	used := make([]bool, len(want))
+	for _, g := range got {
+		found := false
+		for i, w := range want {
+			if !used[i] && cmplx.Abs(g-w) <= tol {
+				used[i] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestArchitectureControllerObserverAssemblyPreservesDiscreteMIMOBehavior(t *testing.T) {
+	sys, err := NewFromSlices(3, 2, 2,
+		[]float64{
+			0.7, 0.2, 0,
+			-0.1, 0.6, 0.15,
+			0.05, -0.2, 0.5,
+		},
+		[]float64{
+			0.2, 0,
+			0.1, 0.3,
+			0, 0.2,
+		},
+		[]float64{
+			1, 0.1, 0,
+			0, 1, -0.2,
+		},
+		[]float64{0, 0, 0, 0},
+		0.1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	Q := eye(3)
+	R := eye(2)
+	Qn := eye(2)
+	Rn := eye(2)
+
+	res, err := Lqg(sys, Q, R, Qn, Rn, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Controller.Dt != sys.Dt {
+		t.Fatalf("controller sample time = %v, want %v", res.Controller.Dt, sys.Dt)
+	}
+	n, m, p := res.Controller.Dims()
+	if n != 3 || m != 2 || p != 2 {
+		t.Fatalf("controller dims = (%d,%d,%d), want (3,2,2)", n, m, p)
+	}
+	kr, kc := res.K.Dims()
+	if kr != 2 || kc != 3 {
+		t.Fatalf("state-feedback gain dims = (%d,%d), want (2,3)", kr, kc)
+	}
+	lr, lc := res.L.Dims()
+	if lr != 3 || lc != 2 {
+		t.Fatalf("observer gain dims = (%d,%d), want (3,2)", lr, lc)
+	}
+	cl, err := Feedback(sys, res.Controller, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable, err := cl.IsStable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stable {
+		poles, _ := cl.Poles()
+		t.Fatalf("observer-based closed-loop poles = %v, want stable", poles)
+	}
+}
+
+func TestArchitectureControllerObserverAssemblyRejectsDescriptorModel(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{-1, 0.5, 0, -2}),
+		mat.NewDense(2, 1, []float64{1, 0}),
+		mat.NewDense(1, 2, []float64{1, 0}),
+		mat.NewDense(1, 1, nil),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.E = mat.NewDense(2, 2, []float64{2, 0, 0, 1})
+	_, err = Lqg(sys, eye(2), eye(1), eye(1), eye(1), nil)
+	if !errors.Is(err, ErrDescriptorRiccati) {
+		t.Fatalf("Lqg descriptor error = %v, want ErrDescriptorRiccati", err)
+	}
+}

--- a/controller_observer_policy.go
+++ b/controller_observer_policy.go
@@ -1,0 +1,60 @@
+package controlsys
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type controllerObserverPolicy struct {
+	sys     *System
+	context string
+	n       int
+	m       int
+	p       int
+}
+
+func newControllerObserverPolicy(sys *System, context string) (controllerObserverPolicy, error) {
+	n, m, p := sys.Dims()
+	if n == 0 {
+		return controllerObserverPolicy{}, fmt.Errorf("%s: system has no states: %w", context, ErrDimensionMismatch)
+	}
+	if err := requireStandardEstimatorSystem(sys, context); err != nil {
+		return controllerObserverPolicy{}, err
+	}
+	return controllerObserverPolicy{sys: sys, context: context, n: n, m: m, p: p}, nil
+}
+
+func (p controllerObserverPolicy) validateNoise(Qn, Rn *mat.Dense) error {
+	if err := validateCovarianceRole(p.context, covarianceProcessNoise, Qn, p.m); err != nil {
+		return err
+	}
+	return validateCovarianceRole(p.context, covarianceMeasurementNoise, Rn, p.p)
+}
+
+func (p controllerObserverPolicy) regulator(Q, R *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) {
+	if p.sys.IsContinuous() {
+		return Lqr(p.sys.A, p.sys.B, Q, R, opts)
+	}
+	return Dlqr(p.sys.A, p.sys.B, Q, R, opts)
+}
+
+func (p controllerObserverPolicy) estimator(Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) {
+	return Kalman(p.sys, Qn, Rn, opts)
+}
+
+func validateRegulatorGains(context string, sys *System, K, L *mat.Dense) (n, m, p int, err error) {
+	n, m, p = sys.Dims()
+	if n == 0 {
+		return 0, 0, 0, fmt.Errorf("%s: system has no states: %w", context, ErrDimensionMismatch)
+	}
+	kr, kc := K.Dims()
+	if kr != m || kc != n {
+		return 0, 0, 0, ErrDimensionMismatch
+	}
+	lr, lc := L.Dims()
+	if lr != n || lc != p {
+		return 0, 0, 0, ErrDimensionMismatch
+	}
+	return n, m, p, nil
+}

--- a/ekf.go
+++ b/ekf.go
@@ -60,9 +60,10 @@ func NewEKF(model *EKFModel, x0 *mat.VecDense, P0 *mat.Dense) (*EKF, error) {
 		return nil, fmt.Errorf("NewEKF: R is %dx%d, must be square: %w", rr, rc, ErrDimensionMismatch)
 	}
 	p := rr
+	contract := newLocalApproximationContract("NewEKF", n, 0, p)
 
 	hProbe := model.H(x0)
-	if err := validateVecResult("NewEKF: H(x0)", hProbe, p); err != nil {
+	if err := contract.validateMeasurementResult("H(x0)", hProbe); err != nil {
 		return nil, err
 	}
 
@@ -91,13 +92,14 @@ func NewEKF(model *EKFModel, x0 *mat.VecDense, P0 *mat.Dense) (*EKF, error) {
 
 // Predict performs the EKF prediction step using control input u.
 func (e *EKF) Predict(u *mat.VecDense) error {
+	contract := newLocalApproximationContract("EKF.Predict", e.n, 0, e.p)
 	xPred := e.model.F(e.X, u)
-	if err := validateVecResult("EKF.Predict: F", xPred, e.n); err != nil {
+	if err := contract.validateStateResult("F", xPred); err != nil {
 		return err
 	}
 
 	A := e.model.FJac(e.X, u)
-	if err := validateDenseResult("EKF.Predict: FJac", A, e.n, e.n); err != nil {
+	if err := contract.validateStateJacobian("FJac", A); err != nil {
 		return err
 	}
 
@@ -115,14 +117,15 @@ func (e *EKF) Update(z *mat.VecDense) error {
 	if z.Len() != e.p {
 		return fmt.Errorf("EKF.Update: z length %d, want %d: %w", z.Len(), e.p, ErrDimensionMismatch)
 	}
+	contract := newLocalApproximationContract("EKF.Update", e.n, 0, e.p)
 
 	yPred := e.model.H(e.X)
-	if err := validateVecResult("EKF.Update: H", yPred, e.p); err != nil {
+	if err := contract.validateMeasurementResult("H", yPred); err != nil {
 		return err
 	}
 
 	C := e.model.HJac(e.X)
-	if err := validateDenseResult("EKF.Update: HJac", C, e.p, e.n); err != nil {
+	if err := contract.validateMeasurementJacobian("HJac", C); err != nil {
 		return err
 	}
 

--- a/freqrestest.go
+++ b/freqrestest.go
@@ -24,6 +24,17 @@ type FreqRespEstResult struct {
 	Coherence []float64
 }
 
+type freqRespEstPlan struct {
+	nfft     int
+	noverlap int
+	hop      int
+	nSeg     int
+	nFreq    int
+	method   string
+	win      []float64
+	winPower float64
+}
+
 func (r *FreqRespEstResult) CoherenceAt(freq, output, input int) float64 {
 	if r.Coherence == nil {
 		return 0
@@ -44,61 +55,29 @@ func FreqRespEst(input, output *mat.Dense, dt float64, opts *FreqRespEstOpts) (*
 		return nil, err
 	}
 
-	nfft, winFunc, noverlap, method := resolveOpts(opts, N)
-	if err := validateFreqRespEstMethod(method, m, p); err != nil {
+	plan, err := newFreqRespEstPlan(opts, N, m, p)
+	if err != nil {
 		return nil, err
 	}
 
-	win := make([]float64, nfft)
-	for i := range win {
-		win[i] = 1
-	}
-	winFunc(win)
-
-	winPower := 0.0
-	for _, w := range win {
-		winPower += w * w
-	}
-	winPower /= float64(nfft)
-
-	if method == "fft" {
-		return freqRespEstFFT(input, output, dt, m, p, N, nfft, win, winPower)
+	if plan.method == "fft" {
+		return freqRespEstFFT(input, output, dt, m, p, N, plan.nfft, plan.win, plan.winPower)
 	}
 
-	hop := nfft - noverlap
-	nSeg := (N - noverlap) / hop
-	if nSeg < 1 {
-		nfft = N
-		noverlap = 0
-		hop = N
-		nSeg = 1
-		win = make([]float64, nfft)
-		for i := range win {
-			win[i] = 1
-		}
-		winFunc(win)
-		winPower = 0
-		for _, w := range win {
-			winPower += w * w
-		}
-		winPower /= float64(nfft)
-	}
-
-	nFreq := nfft/2 + 1
-	fft := fourier.NewFFT(nfft)
-	seg := make([]float64, nfft)
-	coeff := make([]complex128, nFreq)
+	fft := fourier.NewFFT(plan.nfft)
+	seg := make([]float64, plan.nfft)
+	coeff := make([]complex128, plan.nFreq)
 
 	inRaw := input.RawMatrix()
 	outRaw := output.RawMatrix()
 
 	if m == 1 && p == 1 {
-		return welchSISO(fft, seg, coeff, win, inRaw.Data, inRaw.Stride, outRaw.Data, outRaw.Stride,
-			dt, nfft, nFreq, hop, nSeg, winPower, method)
+		return welchSISO(fft, seg, coeff, plan.win, inRaw.Data, inRaw.Stride, outRaw.Data, outRaw.Stride,
+			dt, plan.nfft, plan.nFreq, plan.hop, plan.nSeg, plan.winPower, plan.method)
 	}
 
-	return welchMIMO(fft, seg, coeff, win, input, output,
-		dt, m, p, nfft, nFreq, hop, nSeg, winPower, method)
+	return welchMIMO(fft, seg, coeff, plan.win, input, output,
+		dt, m, p, plan.nfft, plan.nFreq, plan.hop, plan.nSeg, plan.winPower, plan.method)
 }
 
 func validateFreqRespEstMethod(method string, m, p int) error {
@@ -145,6 +124,44 @@ func resolveOpts(opts *FreqRespEstOpts, N int) (nfft int, winFunc func([]float64
 	}
 
 	return
+}
+
+func newFreqRespEstPlan(opts *FreqRespEstOpts, N, m, p int) (freqRespEstPlan, error) {
+	nfft, winFunc, noverlap, method := resolveOpts(opts, N)
+	if err := validateFreqRespEstMethod(method, m, p); err != nil {
+		return freqRespEstPlan{}, err
+	}
+
+	plan := freqRespEstPlan{nfft: nfft, noverlap: noverlap, method: method}
+	plan.rebuildWindow(winFunc)
+	if method == "fft" {
+		return plan, nil
+	}
+
+	plan.hop = plan.nfft - plan.noverlap
+	plan.nSeg = (N - plan.noverlap) / plan.hop
+	if plan.nSeg < 1 {
+		plan.nfft = N
+		plan.noverlap = 0
+		plan.hop = N
+		plan.nSeg = 1
+		plan.rebuildWindow(winFunc)
+	}
+	return plan, nil
+}
+
+func (p *freqRespEstPlan) rebuildWindow(winFunc func([]float64) []float64) {
+	p.win = make([]float64, p.nfft)
+	for i := range p.win {
+		p.win[i] = 1
+	}
+	winFunc(p.win)
+	p.winPower = 0
+	for _, w := range p.win {
+		p.winPower += w * w
+	}
+	p.winPower /= float64(p.nfft)
+	p.nFreq = p.nfft/2 + 1
 }
 
 func welchSISO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,

--- a/linearize.go
+++ b/linearize.go
@@ -2,7 +2,6 @@ package controlsys
 
 import (
 	"fmt"
-	"math"
 
 	"gonum.org/v1/gonum/mat"
 )
@@ -22,102 +21,14 @@ func Linearize(model *NonlinearModel, x0, u0 *mat.VecDense) (*System, error) {
 	if model.F == nil || model.H == nil {
 		return nil, fmt.Errorf("controlsys: nil F or H function: %w", ErrDimensionMismatch)
 	}
-	if x0 == nil || u0 == nil {
-		return nil, fmt.Errorf("controlsys: nil x0 or u0: %w", ErrDimensionMismatch)
+	contract := newLocalApproximationContract("Linearize", model.N, model.M, model.P)
+	if err := contract.validateOperatingPoint(x0, u0); err != nil {
+		return nil, err
 	}
-	if x0.Len() != model.N {
-		return nil, fmt.Errorf("controlsys: x0 length %d != N %d: %w", x0.Len(), model.N, ErrDimensionMismatch)
+	A, B, C, D, err := finiteDifferenceLocalModel(contract, model.F, model.H, x0, u0)
+	if err != nil {
+		return nil, err
 	}
-	if u0.Len() != model.M {
-		return nil, fmt.Errorf("controlsys: u0 length %d != M %d: %w", u0.Len(), model.M, ErrDimensionMismatch)
-	}
-
-	sqrtEps := math.Sqrt(eps())
-	n, m, p := model.N, model.M, model.P
-
-	aData := make([]float64, n*n)
-	bData := make([]float64, n*m)
-	cData := make([]float64, p*n)
-	dData := make([]float64, p*m)
-
-	xp := mat.NewVecDense(n, nil)
-	xm := mat.NewVecDense(n, nil)
-
-	for j := 0; j < n; j++ {
-		h := sqrtEps * math.Max(math.Abs(x0.AtVec(j)), 1.0)
-		inv2h := 1.0 / (2.0 * h)
-
-		xp.CopyVec(x0)
-		xm.CopyVec(x0)
-		xp.SetVec(j, x0.AtVec(j)+h)
-		xm.SetVec(j, x0.AtVec(j)-h)
-
-		fp := model.F(xp, u0)
-		fm := model.F(xm, u0)
-		if err := validateVecResult("Linearize: F(x+h,u)", fp, n); err != nil {
-			return nil, err
-		}
-		if err := validateVecResult("Linearize: F(x-h,u)", fm, n); err != nil {
-			return nil, err
-		}
-		for i := 0; i < n; i++ {
-			aData[i*n+j] = (fp.AtVec(i) - fm.AtVec(i)) * inv2h
-		}
-
-		hp := model.H(xp, u0)
-		hm := model.H(xm, u0)
-		if err := validateVecResult("Linearize: H(x+h,u)", hp, p); err != nil {
-			return nil, err
-		}
-		if err := validateVecResult("Linearize: H(x-h,u)", hm, p); err != nil {
-			return nil, err
-		}
-		for i := 0; i < p; i++ {
-			cData[i*n+j] = (hp.AtVec(i) - hm.AtVec(i)) * inv2h
-		}
-	}
-
-	up := mat.NewVecDense(m, nil)
-	um := mat.NewVecDense(m, nil)
-
-	for j := 0; j < m; j++ {
-		h := sqrtEps * math.Max(math.Abs(u0.AtVec(j)), 1.0)
-		inv2h := 1.0 / (2.0 * h)
-
-		up.CopyVec(u0)
-		um.CopyVec(u0)
-		up.SetVec(j, u0.AtVec(j)+h)
-		um.SetVec(j, u0.AtVec(j)-h)
-
-		fp := model.F(x0, up)
-		fm := model.F(x0, um)
-		if err := validateVecResult("Linearize: F(x,u+h)", fp, n); err != nil {
-			return nil, err
-		}
-		if err := validateVecResult("Linearize: F(x,u-h)", fm, n); err != nil {
-			return nil, err
-		}
-		for i := 0; i < n; i++ {
-			bData[i*m+j] = (fp.AtVec(i) - fm.AtVec(i)) * inv2h
-		}
-
-		hp := model.H(x0, up)
-		hm := model.H(x0, um)
-		if err := validateVecResult("Linearize: H(x,u+h)", hp, p); err != nil {
-			return nil, err
-		}
-		if err := validateVecResult("Linearize: H(x,u-h)", hm, p); err != nil {
-			return nil, err
-		}
-		for i := 0; i < p; i++ {
-			dData[i*m+j] = (hp.AtVec(i) - hm.AtVec(i)) * inv2h
-		}
-	}
-
-	A := mat.NewDense(n, n, aData)
-	B := mat.NewDense(n, m, bData)
-	C := mat.NewDense(p, n, cData)
-	D := mat.NewDense(p, m, dData)
 
 	return New(A, B, C, D, 0)
 }

--- a/local_approx.go
+++ b/local_approx.go
@@ -2,9 +2,50 @@ package controlsys
 
 import (
 	"fmt"
+	"math"
 
 	"gonum.org/v1/gonum/mat"
 )
+
+type localApproximationContract struct {
+	context string
+	n       int
+	m       int
+	p       int
+}
+
+func newLocalApproximationContract(context string, n, m, p int) localApproximationContract {
+	return localApproximationContract{context: context, n: n, m: m, p: p}
+}
+
+func (c localApproximationContract) validateOperatingPoint(x0, u0 *mat.VecDense) error {
+	if x0 == nil || u0 == nil {
+		return fmt.Errorf("%s: nil x0 or u0: %w", c.context, ErrDimensionMismatch)
+	}
+	if x0.Len() != c.n {
+		return fmt.Errorf("%s: x0 length %d != N %d: %w", c.context, x0.Len(), c.n, ErrDimensionMismatch)
+	}
+	if u0.Len() != c.m {
+		return fmt.Errorf("%s: u0 length %d != M %d: %w", c.context, u0.Len(), c.m, ErrDimensionMismatch)
+	}
+	return nil
+}
+
+func (c localApproximationContract) validateStateResult(label string, v *mat.VecDense) error {
+	return validateVecResult(c.context+": "+label, v, c.n)
+}
+
+func (c localApproximationContract) validateMeasurementResult(label string, v *mat.VecDense) error {
+	return validateVecResult(c.context+": "+label, v, c.p)
+}
+
+func (c localApproximationContract) validateStateJacobian(label string, m *mat.Dense) error {
+	return validateDenseResult(c.context+": "+label, m, c.n, c.n)
+}
+
+func (c localApproximationContract) validateMeasurementJacobian(label string, m *mat.Dense) error {
+	return validateDenseResult(c.context+": "+label, m, c.p, c.n)
+}
 
 func validateVecResult(context string, v *mat.VecDense, want int) error {
 	if v == nil {
@@ -14,6 +55,99 @@ func validateVecResult(context string, v *mat.VecDense, want int) error {
 		return fmt.Errorf("%s returned length %d, want %d: %w", context, v.Len(), want, ErrDimensionMismatch)
 	}
 	return nil
+}
+
+func finiteDifferenceLocalModel(
+	contract localApproximationContract,
+	state func(x, u *mat.VecDense) *mat.VecDense,
+	measurement func(x, u *mat.VecDense) *mat.VecDense,
+	x0, u0 *mat.VecDense,
+) (A, B, C, D *mat.Dense, err error) {
+	sqrtEps := math.Sqrt(eps())
+	n, m, p := contract.n, contract.m, contract.p
+
+	aData := make([]float64, n*n)
+	bData := make([]float64, n*m)
+	cData := make([]float64, p*n)
+	dData := make([]float64, p*m)
+
+	xp := mat.NewVecDense(n, nil)
+	xm := mat.NewVecDense(n, nil)
+	for j := range n {
+		h := sqrtEps * math.Max(math.Abs(x0.AtVec(j)), 1.0)
+		inv2h := 1.0 / (2.0 * h)
+
+		xp.CopyVec(x0)
+		xm.CopyVec(x0)
+		xp.SetVec(j, x0.AtVec(j)+h)
+		xm.SetVec(j, x0.AtVec(j)-h)
+
+		fp := state(xp, u0)
+		fm := state(xm, u0)
+		if err := contract.validateStateResult("F(x+h,u)", fp); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		if err := contract.validateStateResult("F(x-h,u)", fm); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		for i := range n {
+			aData[i*n+j] = (fp.AtVec(i) - fm.AtVec(i)) * inv2h
+		}
+
+		hp := measurement(xp, u0)
+		hm := measurement(xm, u0)
+		if err := contract.validateMeasurementResult("H(x+h,u)", hp); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		if err := contract.validateMeasurementResult("H(x-h,u)", hm); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		for i := range p {
+			cData[i*n+j] = (hp.AtVec(i) - hm.AtVec(i)) * inv2h
+		}
+	}
+
+	up := mat.NewVecDense(m, nil)
+	um := mat.NewVecDense(m, nil)
+	for j := range m {
+		h := sqrtEps * math.Max(math.Abs(u0.AtVec(j)), 1.0)
+		inv2h := 1.0 / (2.0 * h)
+
+		up.CopyVec(u0)
+		um.CopyVec(u0)
+		up.SetVec(j, u0.AtVec(j)+h)
+		um.SetVec(j, u0.AtVec(j)-h)
+
+		fp := state(x0, up)
+		fm := state(x0, um)
+		if err := contract.validateStateResult("F(x,u+h)", fp); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		if err := contract.validateStateResult("F(x,u-h)", fm); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		for i := range n {
+			bData[i*m+j] = (fp.AtVec(i) - fm.AtVec(i)) * inv2h
+		}
+
+		hp := measurement(x0, up)
+		hm := measurement(x0, um)
+		if err := contract.validateMeasurementResult("H(x,u+h)", hp); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		if err := contract.validateMeasurementResult("H(x,u-h)", hm); err != nil {
+			return nil, nil, nil, nil, err
+		}
+		for i := range p {
+			dData[i*m+j] = (hp.AtVec(i) - hm.AtVec(i)) * inv2h
+		}
+	}
+
+	return mat.NewDense(n, n, aData),
+		mat.NewDense(n, m, bData),
+		mat.NewDense(p, n, cData),
+		mat.NewDense(p, m, dData),
+		nil
 }
 
 func validateDenseResult(context string, m *mat.Dense, wantR, wantC int) error {

--- a/lqg.go
+++ b/lqg.go
@@ -18,26 +18,17 @@ type LqgResult struct {
 // Q, R are state/input weights for LQR; Qn, Rn are process/measurement noise covariances.
 // Returns the observer-based controller and all intermediate gains and Riccati solutions.
 func Lqg(sys *System, Q, R, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*LqgResult, error) {
-	n, _, _ := sys.Dims()
-	if n == 0 {
-		return nil, fmt.Errorf("Lqg: system has no states: %w", ErrDimensionMismatch)
-	}
-	if err := requireStandardEstimatorSystem(sys, "Lqg"); err != nil {
+	policy, err := newControllerObserverPolicy(sys, "Lqg")
+	if err != nil {
 		return nil, err
 	}
 
-	var kRes *RiccatiResult
-	var err error
-	if sys.IsContinuous() {
-		kRes, err = Lqr(sys.A, sys.B, Q, R, opts)
-	} else {
-		kRes, err = Dlqr(sys.A, sys.B, Q, R, opts)
-	}
+	kRes, err := policy.regulator(Q, R, opts)
 	if err != nil {
 		return nil, fmt.Errorf("Lqg: %w", err)
 	}
 
-	lRes, err := Kalman(sys, Qn, Rn, opts)
+	lRes, err := policy.estimator(Qn, Rn, opts)
 	if err != nil {
 		return nil, fmt.Errorf("Lqg: %w", err)
 	}

--- a/observer.go
+++ b/observer.go
@@ -36,26 +36,7 @@ func Lqe(A, G, C, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) 
 		return &RiccatiResult{X: &mat.Dense{}, K: &mat.Dense{}, Eig: nil}, nil
 	}
 
-	GQnGt := inputNoiseIntensity(G, Qn, n, g)
-
-	// Transpose A and C into flat arrays for Care(A', C', ...)
-	atData := make([]float64, n*n)
-	aRaw := A.RawMatrix()
-	for i := range n {
-		for j := range n {
-			atData[i*n+j] = aRaw.Data[j*aRaw.Stride+i]
-		}
-	}
-	At := mat.NewDense(n, n, atData)
-
-	cRaw := C.RawMatrix()
-	ctData := make([]float64, n*p)
-	for i := range n {
-		for j := range p {
-			ctData[i*p+j] = cRaw.Data[j*cRaw.Stride+i]
-		}
-	}
-	Ct := mat.NewDense(n, p, ctData)
+	GQnGt, At, Ct := dualRiccatiSetup(A, G, C, Qn, n, g, p)
 
 	res, err := Care(At, Ct, GQnGt, Rn, opts)
 	if err != nil {
@@ -74,17 +55,11 @@ func Lqe(A, G, C, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) 
 //
 // Qn is m×m (process noise covariance), Rn is p×p (measurement noise covariance).
 func Kalman(sys *System, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) {
-	n, m, p := sys.Dims()
-	if n == 0 {
-		return nil, fmt.Errorf("Kalman: system has no states: %w", ErrDimensionMismatch)
-	}
-	if err := requireStandardEstimatorSystem(sys, "Kalman"); err != nil {
+	policy, err := newControllerObserverPolicy(sys, "Kalman")
+	if err != nil {
 		return nil, err
 	}
-	if err := validateCovarianceRole("Kalman", covarianceProcessNoise, Qn, m); err != nil {
-		return nil, err
-	}
-	if err := validateCovarianceRole("Kalman", covarianceMeasurementNoise, Rn, p); err != nil {
+	if err := policy.validateNoise(Qn, Rn); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +67,7 @@ func Kalman(sys *System, Qn, Rn *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, 
 		return Lqe(sys.A, sys.B, sys.C, Qn, Rn, opts)
 	}
 
-	GQnGt, At, Ct := dualRiccatiSetup(sys.A, sys.B, sys.C, Qn, n, m, p)
+	GQnGt, At, Ct := dualRiccatiSetup(sys.A, sys.B, sys.C, Qn, policy.n, policy.m, policy.p)
 
 	res, err := Dare(At, Ct, GQnGt, Rn, opts)
 	if err != nil {
@@ -115,19 +90,14 @@ func Kalmd(sys *System, Qn, Rn *mat.Dense, dt float64, opts *RiccatiOpts) (*Ricc
 	if dt <= 0 {
 		return nil, ErrInvalidSampleTime
 	}
-	n, m, p := sys.Dims()
-	if n == 0 {
-		return nil, fmt.Errorf("Kalmd: system has no states: %w", ErrDimensionMismatch)
-	}
-	if err := requireStandardEstimatorSystem(sys, "Kalmd"); err != nil {
+	policy, err := newControllerObserverPolicy(sys, "Kalmd")
+	if err != nil {
 		return nil, err
 	}
-	if err := validateCovarianceRole("Kalmd", covarianceProcessNoise, Qn, m); err != nil {
+	if err := policy.validateNoise(Qn, Rn); err != nil {
 		return nil, err
 	}
-	if err := validateCovarianceRole("Kalmd", covarianceMeasurementNoise, Rn, p); err != nil {
-		return nil, err
-	}
+	n, m, p := policy.n, policy.m, policy.p
 
 	GQnGt := inputNoiseIntensity(sys.B, Qn, n, m)
 
@@ -265,17 +235,9 @@ func Estim(sys *System, L *mat.Dense) (*System, error) {
 //
 // K is m×n, L is n×p. Returns system with n states, p inputs, m outputs.
 func Reg(sys *System, K, L *mat.Dense) (*System, error) {
-	n, m, p := sys.Dims()
-	if n == 0 {
-		return nil, fmt.Errorf("Reg: system has no states: %w", ErrDimensionMismatch)
-	}
-	kr, kc := K.Dims()
-	if kr != m || kc != n {
-		return nil, ErrDimensionMismatch
-	}
-	lr, lc := L.Dims()
-	if lr != n || lc != p {
-		return nil, ErrDimensionMismatch
+	n, m, p, err := validateRegulatorGains("Reg", sys, K, L)
+	if err != nil {
+		return nil, err
 	}
 
 	// Ar = A - B*K - L*C + L*D*K

--- a/polynomial_channel.go
+++ b/polynomial_channel.go
@@ -1,0 +1,83 @@
+package controlsys
+
+import "fmt"
+
+func trimLeadingFloatZeros(p []float64) []float64 {
+	i := 0
+	for i < len(p) && p[i] == 0 {
+		i++
+	}
+	if i == len(p) {
+		return []float64{0}
+	}
+	return p[i:]
+}
+
+func channelPolynomialGain(num, den []float64) float64 {
+	num = trimLeadingFloatZeros(num)
+	den = trimLeadingFloatZeros(den)
+	if len(num) == 1 && num[0] == 0 {
+		return 0
+	}
+	return num[0] / den[0]
+}
+
+func validateTransferChannelShape(tf *TransferFunc) (p, m int, err error) {
+	if tf == nil {
+		return 0, 0, fmt.Errorf("TransferFunc: nil model: %w", ErrDimensionMismatch)
+	}
+	p = len(tf.Den)
+	if p == 0 {
+		return 0, 0, nil
+	}
+	if len(tf.Num) != p {
+		return 0, 0, fmt.Errorf("TransferFunc: numerator has %d rows, want %d: %w", len(tf.Num), p, ErrDimensionMismatch)
+	}
+	m = len(tf.Num[0])
+	if m == 0 {
+		return 0, 0, fmt.Errorf("TransferFunc: zero input channels: %w", ErrDimensionMismatch)
+	}
+	if tf.Delay != nil && len(tf.Delay) != p {
+		return 0, 0, fmt.Errorf("TransferFunc: delay has %d rows, want %d: %w", len(tf.Delay), p, ErrDimensionMismatch)
+	}
+	for i := range p {
+		if len(tf.Den[i]) == 0 {
+			return 0, 0, fmt.Errorf("TransferFunc: row %d has empty denominator: %w", i, ErrDimensionMismatch)
+		}
+		if len(tf.Num[i]) != m {
+			return 0, 0, fmt.Errorf("TransferFunc: row %d has %d numerator channels, want %d: %w", i, len(tf.Num[i]), m, ErrDimensionMismatch)
+		}
+		if tf.Delay != nil && len(tf.Delay[i]) != m {
+			return 0, 0, fmt.Errorf("TransferFunc: row %d has %d delays, want %d: %w", i, len(tf.Delay[i]), m, ErrDimensionMismatch)
+		}
+		for j := range m {
+			if len(tf.Num[i][j]) == 0 {
+				return 0, 0, fmt.Errorf("TransferFunc: channel (%d,%d) has empty numerator: %w", i, j, ErrDimensionMismatch)
+			}
+		}
+	}
+	return p, m, nil
+}
+
+func validateZPKChannelShape(z *ZPK) (p, m int, err error) {
+	if z == nil {
+		return 0, 0, fmt.Errorf("ZPK: nil model: %w", ErrDimensionMismatch)
+	}
+	p = len(z.Gain)
+	if p == 0 {
+		return 0, 0, fmt.Errorf("ZPK: zero output channels: %w", ErrDimensionMismatch)
+	}
+	m = len(z.Gain[0])
+	if m == 0 {
+		return 0, 0, fmt.Errorf("ZPK: zero input channels: %w", ErrDimensionMismatch)
+	}
+	if len(z.Zeros) != p || len(z.Poles) != p {
+		return 0, 0, fmt.Errorf("ZPK: channel rows do not match gain rows: %w", ErrDimensionMismatch)
+	}
+	for i := range p {
+		if len(z.Gain[i]) != m || len(z.Zeros[i]) != m || len(z.Poles[i]) != m {
+			return 0, 0, fmt.Errorf("ZPK: row %d channel count mismatch: %w", i, ErrDimensionMismatch)
+		}
+	}
+	return p, m, nil
+}

--- a/transfer.go
+++ b/transfer.go
@@ -31,40 +31,7 @@ func (tf *TransferFunc) Dims() (p, m int) {
 }
 
 func (tf *TransferFunc) validateShape() (p, m int, err error) {
-	if tf == nil {
-		return 0, 0, fmt.Errorf("TransferFunc: nil model: %w", ErrDimensionMismatch)
-	}
-	p = len(tf.Den)
-	if p == 0 {
-		return 0, 0, nil
-	}
-	if len(tf.Num) != p {
-		return 0, 0, fmt.Errorf("TransferFunc: numerator has %d rows, want %d: %w", len(tf.Num), p, ErrDimensionMismatch)
-	}
-	m = len(tf.Num[0])
-	if m == 0 {
-		return 0, 0, fmt.Errorf("TransferFunc: zero input channels: %w", ErrDimensionMismatch)
-	}
-	if tf.Delay != nil && len(tf.Delay) != p {
-		return 0, 0, fmt.Errorf("TransferFunc: delay has %d rows, want %d: %w", len(tf.Delay), p, ErrDimensionMismatch)
-	}
-	for i := 0; i < p; i++ {
-		if len(tf.Den[i]) == 0 {
-			return 0, 0, fmt.Errorf("TransferFunc: row %d has empty denominator: %w", i, ErrDimensionMismatch)
-		}
-		if len(tf.Num[i]) != m {
-			return 0, 0, fmt.Errorf("TransferFunc: row %d has %d numerator channels, want %d: %w", i, len(tf.Num[i]), m, ErrDimensionMismatch)
-		}
-		if tf.Delay != nil && len(tf.Delay[i]) != m {
-			return 0, 0, fmt.Errorf("TransferFunc: row %d has %d delays, want %d: %w", i, len(tf.Delay[i]), m, ErrDimensionMismatch)
-		}
-		for j := 0; j < m; j++ {
-			if len(tf.Num[i][j]) == 0 {
-				return 0, 0, fmt.Errorf("TransferFunc: channel (%d,%d) has empty numerator: %w", i, j, ErrDimensionMismatch)
-			}
-		}
-	}
-	return p, m, nil
+	return validateTransferChannelShape(tf)
 }
 
 func (tf *TransferFunc) Eval(s complex128) [][]complex128 {

--- a/zeros.go
+++ b/zeros.go
@@ -40,33 +40,11 @@ func sisoZeros(sys *System) (*ZerosResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	num := tfr.TF.Num[0][0]
-	if len(num) <= 1 {
-		return &ZerosResult{}, nil
+	zeros, err := Poly(tfr.TF.Num[0][0]).Roots()
+	if err != nil {
+		return nil, err
 	}
-
-	lead := num[0]
-	if lead == 0 {
-		return &ZerosResult{}, nil
-	}
-
-	deg := len(num) - 1
-	data := make([]float64, deg*deg)
-	for i := 0; i < deg; i++ {
-		data[i*deg+deg-1] = -num[deg-i] / lead
-		if i > 0 {
-			data[i*deg+i-1] = 1
-		}
-	}
-	comp := mat.NewDense(deg, deg, data)
-
-	var eig mat.Eigen
-	if !eig.Factorize(comp, mat.EigenNone) {
-		return nil, ErrSingularTransform
-	}
-	zeros := eig.Values(nil)
-	sortZeros(zeros)
-	return &ZerosResult{Zeros: zeros, Rank: deg}, nil
+	return &ZerosResult{Zeros: zeros, Rank: len(zeros)}, nil
 }
 
 func mimoZeros(sys *System) (*ZerosResult, error) {

--- a/zpk.go
+++ b/zpk.go
@@ -1,7 +1,6 @@
 package controlsys
 
 import (
-	"fmt"
 	"math/cmplx"
 	"sort"
 )
@@ -85,26 +84,7 @@ func (z *ZPK) Dims() (p, m int) {
 }
 
 func (z *ZPK) validateShape() (p, m int, err error) {
-	if z == nil {
-		return 0, 0, fmt.Errorf("ZPK: nil model: %w", ErrDimensionMismatch)
-	}
-	p = len(z.Gain)
-	if p == 0 {
-		return 0, 0, fmt.Errorf("ZPK: zero output channels: %w", ErrDimensionMismatch)
-	}
-	m = len(z.Gain[0])
-	if m == 0 {
-		return 0, 0, fmt.Errorf("ZPK: zero input channels: %w", ErrDimensionMismatch)
-	}
-	if len(z.Zeros) != p || len(z.Poles) != p {
-		return 0, 0, fmt.Errorf("ZPK: channel rows do not match gain rows: %w", ErrDimensionMismatch)
-	}
-	for i := 0; i < p; i++ {
-		if len(z.Gain[i]) != m || len(z.Zeros[i]) != m || len(z.Poles[i]) != m {
-			return 0, 0, fmt.Errorf("ZPK: row %d channel count mismatch: %w", i, ErrDimensionMismatch)
-		}
-	}
-	return p, m, nil
+	return validateZPKChannelShape(z)
 }
 
 func (z *ZPK) IsContinuous() bool { return z.Dt == 0 }
@@ -229,8 +209,8 @@ func (tf *TransferFunc) ZPK() (*ZPK, error) {
 		for j := 0; j < m; j++ {
 			z.Poles[i][j] = copyComplex(rowPoles)
 
-			num := tf.Num[i][j]
-			if len(num) == 0 || (len(num) == 1 && num[0] == 0) {
+			num := trimLeadingFloatZeros(tf.Num[i][j])
+			if len(num) == 1 && num[0] == 0 {
 				z.Gain[i][j] = 0
 				continue
 			}
@@ -240,7 +220,7 @@ func (tf *TransferFunc) ZPK() (*ZPK, error) {
 				return nil, err
 			}
 			z.Zeros[i][j] = zeros
-			z.Gain[i][j] = num[0] / tf.Den[i][0]
+			z.Gain[i][j] = channelPolynomialGain(num, tf.Den[i])
 		}
 	}
 	z.InputName = copyStringSlice(tf.InputName)


### PR DESCRIPTION
## Summary

- deepen local nonlinear approximation validation shared by `Linearize` and EKF paths
- deepen frequency-response estimation planning, polynomial channel algebra, and controller/observer assembly policy
- fix transfer-function to ZPK conversion for leading-zero numerators by using trimmed polynomial gain semantics
- route SISO zero extraction through `Poly.Roots` so zero calculation shares polynomial root behavior

Closes #84.
Closes #85.
Closes #86.
Closes #87.

## Tests

- `go test -v -count=1`
- `go test -bench='Benchmark(SystemFRD_MIMO_200|FRDSigma_MIMO_200|FRDMargin_200)$' -benchmem -count=10` + `benchstat`

## Benchmark comparison

- `SystemFRD_MIMO_200`: 97.10µs ±3% -> 96.03µs ±1%, no regression
- `FRDSigma_MIMO_200`: 562.9µs ±0% -> 563.7µs ±0%, no regression
- `FRDMargin_200`: 5.553µs ±1% -> 5.497µs ±0%, 1.01% faster
- allocations unchanged for all benchmarked cases
