### PR TITLE
Deepen remaining architecture modules

### DIFF
--- a/architecture_prd95_test.go
+++ b/architecture_prd95_test.go
@@ -1,0 +1,304 @@
+package controlsys
+
+import (
+	"errors"
+	"math"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func prd95MIMOModel(t *testing.T, dt float64) *System {
+	t.Helper()
+	sys, err := NewFromSlices(3, 2, 2,
+		[]float64{
+			0, 1, 0,
+			-2, -3, 0.5,
+			0.25, -0.75, -1.5,
+		},
+		[]float64{
+			1, 0,
+			0, 1,
+			0.5, -0.25,
+		},
+		[]float64{
+			1, 0.5, 0,
+			0, 1, -0.5,
+		},
+		[]float64{
+			0.05, -0.02,
+			0.01, 0.04,
+		},
+		dt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"u-left", "u-right"}
+	sys.OutputName = []string{"y-top", "y-bottom"}
+	sys.StateName = []string{"x-a", "x-b", "x-c"}
+	return sys
+}
+
+func TestPRD95DelayBankPublicWorkflowsShareRules(t *testing.T) {
+	plant := prd95MIMOModel(t, 0)
+	plant.InputDelay = []float64{0.35, 0}
+	plant.OutputDelay = []float64{0, 0.45}
+	if err := plant.SetDelay(mat.NewDense(2, 2, []float64{
+		0, 0.35,
+		0.45, 0.80,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	disc, err := plant.DiscretizeWithOpts(0.1, C2DOptions{Method: "zoh", ThiranOrder: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disc.Delay != nil {
+		t.Fatalf("discretized model kept input-output delay: %v", disc.Delay)
+	}
+	for _, delays := range [][]float64{disc.InputDelay, disc.OutputDelay} {
+		for _, d := range delays {
+			if math.Abs(d-math.Round(d)) > 1e-12 {
+				t.Fatalf("discretized model kept fractional external delay: input=%v output=%v", disc.InputDelay, disc.OutputDelay)
+			}
+		}
+	}
+	if n, m, p := disc.Dims(); n <= 3 || m != 2 || p != 2 {
+		t.Fatalf("discretized dims = %d,%d,%d, want added delay states and 2x2 channels", n, m, p)
+	}
+
+	controller, err := NewGain(mat.NewDense(2, 2, []float64{0.1, 0.02, -0.03, 0.08}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.Dt = 0.1
+	discPlant := plant.Copy()
+	discPlant.Dt = 0.1
+	discPlant.InputDelay = []float64{3.5, 0}
+	discPlant.OutputDelay = []float64{0, 4.5}
+	discPlant.Delay = mat.NewDense(2, 2, []float64{
+		0, 3.5,
+		4.5, 8.0,
+	})
+
+	if _, err := SafeFeedback(discPlant, controller, -1); !errors.Is(err, ErrFractionalDelay) {
+		t.Fatalf("SafeFeedback without Thiran err = %v, want ErrFractionalDelay", err)
+	}
+	closed, err := SafeFeedback(discPlant, controller, -1, WithThiranOrder(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.HasDelay() {
+		t.Fatalf("SafeFeedback kept external delay: input=%v output=%v io=%v", closed.InputDelay, closed.OutputDelay, closed.Delay)
+	}
+}
+
+func TestPRD95DelayBankKeepsIntegerDelayExactWithThiranOrder(t *testing.T) {
+	sys := prd95MIMOModel(t, 0.1)
+	sys.InputDelay = []float64{2, 0}
+	sys.OutputDelay = []float64{0, 3}
+
+	controller, err := NewGain(mat.NewDense(2, 2, []float64{0.2, 0, 0, 0.1}), 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	closed, err := SafeFeedback(sys, controller, -1, WithThiranOrder(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, m, p := closed.Dims()
+	if m != 2 || p != 2 {
+		t.Fatalf("closed dims = %d,%d,%d, want 2x2 channels", n, m, p)
+	}
+	if n >= 3+2*3 {
+		t.Fatalf("closed state count = %d, want exact integer delay states rather than one Thiran block per delayed channel", n)
+	}
+}
+
+func TestPRD95LFTDelayWorkflowPreservesExternalDelayAndMetadata(t *testing.T) {
+	M, err := NewGain(mat.NewDense(2, 2, []float64{
+		0.2, 0.5,
+		1.0, 0.1,
+	}), 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	M.InputName = []string{"reference", "uncertain-return"}
+	M.OutputName = []string{"controlled", "uncertain-drive"}
+	if err := M.SetInputDelay([]float64{2, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := M.SetOutputDelay([]float64{3, 0}); err != nil {
+		t.Fatal(err)
+	}
+
+	delta, err := New(
+		mat.NewDense(1, 1, []float64{0.8}),
+		mat.NewDense(1, 1, []float64{0.2}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0.1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := delta.SetInputDelay([]float64{2}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LFT(M, delta, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !floatSlicesEqual(result.InputDelay, []float64{2}) {
+		t.Fatalf("InputDelay = %v, want [2]", result.InputDelay)
+	}
+	if !floatSlicesEqual(result.OutputDelay, []float64{3}) {
+		t.Fatalf("OutputDelay = %v, want [3]", result.OutputDelay)
+	}
+	if !stringSlicesEqual(result.InputName, []string{"reference"}) {
+		t.Fatalf("InputName = %v", result.InputName)
+	}
+	if !stringSlicesEqual(result.OutputName, []string{"controlled"}) {
+		t.Fatalf("OutputName = %v", result.OutputName)
+	}
+	if !result.HasInternalDelay() {
+		t.Fatal("expected Delta delay to be represented as internal delay")
+	}
+
+	omega := []float64{0.2, 1.1, 2.7}
+	resp, err := result.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.NFreq != len(omega) || resp.P != 1 || resp.M != 1 {
+		t.Fatalf("FreqResponse dims = %d,%d,%d", resp.NFreq, resp.P, resp.M)
+	}
+}
+
+func TestPRD95TimeDomainResponsePreparationPublicContracts(t *testing.T) {
+	cont := prd95MIMOModel(t, 0)
+	cont.OutputName = []string{"temperature", "pressure"}
+	tFinal := 0.5
+
+	step, err := Step(cont, tFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(step.OutputName, cont.OutputName) {
+		t.Fatalf("Step OutputName = %v, want %v", step.OutputName, cont.OutputName)
+	}
+	imp, err := Impulse(cont, tFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(imp.OutputName, cont.OutputName) {
+		t.Fatalf("Impulse OutputName = %v, want %v", imp.OutputName, cont.OutputName)
+	}
+	initResp, err := Initial(cont, mat.NewVecDense(3, []float64{1, -1, 0.5}), tFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(initResp.OutputName, cont.OutputName) {
+		t.Fatalf("Initial OutputName = %v, want %v", initResp.OutputName, cont.OutputName)
+	}
+
+	disc, err := cont.DiscretizeZOH(0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tvec := []float64{0, 0.1, 0.2, 0.3, 0.4}
+	uLsim := mat.NewDense(len(tvec), 2, []float64{
+		1, -1,
+		0.5, -0.5,
+		0.25, -0.25,
+		0, 0,
+		-0.25, 0.25,
+	})
+	uSim := mat.NewDense(2, len(tvec), []float64{
+		1, 0.5, 0.25, 0, -0.25,
+		-1, -0.5, -0.25, 0, 0.25,
+	})
+	lsim, err := Lsim(disc, uLsim, tvec, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sim, err := disc.Simulate(uSim, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDenseApprox(t, lsim.Y, sim.Y, 1e-12)
+
+	if _, err := Lsim(disc, uLsim, []float64{0, 0.1, 0.25, 0.3, 0.4}, nil); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("non-uniform Lsim err = %v, want ErrDimensionMismatch", err)
+	}
+	otherDt := disc.Copy()
+	otherDt.Dt = 0.2
+	if _, err := Lsim(otherDt, uLsim, tvec, nil); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("Dt mismatch Lsim err = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestPRD95FrequencyResponseLayoutPublicWorkflowsAgree(t *testing.T) {
+	sys := prd95MIMOModel(t, 0.1)
+	omega := []float64{0.2, 1.0, 2.4}
+	resp, err := sys.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frd, err := sys.FRD(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bode, err := sys.Bode(omega, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k := range omega {
+		for i := 0; i < resp.P; i++ {
+			for j := 0; j < resp.M; j++ {
+				h := resp.At(k, i, j)
+				assertComplexApprox(t, frd.At(k, i, j), h, 1e-12)
+				wantMag := 20 * math.Log10(cmplx.Abs(h))
+				if math.Abs(bode.MagDBAt(k, i, j)-wantMag) > 1e-10 {
+					t.Fatalf("Bode mag[%d,%d,%d] = %v, want %v", k, i, j, bode.MagDBAt(k, i, j), wantMag)
+				}
+			}
+		}
+	}
+
+	dt := 0.05
+	steps := 512
+	u := mat.NewDense(2, steps, nil)
+	for k := range steps {
+		u.Set(0, k, math.Sin(0.17*float64(k)))
+		u.Set(1, k, math.Cos(0.11*float64(k)))
+	}
+	disc, err := sys.D2D(dt, C2DOptions{Method: "tustin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sim, err := disc.Simulate(u, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	est, err := FreqRespEst(u, sim.Y, dt, &FreqRespEstOpts{NFFT: 128})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for f := range est.Omega {
+		for i := 0; i < est.H.P; i++ {
+			for j := 0; j < est.H.M; j++ {
+				coh := est.CoherenceAt(f, i, j)
+				if coh < 0 || coh > 1+1e-9 {
+					t.Fatalf("coherence[%d,%d,%d] = %v, want [0,1]", f, i, j, coh)
+				}
+			}
+		}
+	}
+}

--- a/convert.go
+++ b/convert.go
@@ -412,57 +412,7 @@ func absorbFractionalDelays(disc *System, contInputDelay, contOutputDelay []floa
 }
 
 func buildDelayBank(contDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
-	hasFractional := false
-	for _, tau := range contDelay {
-		if tau == 0 {
-			continue
-		}
-		samples := tau / dt
-		if math.Abs(samples-math.Round(samples)) >= 1e-9 {
-			hasFractional = true
-			break
-		}
-	}
-	if !hasFractional {
-		return nil, nil
-	}
-
-	var bank *System
-	for i := 0; i < n; i++ {
-		tau := contDelay[i]
-		var ch *System
-		var err error
-
-		if tau == 0 {
-			ch, err = NewGain(mat.NewDense(1, 1, []float64{1}), dt)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			samples := tau / dt
-			if math.Abs(samples-math.Round(samples)) < 1e-9 {
-				ch, err = integerDelaySS(int(math.Round(samples)), dt)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				ch, err = ThiranDelay(tau, thiranOrder, dt)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		if bank == nil {
-			bank = ch
-		} else {
-			bank, err = Append(bank, ch)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	return bank, nil
+	return buildFractionalThiranDelayBank(contDelay, n, dt, thiranOrder)
 }
 
 func (sys *System) DiscretizeZOH(dt float64) (*System, error) {

--- a/delay.go
+++ b/delay.go
@@ -1062,40 +1062,6 @@ func absorbOutputDelay(sys *System) (*System, error) {
 	return augSys, nil
 }
 
-func buildPadeBank(delays []float64, order int) (*System, error) {
-	var bank *System
-	for _, tau := range delays {
-		if tau == 0 {
-			g, err := NewGain(mat.NewDense(1, 1, []float64{1}), 0)
-			if err != nil {
-				return nil, err
-			}
-			if bank == nil {
-				bank = g
-			} else {
-				bank, err = Append(bank, g)
-				if err != nil {
-					return nil, err
-				}
-			}
-			continue
-		}
-		pd, err := PadeDelay(tau, order)
-		if err != nil {
-			return nil, fmt.Errorf("buildPadeBank: %w", err)
-		}
-		if bank == nil {
-			bank = pd
-		} else {
-			bank, err = Append(bank, pd)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	return bank, nil
-}
-
 func absorbInputDelayContinuous(sys *System, order int) (*System, error) {
 	hasInput := false
 	if sys.InputDelay != nil {

--- a/delay_bank.go
+++ b/delay_bank.go
@@ -1,0 +1,110 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type delayBankMode int
+
+const (
+	delayBankPade delayBankMode = iota
+	delayBankDiscreteSamples
+	delayBankContinuousThiran
+)
+
+type delayBankSpec struct {
+	mode  delayBankMode
+	order int
+	dt    float64
+}
+
+func buildPadeBank(delays []float64, order int) (*System, error) {
+	return buildChannelDelayBank(delays, len(delays), delayBankSpec{mode: delayBankPade, order: order})
+}
+
+func buildDiscreteSampleDelayBank(sampleDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
+	return buildChannelDelayBank(sampleDelay, n, delayBankSpec{mode: delayBankDiscreteSamples, dt: dt, order: thiranOrder})
+}
+
+func buildFractionalThiranDelayBank(contDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
+	if !hasFractionalSampleDelay(contDelay, dt) {
+		return nil, nil
+	}
+	return buildChannelDelayBank(contDelay, n, delayBankSpec{mode: delayBankContinuousThiran, dt: dt, order: thiranOrder})
+}
+
+func buildChannelDelayBank(delays []float64, n int, spec delayBankSpec) (*System, error) {
+	var bank *System
+	for i := 0; i < n; i++ {
+		ch, err := buildDelayChannel(delays[i], spec)
+		if err != nil {
+			return nil, err
+		}
+		if bank == nil {
+			bank = ch
+			continue
+		}
+		bank, err = Append(bank, ch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return bank, nil
+}
+
+func buildDelayChannel(delay float64, spec delayBankSpec) (*System, error) {
+	switch spec.mode {
+	case delayBankPade:
+		if delay == 0 {
+			return NewGain(mat.NewDense(1, 1, []float64{1}), 0)
+		}
+		pd, err := PadeDelay(delay, spec.order)
+		if err != nil {
+			return nil, fmt.Errorf("buildPadeBank: %w", err)
+		}
+		return pd, nil
+	case delayBankDiscreteSamples:
+		return buildDiscreteSampleDelayChannel(delay, spec.dt, spec.order)
+	case delayBankContinuousThiran:
+		return buildContinuousThiranDelayChannel(delay, spec.dt, spec.order)
+	default:
+		panic("unvalidated delay bank mode")
+	}
+}
+
+func buildDiscreteSampleDelayChannel(samples, dt float64, thiranOrder int) (*System, error) {
+	if samples == 0 {
+		return NewGain(mat.NewDense(1, 1, []float64{1}), dt)
+	}
+	if math.Abs(samples-math.Round(samples)) < 1e-9 {
+		return integerDelaySS(int(math.Round(samples)), dt)
+	}
+	return ThiranDelay(samples*dt, thiranOrder, dt)
+}
+
+func buildContinuousThiranDelayChannel(tau, dt float64, thiranOrder int) (*System, error) {
+	if tau == 0 {
+		return NewGain(mat.NewDense(1, 1, []float64{1}), dt)
+	}
+	samples := tau / dt
+	if math.Abs(samples-math.Round(samples)) < 1e-9 {
+		return integerDelaySS(int(math.Round(samples)), dt)
+	}
+	return ThiranDelay(tau, thiranOrder, dt)
+}
+
+func hasFractionalSampleDelay(delays []float64, dt float64) bool {
+	for _, tau := range delays {
+		if tau == 0 {
+			continue
+		}
+		samples := tau / dt
+		if math.Abs(samples-math.Round(samples)) >= 1e-9 {
+			return true
+		}
+	}
+	return false
+}

--- a/freqrestest.go
+++ b/freqrestest.go
@@ -39,7 +39,7 @@ func (r *FreqRespEstResult) CoherenceAt(freq, output, input int) float64 {
 	if r.Coherence == nil {
 		return 0
 	}
-	return r.Coherence[freq*r.H.P*r.H.M+output*r.H.M+input]
+	return r.Coherence[r.H.index(freq, output, input)]
 }
 
 func (r *FreqRespEstResult) FRD() (*FRD, error) {

--- a/frequency.go
+++ b/frequency.go
@@ -19,7 +19,15 @@ type FreqResponseMatrix struct {
 }
 
 func (f *FreqResponseMatrix) At(freq, output, input int) complex128 {
-	return f.Data[freq*f.P*f.M+output*f.M+input]
+	return f.Data[f.index(freq, output, input)]
+}
+
+func (f *FreqResponseMatrix) index(freq, output, input int) int {
+	return freq*f.P*f.M + output*f.M + input
+}
+
+func freqResponseIndex(freq, output, input, p, m int) int {
+	return freq*p*m + output*m + input
 }
 
 func newFreqResponseMatrix(data []complex128, omega []float64, p, m int, inputName, outputName []string) *FreqResponseMatrix {
@@ -57,7 +65,7 @@ func (b *BodeResult) PhaseAt(freq, output, input int) float64 {
 
 func bodeResultFromResponse(omega []float64, data []complex128, p, m int, inputName, outputName []string) *BodeResult {
 	return bodeResultFromAccessor(omega, p, m, inputName, outputName, func(k, i, j int) complex128 {
-		return data[(k*p+i)*m+j]
+		return data[freqResponseIndex(k, i, j, p, m)]
 	})
 }
 
@@ -70,7 +78,7 @@ func bodeResultFromAccessor(omega []float64, p, m int, inputName, outputName []s
 	for k := range omega {
 		for i := 0; i < p; i++ {
 			for j := 0; j < m; j++ {
-				off := (k*p+i)*m + j
+				off := freqResponseIndex(k, i, j, p, m)
 				h := at(k, i, j)
 				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
 				phase[off] = cmplx.Phase(h) * 180 / math.Pi
@@ -95,8 +103,8 @@ func unwrapBodePhase(phase []float64, p, m, nw int) {
 	for i := 0; i < p; i++ {
 		for j := 0; j < m; j++ {
 			for k := 1; k < nw; k++ {
-				cur := (k*p+i)*m + j
-				prev := ((k-1)*p+i)*m + j
+				cur := freqResponseIndex(k, i, j, p, m)
+				prev := freqResponseIndex(k-1, i, j, p, m)
 				diff := phase[cur] - phase[prev]
 				if diff > 180 {
 					phase[cur] -= 360

--- a/lft.go
+++ b/lft.go
@@ -187,60 +187,8 @@ func solveLFTLoop(D22M, DDelta *mat.Dense, w int) (*mat.Dense, error) {
 func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 	_, mM, pM := M.Dims()
 
-	savedInputDelay := make([]float64, nu)
-	if M.InputDelay != nil {
-		copy(savedInputDelay, M.InputDelay[:nu])
-	}
-	savedOutputDelay := make([]float64, ny)
-	if M.OutputDelay != nil {
-		copy(savedOutputDelay, M.OutputDelay[:ny])
-	}
-	hasExtInput := false
-	for _, v := range savedInputDelay {
-		if v != 0 {
-			hasExtInput = true
-			break
-		}
-	}
-	hasExtOutput := false
-	for _, v := range savedOutputDelay {
-		if v != 0 {
-			hasExtOutput = true
-			break
-		}
-	}
-
-	mCopy := M.Copy()
-	if mCopy.InputDelay != nil {
-		for i := 0; i < nu; i++ {
-			mCopy.InputDelay[i] = 0
-		}
-		allZero := true
-		for _, v := range mCopy.InputDelay {
-			if v != 0 {
-				allZero = false
-				break
-			}
-		}
-		if allZero {
-			mCopy.InputDelay = nil
-		}
-	}
-	if mCopy.OutputDelay != nil {
-		for i := 0; i < ny; i++ {
-			mCopy.OutputDelay[i] = 0
-		}
-		allZero := true
-		for _, v := range mCopy.OutputDelay {
-			if v != 0 {
-				allZero = false
-				break
-			}
-		}
-		if allZero {
-			mCopy.OutputDelay = nil
-		}
-	}
+	external := newLFTExternalDelayState(M, nu, ny)
+	mCopy := external.strippedMain()
 
 	mLFT, err := mCopy.PullDelaysToLFT()
 	if err != nil {
@@ -356,18 +304,7 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 		if err != nil {
 			return nil, err
 		}
-		if hasExtInput {
-			sys.InputDelay = savedInputDelay
-		}
-		if hasExtOutput {
-			sys.OutputDelay = savedOutputDelay
-		}
-		if M.InputName != nil {
-			sys.InputName = copyStringSlice(M.InputName[:nu])
-		}
-		if M.OutputName != nil {
-			sys.OutputName = copyStringSlice(M.OutputName[:ny])
-		}
+		external.apply(sys)
 		return sys, nil
 	}
 
@@ -388,7 +325,9 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 		D12iD = extractBlock(dH.D, 0, w, z, ND)
 		D21iD = extractBlock(dH.D, z, 0, ND, w)
 		GD12iD = mulDense(G, D12iD)
-		FD12iMw = mulDense(F, D12iMw)
+		if NM > 0 {
+			FD12iMw = mulDense(F, D12iMw)
+		}
 		FD22pD12iD = mulDense(F, mulDense(D22p, D12iD))
 	}
 
@@ -513,17 +452,68 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 	if err != nil {
 		return nil, err
 	}
-	if hasExtInput {
-		result.InputDelay = savedInputDelay
+	external.apply(result)
+	return result, nil
+}
+
+type lftExternalDelayState struct {
+	main        *System
+	nu, ny      int
+	inputDelay  []float64
+	outputDelay []float64
+	hasInput    bool
+	hasOutput   bool
+	inputName   []string
+	outputName  []string
+}
+
+func newLFTExternalDelayState(M *System, nu, ny int) lftExternalDelayState {
+	state := lftExternalDelayState{main: M, nu: nu, ny: ny}
+	state.inputDelay = make([]float64, nu)
+	if M.InputDelay != nil {
+		copy(state.inputDelay, M.InputDelay[:nu])
 	}
-	if hasExtOutput {
-		result.OutputDelay = savedOutputDelay
+	state.outputDelay = make([]float64, ny)
+	if M.OutputDelay != nil {
+		copy(state.outputDelay, M.OutputDelay[:ny])
 	}
+	state.hasInput = delaySliceHasNonzero(state.inputDelay)
+	state.hasOutput = delaySliceHasNonzero(state.outputDelay)
 	if M.InputName != nil {
-		result.InputName = copyStringSlice(M.InputName[:nu])
+		state.inputName = copyStringSlice(M.InputName[:nu])
 	}
 	if M.OutputName != nil {
-		result.OutputName = copyStringSlice(M.OutputName[:ny])
+		state.outputName = copyStringSlice(M.OutputName[:ny])
 	}
-	return result, nil
+	return state
+}
+
+func (s lftExternalDelayState) strippedMain() *System {
+	mCopy := s.main.Copy()
+	zeroDelayPrefix(mCopy.InputDelay, s.nu)
+	if mCopy.InputDelay != nil && !delaySliceHasNonzero(mCopy.InputDelay) {
+		mCopy.InputDelay = nil
+	}
+	zeroDelayPrefix(mCopy.OutputDelay, s.ny)
+	if mCopy.OutputDelay != nil && !delaySliceHasNonzero(mCopy.OutputDelay) {
+		mCopy.OutputDelay = nil
+	}
+	return mCopy
+}
+
+func (s lftExternalDelayState) apply(sys *System) {
+	if s.hasInput {
+		sys.InputDelay = copyFloatSlice(s.inputDelay)
+	}
+	if s.hasOutput {
+		sys.OutputDelay = copyFloatSlice(s.outputDelay)
+	}
+	sys.InputName = copyStringSlice(s.inputName)
+	sys.OutputName = copyStringSlice(s.outputName)
+}
+
+func zeroDelayPrefix(delay []float64, n int) {
+	for i := 0; i < n && i < len(delay); i++ {
+		delay[i] = 0
+	}
 }

--- a/response.go
+++ b/response.go
@@ -127,6 +127,59 @@ func makeTimeVector(steps int, dt float64) []float64 {
 	return t
 }
 
+type timeResponseGrid struct {
+	t     []float64
+	dt    float64
+	steps int
+}
+
+func newTimeResponseGrid(t []float64) (timeResponseGrid, error) {
+	if len(t) < 2 {
+		return timeResponseGrid{}, fmt.Errorf("Lsim: need at least 2 time points: %w", ErrDimensionMismatch)
+	}
+	dt := t[1] - t[0]
+	if dt <= 0 {
+		return timeResponseGrid{}, fmt.Errorf("Lsim: time step must be positive, got %g: %w", dt, ErrDimensionMismatch)
+	}
+	for k := 2; k < len(t); k++ {
+		dk := t[k] - t[k-1]
+		if math.Abs(dk-dt)/dt > 1e-6 {
+			return timeResponseGrid{}, fmt.Errorf("Lsim: non-uniform time grid at index %d (dt=%g, expected %g); uniform grid required: %w", k, dk, dt, ErrDimensionMismatch)
+		}
+	}
+	return timeResponseGrid{t: t, dt: dt, steps: len(t)}, nil
+}
+
+func (g timeResponseGrid) prepareModel(sys *System) (*System, error) {
+	if sys.IsContinuous() {
+		dsys, err := sys.DiscretizeZOH(g.dt)
+		if err != nil {
+			return nil, fmt.Errorf("Lsim: %w", err)
+		}
+		return dsys, nil
+	}
+	if math.Abs(sys.Dt-g.dt)/sys.Dt > 1e-6 {
+		return nil, fmt.Errorf("Lsim: time grid spacing %g does not match system Dt %g: %w", g.dt, sys.Dt, ErrDimensionMismatch)
+	}
+	return sys, nil
+}
+
+func (g timeResponseGrid) inputByChannel(u *mat.Dense, m int) (*mat.Dense, error) {
+	ur, uc := u.Dims()
+	if ur != g.steps || uc != m {
+		return nil, fmt.Errorf("Lsim: u must be %d×%d, got %d×%d: %w", g.steps, m, ur, uc, ErrDimensionMismatch)
+	}
+	uSim := mat.NewDense(m, g.steps, nil)
+	uRaw := u.RawMatrix()
+	uSimRaw := uSim.RawMatrix()
+	for i := 0; i < g.steps; i++ {
+		for j := 0; j < m; j++ {
+			uSimRaw.Data[j*uSimRaw.Stride+i] = uRaw.Data[i*uRaw.Stride+j]
+		}
+	}
+	return uSim, nil
+}
+
 func (sys *System) DCGain() (*mat.Dense, error) {
 	n, m, p := sys.Dims()
 
@@ -295,50 +348,18 @@ func Initial(sys *System, x0 *mat.VecDense, tFinal float64) (*TimeResponse, erro
 }
 
 func Lsim(sys *System, u *mat.Dense, t []float64, x0 *mat.VecDense) (*TimeResponse, error) {
-	if len(t) < 2 {
-		return nil, fmt.Errorf("Lsim: need at least 2 time points: %w", ErrDimensionMismatch)
+	grid, err := newTimeResponseGrid(t)
+	if err != nil {
+		return nil, err
 	}
-
 	_, m, _ := sys.Dims()
-	ur, uc := u.Dims()
-	if ur != len(t) || uc != m {
-		return nil, fmt.Errorf("Lsim: u must be %d×%d, got %d×%d: %w", len(t), m, ur, uc, ErrDimensionMismatch)
+	uSim, err := grid.inputByChannel(u, m)
+	if err != nil {
+		return nil, err
 	}
-
-	steps := len(t)
-	dt := t[1] - t[0]
-	if dt <= 0 {
-		return nil, fmt.Errorf("Lsim: time step must be positive, got %g: %w", dt, ErrDimensionMismatch)
-	}
-	for k := 2; k < steps; k++ {
-		dk := t[k] - t[k-1]
-		if math.Abs(dk-dt)/dt > 1e-6 {
-			return nil, fmt.Errorf("Lsim: non-uniform time grid at index %d (dt=%g, expected %g); uniform grid required: %w", k, dk, dt, ErrDimensionMismatch)
-		}
-	}
-
-	var dsys *System
-	var err error
-	if sys.IsContinuous() {
-		dsys, err = sys.DiscretizeZOH(dt)
-		if err != nil {
-			return nil, fmt.Errorf("Lsim: %w", err)
-		}
-	} else {
-		if math.Abs(sys.Dt-dt)/sys.Dt > 1e-6 {
-			return nil, fmt.Errorf("Lsim: time grid spacing %g does not match system Dt %g: %w", dt, sys.Dt, ErrDimensionMismatch)
-		}
-		dsys = sys
-	}
-
-	// Transpose u from len(t)×m to m×len(t) for Simulate
-	uSim := mat.NewDense(m, steps, nil)
-	uRaw := u.RawMatrix()
-	uSimRaw := uSim.RawMatrix()
-	for i := 0; i < steps; i++ {
-		for j := 0; j < m; j++ {
-			uSimRaw.Data[j*uSimRaw.Stride+i] = uRaw.Data[i*uRaw.Stride+j]
-		}
+	dsys, err := grid.prepareModel(sys)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := dsys.Simulate(uSim, x0, nil)

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -2,7 +2,6 @@ package controlsys
 
 import (
 	"fmt"
-	"math"
 
 	"gonum.org/v1/gonum/mat"
 )
@@ -20,9 +19,9 @@ func WithPadeOrder(n int) SafeFeedbackOption {
 	}
 }
 
-// WithThiranOrder is reserved for future fractional discrete-delay feedback
-// workflows. SafeFeedback currently absorbs exact integer discrete delays and
-// uses Pade approximation for continuous transport delays.
+// WithThiranOrder configures SafeFeedback to replace discrete-time fractional
+// external delays with Thiran allpass delay models before closing the loop.
+// Integer discrete delays remain exact delay states.
 func WithThiranOrder(n int) SafeFeedbackOption {
 	return func(c *safeFeedbackConfig) {
 		c.thiranOrder = n
@@ -171,34 +170,6 @@ func replaceDiscreteExternalDelaysWithThiran(sys *System, thiranOrder int) (*Sys
 	result.OutputDelay = nil
 	result.Delay = nil
 	return result, nil
-}
-
-func buildDiscreteSampleDelayBank(sampleDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
-	var bank *System
-	for i := 0; i < n; i++ {
-		tau := sampleDelay[i] * dt
-		var ch *System
-		var err error
-		if tau == 0 {
-			ch, err = NewGain(mat.NewDense(1, 1, []float64{1}), dt)
-		} else if math.Abs(sampleDelay[i]-math.Round(sampleDelay[i])) < 1e-9 {
-			ch, err = integerDelaySS(int(math.Round(sampleDelay[i])), dt)
-		} else {
-			ch, err = ThiranDelay(tau, thiranOrder, dt)
-		}
-		if err != nil {
-			return nil, err
-		}
-		if bank == nil {
-			bank = ch
-			continue
-		}
-		bank, err = Append(bank, ch)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return bank, nil
 }
 
 func replaceContinuousDelays(sys *System, padeOrder int) (*System, error) {


### PR DESCRIPTION
## Summary

- Deepens delay bank construction behind one private module shared by C2D, Safe feedback, Pade, and Thiran workflows.
- Deepens delayed LFT handling by naming external-delay preservation and fixes the Delta-only internal-delay path that the new public regression exposed.
- Centralizes Lsim sample-grid validation, sample-time matching, and input orientation through a time-response grid helper.
- Adds shared frequency-response matrix indexing for Bode/coherence layout and updates Safe feedback Thiran documentation.
- Adds PRD95 public regression coverage for delay bank, LFT delay, time-domain response, and frequency-response layout workflows.

## Verification

- `go test -v -count=1`
- `go test -run 'TestPRD95' -count=1`
- `go test -coverprofile=/tmp/controlsys-arch-cover.out ./... && go tool cover -func=/tmp/controlsys-arch-cover.out | tail -1` => `87.2%`
- Baseline: `go test -bench=. -benchmem -run '^$' > /tmp/controlsys-arch-before.bench`
- After: `go test -bench=. -benchmem -run '^$' > /tmp/controlsys-arch-after.bench`
- `benchstat /tmp/controlsys-arch-before.bench /tmp/controlsys-arch-after.bench > /tmp/controlsys-arch-benchstat.txt`

## Benchmark Notes

Benchstat found no statistically detected regressions (`n=1`, so all comparisons are marked `~`). Overall `sec/op` geomean moved `42.30µs -> 41.84µs` (`-1.11%`). Allocation geomeans were effectively unchanged.

Selected affected paths:

- `DiscretizeWithOpts_IODelayThiran-8`: `3.948µs -> 4.075µs`, no significant change
- `SafeFeedback-8`: `5.688µs -> 5.673µs`, no significant change
- `LFT-8`: `5.661µs -> 5.586µs`, no significant change
- `FreqRespEst_MIMO-8`: `382.9µs -> 381.0µs`, no significant change
- `SystemFRD_MIMO_2000-8`: `566.4µs -> 560.9µs`, no significant change
- `Lsim_MIMO_N10-8`: `123.11µs -> 93.20µs`, no significant change

Part of #95.
Closes #96.
Closes #97.
Closes #98.
Closes #99.
Closes #100.
