### PR TITLE
Deepen safe feedback delay strategy

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -271,8 +271,8 @@ func parallelNeedsLFT(sys1, sys2 *System) bool {
 	}
 	_, m, p := sys1.Dims()
 
-	td1 := totalDelayMatrix(sys1, p, m)
-	td2 := totalDelayMatrix(sys2, p, m)
+	td1 := totalDelayMatrix(sys1)
+	td2 := totalDelayMatrix(sys2)
 	if td1 == nil && td2 == nil {
 		return false
 	}
@@ -285,8 +285,8 @@ func parallelNeedsLFT(sys1, sys2 *System) bool {
 	return !mat.Equal(td1, td2)
 }
 
-func totalDelayMatrix(sys *System, p, m int) *mat.Dense {
-	return effectiveIODelayMatrix(sys, p, m, true)
+func totalDelayMatrix(sys *System) *mat.Dense {
+	return newDelayTopology(sys).totalExternal(true)
 }
 
 func parallelSimple(sys1, sys2 *System) (*System, error) {

--- a/connect_test.go
+++ b/connect_test.go
@@ -1204,6 +1204,53 @@ func TestSafeFeedback_DiscreteWithThiranOrder(t *testing.T) {
 	}
 }
 
+func TestSafeFeedback_DiscreteFractionalDelayRequiresThiranOrder(t *testing.T) {
+	plant, _ := New(
+		mat.NewDense(1, 1, []float64{0.7}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0.1,
+	)
+	plant.InputDelay = []float64{3.5}
+	controller, _ := NewGain(mat.NewDense(1, 1, []float64{0.2}), 0.1)
+
+	if _, err := SafeFeedback(plant, controller, -1); !errors.Is(err, ErrFractionalDelay) {
+		t.Fatalf("SafeFeedback fractional delay error = %v, want ErrFractionalDelay", err)
+	}
+
+	cl, err := SafeFeedback(plant, controller, -1, WithThiranOrder(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cl.HasDelay() {
+		t.Fatal("Thiran safe feedback should absorb external delays")
+	}
+	n, m, p := cl.Dims()
+	if n != 4 || m != 1 || p != 1 {
+		t.Fatalf("closed-loop dims n=%d m=%d p=%d, want 4,1,1", n, m, p)
+	}
+}
+
+func TestSafeFeedback_DiscreteThiranRejectsResidualIODelay(t *testing.T) {
+	plant, _ := New(
+		mat.NewDense(2, 2, []float64{0.7, 0.2, -0.1, 0.6}),
+		mat.NewDense(2, 2, []float64{1, 0, 0, 1}),
+		mat.NewDense(2, 2, []float64{1, 0.1, -0.2, 1}),
+		mat.NewDense(2, 2, nil),
+		0.1,
+	)
+	plant.Delay = mat.NewDense(2, 2, []float64{
+		1.5, 4.0,
+		2.0, 1.5,
+	})
+	controller, _ := NewGain(mat.NewDense(2, 2, []float64{0.1, 0, 0, 0.2}), 0.1)
+
+	if _, err := SafeFeedback(plant, controller, -1, WithThiranOrder(2)); !errors.Is(err, ErrFeedbackDelay) {
+		t.Fatalf("SafeFeedback residual IODelay error = %v, want ErrFeedbackDelay", err)
+	}
+}
+
 func TestSafeFeedback_ContinuousMIMO(t *testing.T) {
 	plant, _ := New(
 		mat.NewDense(2, 2, []float64{-1, 0.5, 0, -2}),

--- a/conversion_plan.go
+++ b/conversion_plan.go
@@ -59,14 +59,14 @@ func newC2DPlan(sys *System, dt float64, opts C2DOptions) (c2dPlan, error) {
 	plan.workSys.InputDelay = nil
 	plan.workSys.OutputDelay = nil
 	if sys.Delay != nil && (opts.ThiranOrder > 0 || delayModeling == "internal") {
-		inD, outD, residual := DecomposeIODelay(sys.Delay)
-		if delayMatrixHasNonzeroTol(residual, delayTopologyTol) {
-			plan.workSys.Delay = residual
+		decomp := decomposedDelayMatrix(sys.Delay)
+		if decomp.hasResidual() {
+			plan.workSys.Delay = decomp.residual
 		} else {
 			plan.workSys.Delay = nil
 		}
-		plan.contInputDelay = mergeDelays(sys.InputDelay, inD)
-		plan.contOutputDelay = mergeDelays(sys.OutputDelay, outD)
+		plan.contInputDelay = mergeDelays(sys.InputDelay, decomp.inputDelay)
+		plan.contOutputDelay = mergeDelays(sys.OutputDelay, decomp.outputDelay)
 	}
 
 	return plan, nil

--- a/delay.go
+++ b/delay.go
@@ -134,7 +134,7 @@ func validateSliceDelay(delay []float64, expected int, dt float64) error {
 }
 
 func (sys *System) TotalDelay() *mat.Dense {
-	return newDelayTopology(sys).total(true)
+	return newDelayTopology(sys).totalExternal(true)
 }
 
 func effectiveIODelayMatrix(sys *System, p, m int, includeDelayMatrix bool) *mat.Dense {

--- a/delay_topology.go
+++ b/delay_topology.go
@@ -14,21 +14,64 @@ type delayTopology struct {
 	m   int
 }
 
+type delayTopologyDecomposition struct {
+	inputDelay  []float64
+	outputDelay []float64
+	residual    *mat.Dense
+}
+
 func newDelayTopology(sys *System) delayTopology {
 	_, m, p := sys.Dims()
 	return delayTopology{sys: sys, p: p, m: m}
 }
 
-func (dt delayTopology) total(includeDelayMatrix bool) *mat.Dense {
+func (dt delayTopology) totalExternal(includeDelayMatrix bool) *mat.Dense {
 	return effectiveIODelayMatrix(dt.sys, dt.p, dt.m, includeDelayMatrix)
 }
 
-func (dt delayTopology) decomposeTotal() (inputDelay, outputDelay []float64, residual *mat.Dense) {
-	total := dt.total(true)
-	if total == nil {
-		return nil, nil, nil
+func (dt delayTopology) decomposedExternal() delayTopologyDecomposition {
+	total := dt.totalExternal(true)
+	return decomposedDelayMatrix(total)
+}
+
+func decomposedDelayMatrix(delay *mat.Dense) delayTopologyDecomposition {
+	if delay == nil {
+		return delayTopologyDecomposition{}
 	}
-	return DecomposeIODelay(total)
+	inputDelay, outputDelay, residual := DecomposeIODelay(delay)
+	return delayTopologyDecomposition{
+		inputDelay:  inputDelay,
+		outputDelay: outputDelay,
+		residual:    residual,
+	}
+}
+
+func (dt delayTopology) decomposableExternal(context string) (inputDelay, outputDelay []float64, err error) {
+	decomp := dt.decomposedExternal()
+	if decomp.hasResidual() {
+		return nil, nil, &delayTopologyResidualError{context: context}
+	}
+	return decomp.inputDelay, decomp.outputDelay, nil
+}
+
+func (d delayTopologyDecomposition) hasDelay() bool {
+	return delaySliceHasNonzero(d.inputDelay) || delaySliceHasNonzero(d.outputDelay) || d.hasResidual()
+}
+
+func (d delayTopologyDecomposition) hasResidual() bool {
+	return delayMatrixHasNonzeroTol(d.residual, delayTopologyTol)
+}
+
+type delayTopologyResidualError struct {
+	context string
+}
+
+func (e *delayTopologyResidualError) Error() string {
+	return e.context + ": non-decomposable IODelay residual: " + ErrFeedbackDelay.Error()
+}
+
+func (e *delayTopologyResidualError) Unwrap() error {
+	return ErrFeedbackDelay
 }
 
 func delayMatrixHasNonzero(m *mat.Dense) bool {

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -2,6 +2,7 @@ package controlsys
 
 import (
 	"fmt"
+	"math"
 
 	"gonum.org/v1/gonum/mat"
 )
@@ -38,37 +39,10 @@ func SafeFeedback(plant, controller *System, sign float64, opts ...SafeFeedbackO
 		o(&cfg)
 	}
 
-	var p, c *System
-	var err error
-
-	if plant.IsDiscrete() {
-		p, err = plant.AbsorbDelay()
-		if err != nil {
-			return nil, fmt.Errorf("SafeFeedback: absorb plant: %w", err)
-		}
-		c, err = controller.AbsorbDelay()
-		if err != nil {
-			return nil, fmt.Errorf("SafeFeedback: absorb controller: %w", err)
-		}
-	} else {
-		p, err = replaceContinuousDelays(plant, cfg.padeOrder)
-		if err != nil {
-			return nil, fmt.Errorf("SafeFeedback: pade plant: %w", err)
-		}
-		c, err = replaceContinuousDelays(controller, cfg.padeOrder)
-		if err != nil {
-			return nil, fmt.Errorf("SafeFeedback: pade controller: %w", err)
-		}
-
-		// Well-posedness check for Pade approximations (§7.6)
-		// Pade approximants have D = (-1)^N, which might create a singular algebraic loop.
-		_, mPlant, pPlant := p.Dims()
-		_, mCtrl, pCtrl := c.Dims()
-		if pPlant == mCtrl && pCtrl == mPlant {
-			if _, err := solveFeedbackFeedthrough(p.D, c.D, sign, pPlant, "SafeFeedback", ErrAlgebraicLoop); err != nil {
-				return nil, fmt.Errorf("SafeFeedback: Pade approximation creates singular algebraic loop; try a different padeOrder (even vs odd) to flip feedthrough sign")
-			}
-		}
+	strategy := safeFeedbackDelayStrategy{cfg: cfg}
+	p, c, err := strategy.prepare(plant, controller, sign)
+	if err != nil {
+		return nil, err
 	}
 
 	result, err := Feedback(p, c, sign)
@@ -78,6 +52,153 @@ func SafeFeedback(plant, controller *System, sign float64, opts ...SafeFeedbackO
 	result.InputName = copyStringSlice(plant.InputName)
 	result.OutputName = copyStringSlice(plant.OutputName)
 	return result, nil
+}
+
+type safeFeedbackDelayStrategy struct {
+	cfg safeFeedbackConfig
+}
+
+func (s safeFeedbackDelayStrategy) prepare(plant, controller *System, sign float64) (*System, *System, error) {
+	if plant.IsDiscrete() {
+		p, err := s.replaceDiscreteDelays(plant, "plant")
+		if err != nil {
+			return nil, nil, err
+		}
+		c, err := s.replaceDiscreteDelays(controller, "controller")
+		if err != nil {
+			return nil, nil, err
+		}
+		return p, c, nil
+	}
+
+	p, err := replaceContinuousDelays(plant, s.cfg.padeOrder)
+	if err != nil {
+		return nil, nil, fmt.Errorf("SafeFeedback: pade plant: %w", err)
+	}
+	c, err := replaceContinuousDelays(controller, s.cfg.padeOrder)
+	if err != nil {
+		return nil, nil, fmt.Errorf("SafeFeedback: pade controller: %w", err)
+	}
+	if err := s.requireWellPosedPade(p, c, sign); err != nil {
+		return nil, nil, err
+	}
+	return p, c, nil
+}
+
+func (s safeFeedbackDelayStrategy) replaceDiscreteDelays(sys *System, role string) (*System, error) {
+	if s.cfg.thiranOrder == 0 {
+		if err := sys.Validate(); err != nil {
+			return nil, fmt.Errorf("SafeFeedback: validate %s: %w", role, err)
+		}
+		out, err := sys.AbsorbDelay()
+		if err != nil {
+			return nil, fmt.Errorf("SafeFeedback: absorb %s: %w", role, err)
+		}
+		return out, nil
+	}
+	out, err := replaceDiscreteExternalDelaysWithThiran(sys, s.cfg.thiranOrder)
+	if err != nil {
+		return nil, fmt.Errorf("SafeFeedback: thiran %s: %w", role, err)
+	}
+	return out, nil
+}
+
+func (s safeFeedbackDelayStrategy) requireWellPosedPade(plant, controller *System, sign float64) error {
+	_, mPlant, pPlant := plant.Dims()
+	_, mCtrl, pCtrl := controller.Dims()
+	if pPlant != mCtrl || pCtrl != mPlant {
+		return nil
+	}
+	if _, err := solveFeedbackFeedthrough(plant.D, controller.D, sign, pPlant, "SafeFeedback", ErrAlgebraicLoop); err != nil {
+		return fmt.Errorf("SafeFeedback: Pade approximation creates singular algebraic loop; try a different padeOrder (even vs odd) to flip feedthrough sign")
+	}
+	return nil
+}
+
+func replaceDiscreteExternalDelaysWithThiran(sys *System, thiranOrder int) (*System, error) {
+	if !sys.HasDelay() {
+		return sys.Copy(), nil
+	}
+	if sys.HasInternalDelay() {
+		if err := validateSliceDelay(sys.LFT.Tau, len(sys.LFT.Tau), sys.Dt); err != nil {
+			return nil, err
+		}
+	}
+
+	cur := sys.Copy()
+	if cur.HasInternalDelay() {
+		var err error
+		cur, err = absorbInternalDelay(cur)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	inputDelay, outputDelay, err := newDelayTopology(cur).decomposableExternal("SafeFeedback")
+	if err != nil {
+		return nil, err
+	}
+	if !delaySliceHasNonzero(inputDelay) && !delaySliceHasNonzero(outputDelay) {
+		cur.Delay = nil
+		cur.InputDelay = nil
+		cur.OutputDelay = nil
+		return cur, nil
+	}
+
+	result := &System{A: cur.A, B: cur.B, C: cur.C, D: cur.D, Dt: cur.Dt}
+	if delaySliceHasNonzero(inputDelay) {
+		bank, err := buildDiscreteSampleDelayBank(inputDelay, len(inputDelay), cur.Dt, thiranOrder)
+		if err != nil {
+			return nil, err
+		}
+		result, err = Series(bank, result)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if delaySliceHasNonzero(outputDelay) {
+		bank, err := buildDiscreteSampleDelayBank(outputDelay, len(outputDelay), cur.Dt, thiranOrder)
+		if err != nil {
+			return nil, err
+		}
+		result, err = Series(result, bank)
+		if err != nil {
+			return nil, err
+		}
+	}
+	propagateNames(result, cur)
+	result.InputDelay = nil
+	result.OutputDelay = nil
+	result.Delay = nil
+	return result, nil
+}
+
+func buildDiscreteSampleDelayBank(sampleDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
+	var bank *System
+	for i := 0; i < n; i++ {
+		tau := sampleDelay[i] * dt
+		var ch *System
+		var err error
+		if tau == 0 {
+			ch, err = NewGain(mat.NewDense(1, 1, []float64{1}), dt)
+		} else if math.Abs(sampleDelay[i]-math.Round(sampleDelay[i])) < 1e-9 {
+			ch, err = integerDelaySS(int(math.Round(sampleDelay[i])), dt)
+		} else {
+			ch, err = ThiranDelay(tau, thiranOrder, dt)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if bank == nil {
+			bank = ch
+			continue
+		}
+		bank, err = Append(bank, ch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return bank, nil
 }
 
 func replaceContinuousDelays(sys *System, padeOrder int) (*System, error) {
@@ -90,13 +211,13 @@ func replaceContinuousDelays(sys *System, padeOrder int) (*System, error) {
 	cur := sys.Copy()
 
 	if cur.Delay != nil {
-		inDel, outDel, residual := DecomposeIODelay(cur.Delay)
-		if delayMatrixHasNonzeroTol(residual, delayTopologyTol) {
-			return nil, fmt.Errorf("SafeFeedback: non-decomposable IODelay residual: %w", ErrFeedbackDelay)
+		decomp := decomposedDelayMatrix(cur.Delay)
+		if decomp.hasResidual() {
+			return nil, &delayTopologyResidualError{context: "SafeFeedback"}
 		}
 		cur.Delay = nil
-		cur.InputDelay = mergeDelays(cur.InputDelay, inDel)
-		cur.OutputDelay = mergeDelays(cur.OutputDelay, outDel)
+		cur.InputDelay = mergeDelays(cur.InputDelay, decomp.inputDelay)
+		cur.OutputDelay = mergeDelays(cur.OutputDelay, decomp.outputDelay)
 	}
 
 	result := &System{A: cur.A, B: cur.B, C: cur.C, D: cur.D, Dt: cur.Dt}


### PR DESCRIPTION
## Summary

- Deepens `SafeFeedback` delay handling behind an explicit delay strategy path.
- Makes `WithThiranOrder` observable for fractional discrete external delays instead of being a silent no-op.
- Deepens delay topology with named external delay outcomes shared by total-delay, conversion planning, parallel checks, and safe feedback.
- Adds public safe feedback regressions for fractional discrete delay and unsupported residual I/O delay.

## Verification

- `go test -v -count=1`
- `go test -bench=. -benchmem -run '^$'` before and after
- `benchstat /tmp/controlsys-delay-before.bench /tmp/controlsys-delay-after.bench`

Benchmark notes:
- `SafeFeedback-8`: `5.747µs -> 5.757µs`, no significant change (`p=1.000`, `n=1`)
- `DiscretizeWithOpts_IODelayThiran-8`: `3.830µs -> 3.899µs`, no significant change (`p=1.000`, `n=1`)
- `sec/op` geomean: `42.12µs -> 41.65µs` (`-1.13%`)
- allocation geomeans effectively unchanged (`B/op -0.01%`, `allocs/op -0.00%`)

Part of #89.
Closes #90.
Closes #91.
Closes #92.
Closes #93.
