### PR TITLE
Refactor architecture issue slices

### DIFF
--- a/architecture_prd95_test.go
+++ b/architecture_prd95_test.go
@@ -1,0 +1,304 @@
+package controlsys
+
+import (
+	"errors"
+	"math"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func prd95MIMOModel(t *testing.T, dt float64) *System {
+	t.Helper()
+	sys, err := NewFromSlices(3, 2, 2,
+		[]float64{
+			0, 1, 0,
+			-2, -3, 0.5,
+			0.25, -0.75, -1.5,
+		},
+		[]float64{
+			1, 0,
+			0, 1,
+			0.5, -0.25,
+		},
+		[]float64{
+			1, 0.5, 0,
+			0, 1, -0.5,
+		},
+		[]float64{
+			0.05, -0.02,
+			0.01, 0.04,
+		},
+		dt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"u-left", "u-right"}
+	sys.OutputName = []string{"y-top", "y-bottom"}
+	sys.StateName = []string{"x-a", "x-b", "x-c"}
+	return sys
+}
+
+func TestPRD95DelayBankPublicWorkflowsShareRules(t *testing.T) {
+	plant := prd95MIMOModel(t, 0)
+	plant.InputDelay = []float64{0.35, 0}
+	plant.OutputDelay = []float64{0, 0.45}
+	if err := plant.SetDelay(mat.NewDense(2, 2, []float64{
+		0, 0.35,
+		0.45, 0.80,
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	disc, err := plant.DiscretizeWithOpts(0.1, C2DOptions{Method: "zoh", ThiranOrder: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disc.Delay != nil {
+		t.Fatalf("discretized model kept input-output delay: %v", disc.Delay)
+	}
+	for _, delays := range [][]float64{disc.InputDelay, disc.OutputDelay} {
+		for _, d := range delays {
+			if math.Abs(d-math.Round(d)) > 1e-12 {
+				t.Fatalf("discretized model kept fractional external delay: input=%v output=%v", disc.InputDelay, disc.OutputDelay)
+			}
+		}
+	}
+	if n, m, p := disc.Dims(); n <= 3 || m != 2 || p != 2 {
+		t.Fatalf("discretized dims = %d,%d,%d, want added delay states and 2x2 channels", n, m, p)
+	}
+
+	controller, err := NewGain(mat.NewDense(2, 2, []float64{0.1, 0.02, -0.03, 0.08}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.Dt = 0.1
+	discPlant := plant.Copy()
+	discPlant.Dt = 0.1
+	discPlant.InputDelay = []float64{3.5, 0}
+	discPlant.OutputDelay = []float64{0, 4.5}
+	discPlant.Delay = mat.NewDense(2, 2, []float64{
+		0, 3.5,
+		4.5, 8.0,
+	})
+
+	if _, err := SafeFeedback(discPlant, controller, -1); !errors.Is(err, ErrFractionalDelay) {
+		t.Fatalf("SafeFeedback without Thiran err = %v, want ErrFractionalDelay", err)
+	}
+	closed, err := SafeFeedback(discPlant, controller, -1, WithThiranOrder(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closed.HasDelay() {
+		t.Fatalf("SafeFeedback kept external delay: input=%v output=%v io=%v", closed.InputDelay, closed.OutputDelay, closed.Delay)
+	}
+}
+
+func TestPRD95DelayBankKeepsIntegerDelayExactWithThiranOrder(t *testing.T) {
+	sys := prd95MIMOModel(t, 0.1)
+	sys.InputDelay = []float64{2, 0}
+	sys.OutputDelay = []float64{0, 3}
+
+	controller, err := NewGain(mat.NewDense(2, 2, []float64{0.2, 0, 0, 0.1}), 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	closed, err := SafeFeedback(sys, controller, -1, WithThiranOrder(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, m, p := closed.Dims()
+	if m != 2 || p != 2 {
+		t.Fatalf("closed dims = %d,%d,%d, want 2x2 channels", n, m, p)
+	}
+	if n >= 3+2*3 {
+		t.Fatalf("closed state count = %d, want exact integer delay states rather than one Thiran block per delayed channel", n)
+	}
+}
+
+func TestPRD95LFTDelayWorkflowPreservesExternalDelayAndMetadata(t *testing.T) {
+	M, err := NewGain(mat.NewDense(2, 2, []float64{
+		0.2, 0.5,
+		1.0, 0.1,
+	}), 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	M.InputName = []string{"reference", "uncertain-return"}
+	M.OutputName = []string{"controlled", "uncertain-drive"}
+	if err := M.SetInputDelay([]float64{2, 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := M.SetOutputDelay([]float64{3, 0}); err != nil {
+		t.Fatal(err)
+	}
+
+	delta, err := New(
+		mat.NewDense(1, 1, []float64{0.8}),
+		mat.NewDense(1, 1, []float64{0.2}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0.1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := delta.SetInputDelay([]float64{2}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LFT(M, delta, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !floatSlicesEqual(result.InputDelay, []float64{2}) {
+		t.Fatalf("InputDelay = %v, want [2]", result.InputDelay)
+	}
+	if !floatSlicesEqual(result.OutputDelay, []float64{3}) {
+		t.Fatalf("OutputDelay = %v, want [3]", result.OutputDelay)
+	}
+	if !stringSlicesEqual(result.InputName, []string{"reference"}) {
+		t.Fatalf("InputName = %v", result.InputName)
+	}
+	if !stringSlicesEqual(result.OutputName, []string{"controlled"}) {
+		t.Fatalf("OutputName = %v", result.OutputName)
+	}
+	if !result.HasInternalDelay() {
+		t.Fatal("expected Delta delay to be represented as internal delay")
+	}
+
+	omega := []float64{0.2, 1.1, 2.7}
+	resp, err := result.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.NFreq != len(omega) || resp.P != 1 || resp.M != 1 {
+		t.Fatalf("FreqResponse dims = %d,%d,%d", resp.NFreq, resp.P, resp.M)
+	}
+}
+
+func TestPRD95TimeDomainResponsePreparationPublicContracts(t *testing.T) {
+	cont := prd95MIMOModel(t, 0)
+	cont.OutputName = []string{"temperature", "pressure"}
+	tFinal := 0.5
+
+	step, err := Step(cont, tFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(step.OutputName, cont.OutputName) {
+		t.Fatalf("Step OutputName = %v, want %v", step.OutputName, cont.OutputName)
+	}
+	imp, err := Impulse(cont, tFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(imp.OutputName, cont.OutputName) {
+		t.Fatalf("Impulse OutputName = %v, want %v", imp.OutputName, cont.OutputName)
+	}
+	initResp, err := Initial(cont, mat.NewVecDense(3, []float64{1, -1, 0.5}), tFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stringSlicesEqual(initResp.OutputName, cont.OutputName) {
+		t.Fatalf("Initial OutputName = %v, want %v", initResp.OutputName, cont.OutputName)
+	}
+
+	disc, err := cont.DiscretizeZOH(0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tvec := []float64{0, 0.1, 0.2, 0.3, 0.4}
+	uLsim := mat.NewDense(len(tvec), 2, []float64{
+		1, -1,
+		0.5, -0.5,
+		0.25, -0.25,
+		0, 0,
+		-0.25, 0.25,
+	})
+	uSim := mat.NewDense(2, len(tvec), []float64{
+		1, 0.5, 0.25, 0, -0.25,
+		-1, -0.5, -0.25, 0, 0.25,
+	})
+	lsim, err := Lsim(disc, uLsim, tvec, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sim, err := disc.Simulate(uSim, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertDenseApprox(t, lsim.Y, sim.Y, 1e-12)
+
+	if _, err := Lsim(disc, uLsim, []float64{0, 0.1, 0.25, 0.3, 0.4}, nil); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("non-uniform Lsim err = %v, want ErrDimensionMismatch", err)
+	}
+	otherDt := disc.Copy()
+	otherDt.Dt = 0.2
+	if _, err := Lsim(otherDt, uLsim, tvec, nil); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("Dt mismatch Lsim err = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestPRD95FrequencyResponseLayoutPublicWorkflowsAgree(t *testing.T) {
+	sys := prd95MIMOModel(t, 0.1)
+	omega := []float64{0.2, 1.0, 2.4}
+	resp, err := sys.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frd, err := sys.FRD(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bode, err := sys.Bode(omega, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for k := range omega {
+		for i := 0; i < resp.P; i++ {
+			for j := 0; j < resp.M; j++ {
+				h := resp.At(k, i, j)
+				assertComplexApprox(t, frd.At(k, i, j), h, 1e-12)
+				wantMag := 20 * math.Log10(cmplx.Abs(h))
+				if math.Abs(bode.MagDBAt(k, i, j)-wantMag) > 1e-10 {
+					t.Fatalf("Bode mag[%d,%d,%d] = %v, want %v", k, i, j, bode.MagDBAt(k, i, j), wantMag)
+				}
+			}
+		}
+	}
+
+	dt := 0.05
+	steps := 512
+	u := mat.NewDense(2, steps, nil)
+	for k := range steps {
+		u.Set(0, k, math.Sin(0.17*float64(k)))
+		u.Set(1, k, math.Cos(0.11*float64(k)))
+	}
+	disc, err := sys.D2D(dt, C2DOptions{Method: "tustin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sim, err := disc.Simulate(u, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	est, err := FreqRespEst(u, sim.Y, dt, &FreqRespEstOpts{NFFT: 128})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for f := range est.Omega {
+		for i := 0; i < est.H.P; i++ {
+			for j := 0; j < est.H.M; j++ {
+				coh := est.CoherenceAt(f, i, j)
+				if coh < 0 || coh > 1+1e-9 {
+					t.Fatalf("coherence[%d,%d,%d] = %v, want [0,1]", f, i, j, coh)
+				}
+			}
+		}
+	}
+}

--- a/connect.go
+++ b/connect.go
@@ -1403,30 +1403,12 @@ func Connect(sys *System, Q *mat.Dense, inputs, outputs []int) (*System, error) 
 func connectWithDelay(sys *System, Q *mat.Dense, inputs, outputs []int) (*System, error) {
 	_, m, p := sys.Dims()
 
-	savedInputDelay := make([]float64, len(inputs))
-	if sys.InputDelay != nil {
-		for k, j := range inputs {
-			savedInputDelay[k] = sys.InputDelay[j]
-		}
-	}
-	savedOutputDelay := make([]float64, len(outputs))
-	if sys.OutputDelay != nil {
-		for k, i := range outputs {
-			savedOutputDelay[k] = sys.OutputDelay[i]
-		}
-	}
+	savedInputDelay := selectVisibleDelays(sys.InputDelay, inputs)
+	savedOutputDelay := selectVisibleDelays(sys.OutputDelay, outputs)
 
 	sCopy := sys.Copy()
-	if sCopy.InputDelay != nil {
-		for _, j := range inputs {
-			sCopy.InputDelay[j] = 0
-		}
-	}
-	if sCopy.OutputDelay != nil {
-		for _, i := range outputs {
-			sCopy.OutputDelay[i] = 0
-		}
-	}
+	sCopy.InputDelay = clearDelayIndexes(sCopy.InputDelay, inputs)
+	sCopy.OutputDelay = clearDelayIndexes(sCopy.OutputDelay, outputs)
 
 	sLFT, err := sCopy.PullDelaysToLFT()
 	if err != nil {
@@ -1576,25 +1558,11 @@ func connectWithDelay(sys *System, Q *mat.Dense, inputs, outputs []int) (*System
 		return nil, err
 	}
 
-	hasExtIn := false
-	for _, v := range savedInputDelay {
-		if v != 0 {
-			hasExtIn = true
-			break
-		}
+	if savedInputDelay.hasNonzero {
+		result.InputDelay = savedInputDelay.values
 	}
-	if hasExtIn {
-		result.InputDelay = savedInputDelay
-	}
-	hasExtOut := false
-	for _, v := range savedOutputDelay {
-		if v != 0 {
-			hasExtOut = true
-			break
-		}
-	}
-	if hasExtOut {
-		result.OutputDelay = savedOutputDelay
+	if savedOutputDelay.hasNonzero {
+		result.OutputDelay = savedOutputDelay.values
 	}
 
 	result.InputName = selectStringSlice(sys.InputName, inputs)

--- a/convert.go
+++ b/convert.go
@@ -381,7 +381,7 @@ func absorbFractionalDelays(disc *System, contInputDelay, contOutputDelay []floa
 	_, m, p := disc.Dims()
 
 	if contInputDelay != nil {
-		bank, err := buildDelayBank(contInputDelay, m, dt, thiranOrder)
+		bank, err := buildContinuousDelayBank(contInputDelay, m, dt, thiranOrder)
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +395,7 @@ func absorbFractionalDelays(disc *System, contInputDelay, contOutputDelay []floa
 	}
 
 	if contOutputDelay != nil {
-		bank, err := buildDelayBank(contOutputDelay, p, dt, thiranOrder)
+		bank, err := buildContinuousDelayBank(contOutputDelay, p, dt, thiranOrder)
 		if err != nil {
 			return nil, err
 		}
@@ -409,60 +409,6 @@ func absorbFractionalDelays(disc *System, contInputDelay, contOutputDelay []floa
 	}
 
 	return disc, nil
-}
-
-func buildDelayBank(contDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
-	hasFractional := false
-	for _, tau := range contDelay {
-		if tau == 0 {
-			continue
-		}
-		samples := tau / dt
-		if math.Abs(samples-math.Round(samples)) >= 1e-9 {
-			hasFractional = true
-			break
-		}
-	}
-	if !hasFractional {
-		return nil, nil
-	}
-
-	var bank *System
-	for i := 0; i < n; i++ {
-		tau := contDelay[i]
-		var ch *System
-		var err error
-
-		if tau == 0 {
-			ch, err = NewGain(mat.NewDense(1, 1, []float64{1}), dt)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			samples := tau / dt
-			if math.Abs(samples-math.Round(samples)) < 1e-9 {
-				ch, err = integerDelaySS(int(math.Round(samples)), dt)
-				if err != nil {
-					return nil, err
-				}
-			} else {
-				ch, err = ThiranDelay(tau, thiranOrder, dt)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-
-		if bank == nil {
-			bank = ch
-		} else {
-			bank, err = Append(bank, ch)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	return bank, nil
 }
 
 func (sys *System) DiscretizeZOH(dt float64) (*System, error) {

--- a/delay_bank.go
+++ b/delay_bank.go
@@ -1,0 +1,87 @@
+package controlsys
+
+import (
+	"math"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type delayBankSpec struct {
+	sampleDelay             []float64
+	channels                int
+	dt                      float64
+	thiranOrder             int
+	requiresFractionalModel bool
+}
+
+func buildContinuousDelayBank(contDelay []float64, channels int, dt float64, thiranOrder int) (*System, error) {
+	sampleDelay := make([]float64, channels)
+	for i := 0; i < channels; i++ {
+		sampleDelay[i] = contDelay[i] / dt
+	}
+	return buildDelayBank(delayBankSpec{
+		sampleDelay:             sampleDelay,
+		channels:                channels,
+		dt:                      dt,
+		thiranOrder:             thiranOrder,
+		requiresFractionalModel: true,
+	})
+}
+
+func buildDiscreteSampleDelayBank(sampleDelay []float64, channels int, dt float64, thiranOrder int) (*System, error) {
+	return buildDelayBank(delayBankSpec{
+		sampleDelay: sampleDelay,
+		channels:    channels,
+		dt:          dt,
+		thiranOrder: thiranOrder,
+	})
+}
+
+func buildDelayBank(spec delayBankSpec) (*System, error) {
+	if spec.requiresFractionalModel && !hasFractionalSampleDelay(spec.sampleDelay) {
+		return nil, nil
+	}
+
+	var bank *System
+	for i := 0; i < spec.channels; i++ {
+		ch, err := buildDelayChannel(spec.sampleDelay[i], spec.dt, spec.thiranOrder)
+		if err != nil {
+			return nil, err
+		}
+		if bank == nil {
+			bank = ch
+			continue
+		}
+		bank, err = Append(bank, ch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return bank, nil
+}
+
+func hasFractionalSampleDelay(sampleDelay []float64) bool {
+	for _, samples := range sampleDelay {
+		if samples == 0 {
+			continue
+		}
+		if !isIntegerSampleDelay(samples) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildDelayChannel(samples, dt float64, thiranOrder int) (*System, error) {
+	if samples == 0 {
+		return NewGain(mat.NewDense(1, 1, []float64{1}), dt)
+	}
+	if isIntegerSampleDelay(samples) {
+		return integerDelaySS(int(math.Round(samples)), dt)
+	}
+	return ThiranDelay(samples*dt, thiranOrder, dt)
+}
+
+func isIntegerSampleDelay(samples float64) bool {
+	return math.Abs(samples-math.Round(samples)) < 1e-9
+}

--- a/delay_visibility.go
+++ b/delay_visibility.go
@@ -1,0 +1,56 @@
+package controlsys
+
+type visibleDelaySelection struct {
+	values     []float64
+	hasNonzero bool
+}
+
+func selectVisibleDelays(delay []float64, indexes []int) visibleDelaySelection {
+	out := visibleDelaySelection{values: make([]float64, len(indexes))}
+	if delay == nil {
+		return out
+	}
+	for k, idx := range indexes {
+		out.values[k] = delay[idx]
+		if delay[idx] != 0 {
+			out.hasNonzero = true
+		}
+	}
+	return out
+}
+
+func selectLeadingVisibleDelays(delay []float64, n int) visibleDelaySelection {
+	out := visibleDelaySelection{values: make([]float64, n)}
+	if delay == nil {
+		return out
+	}
+	copy(out.values, delay[:n])
+	out.hasNonzero = delaySliceHasNonzero(out.values)
+	return out
+}
+
+func clearDelayIndexes(delay []float64, indexes []int) []float64 {
+	if delay == nil {
+		return nil
+	}
+	for _, idx := range indexes {
+		delay[idx] = 0
+	}
+	if delaySliceHasNonzero(delay) {
+		return delay
+	}
+	return nil
+}
+
+func clearLeadingDelays(delay []float64, n int) []float64 {
+	if delay == nil {
+		return nil
+	}
+	for i := 0; i < n; i++ {
+		delay[i] = 0
+	}
+	if delaySliceHasNonzero(delay) {
+		return delay
+	}
+	return nil
+}

--- a/frd.go
+++ b/frd.go
@@ -5,8 +5,6 @@ import (
 	"math"
 	"math/cmplx"
 	"sort"
-
-	"gonum.org/v1/gonum/lapack"
 )
 
 // FRD represents a Frequency Response Data model — measured or computed
@@ -299,55 +297,13 @@ func (f *FRD) Sigma() (*SigmaResult, error) {
 		return &SigmaResult{Omega: omega, sv: sv, nSV: nsv}, nil
 	}
 
-	ws := newFRDSVDWorkspace(p, m)
+	ws := newComplexSVDWorkspace(p, m)
 	for k := 0; k < nw; k++ {
-		H := f.Response[k]
-		for i := 0; i < p; i++ {
-			top := i * ws.cols
-			bottom := (p + i) * ws.cols
-			for j := 0; j < m; j++ {
-				h := H[i][j]
-				ws.block[top+j] = real(h)
-				ws.block[top+m+j] = -imag(h)
-				ws.block[bottom+j] = imag(h)
-				ws.block[bottom+m+j] = real(h)
-			}
-		}
-		impl.Dgesvd(lapack.SVDNone, lapack.SVDNone, ws.rows, ws.cols, ws.block, ws.cols,
-			ws.fullSV, nil, 1, nil, 1, ws.work, len(ws.work))
-		for i := 0; i < nsv; i++ {
-			sv[k*nsv+i] = ws.fullSV[2*i]
-		}
+		ws.singularValuesFromNested(sv[k*nsv:(k+1)*nsv], f.Response[k], p, m)
 	}
 	omega := make([]float64, nw)
 	copy(omega, f.Omega)
 	return &SigmaResult{Omega: omega, sv: sv, nSV: nsv}, nil
-}
-
-type frdSVDWorkspace struct {
-	block  []float64
-	fullSV []float64
-	work   []float64
-	rows   int
-	cols   int
-}
-
-func newFRDSVDWorkspace(p, m int) *frdSVDWorkspace {
-	rows := 2 * p
-	cols := 2 * m
-	fullSV := make([]float64, min(rows, cols))
-	block := make([]float64, rows*cols)
-	workQuery := make([]float64, 1)
-	impl.Dgesvd(lapack.SVDNone, lapack.SVDNone, rows, cols, block, cols,
-		fullSV, nil, 1, nil, 1, workQuery, -1)
-	work := make([]float64, int(workQuery[0]))
-	return &frdSVDWorkspace{
-		block:  block,
-		fullSV: fullSV,
-		work:   work,
-		rows:   rows,
-		cols:   cols,
-	}
 }
 
 func FRDMargin(f *FRD) (*MarginResult, error) {

--- a/frequency.go
+++ b/frequency.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"math/cmplx"
 
-	"gonum.org/v1/gonum/lapack"
 	"gonum.org/v1/gonum/mat"
 )
 
@@ -692,27 +691,6 @@ func (r *SigmaResult) NSV() int {
 	return r.nSV
 }
 
-type svdWorkspace struct {
-	rData []float64
-	sv    []float64
-	work  []float64
-	p, m  int
-}
-
-func newSVDWorkspace(p, m int) *svdWorkspace {
-	rows := 2 * p
-	cols := m
-	nSV := min(rows, cols)
-	rData := make([]float64, rows*cols)
-	sv := make([]float64, nSV)
-
-	wq := make([]float64, 1)
-	impl.Dgesvd(lapack.SVDNone, lapack.SVDNone, rows, cols, rData, cols, sv, nil, 1, nil, 1, wq, -1)
-	work := make([]float64, int(wq[0]))
-
-	return &svdWorkspace{rData: rData, sv: sv, work: work, p: p, m: m}
-}
-
 func (sys *System) Sigma(omega []float64, nPoints int) (*SigmaResult, error) {
 	if omega == nil {
 		var err error
@@ -748,24 +726,12 @@ func (sys *System) Sigma(omega []float64, nPoints int) (*SigmaResult, error) {
 		return &SigmaResult{Omega: omega, sv: sv, nSV: 1, InputName: copyStringSlice(sys.InputName), OutputName: copyStringSlice(sys.OutputName)}, nil
 	}
 
-	ws := newSVDWorkspace(p, m)
+	ws := newComplexSVDWorkspace(p, m)
 	allSV := make([]float64, nw*nSV)
-	rData := ws.rData
 
 	for k := range nw {
 		base := k * pm
-		for i := range p {
-			row := i * m
-			rowShift := (p + i) * m
-			for j := range m {
-				h := data[base+row+j]
-				rData[row+j] = real(h)
-				rData[rowShift+j] = imag(h)
-			}
-		}
-		impl.Dgesvd(lapack.SVDNone, lapack.SVDNone, 2*p, m, rData, m,
-			ws.sv, nil, 1, nil, 1, ws.work, len(ws.work))
-		copy(allSV[k*nSV:], ws.sv[:nSV])
+		ws.singularValuesFromFlat(allSV[k*nSV:(k+1)*nSV], data, base, p, m)
 	}
 
 	return &SigmaResult{Omega: omega, sv: allSV, nSV: nSV, InputName: copyStringSlice(sys.InputName), OutputName: copyStringSlice(sys.OutputName)}, nil

--- a/frequency_svd.go
+++ b/frequency_svd.go
@@ -1,0 +1,109 @@
+package controlsys
+
+import (
+	"math"
+	"math/cmplx"
+
+	"gonum.org/v1/gonum/blas"
+	"gonum.org/v1/gonum/lapack"
+)
+
+type complexSVDWorkspace struct {
+	block  []float64
+	eig    []float64
+	work   []float64
+	nSV    int
+	gramN  int
+	blockN int
+	useCol bool
+}
+
+func newComplexSVDWorkspace(p, m int) *complexSVDWorkspace {
+	gramN := min(p, m)
+	blockN := 2 * gramN
+	block := make([]float64, blockN*blockN)
+	eig := make([]float64, blockN)
+	workQuery := make([]float64, 1)
+	impl.Dsyev(lapack.EVNone, blas.Upper, blockN, block, blockN, eig, workQuery, -1)
+	work := make([]float64, int(workQuery[0]))
+	return &complexSVDWorkspace{
+		block:  block,
+		eig:    eig,
+		work:   work,
+		nSV:    gramN,
+		gramN:  gramN,
+		blockN: blockN,
+		useCol: m <= p,
+	}
+}
+
+func (ws *complexSVDWorkspace) singularValuesFromFlat(dst []float64, data []complex128, base, p, m int) {
+	ws.fillBlock(func(i, j int) complex128 {
+		return data[base+i*m+j]
+	}, p, m)
+	ws.singularValues(dst)
+}
+
+func (ws *complexSVDWorkspace) singularValuesFromNested(dst []float64, data [][]complex128, p, m int) {
+	ws.fillBlock(func(i, j int) complex128 {
+		return data[i][j]
+	}, p, m)
+	ws.singularValues(dst)
+}
+
+func (ws *complexSVDWorkspace) fillBlock(at func(i, j int) complex128, p, m int) {
+	n := ws.gramN
+	stride := ws.blockN
+	for i := range ws.block {
+		ws.block[i] = 0
+	}
+
+	for a := 0; a < n; a++ {
+		for b := 0; b < n; b++ {
+			var g complex128
+			if ws.useCol {
+				for row := 0; row < p; row++ {
+					g += cmplx.Conj(at(row, a)) * at(row, b)
+				}
+			} else {
+				for col := 0; col < m; col++ {
+					g += at(a, col) * cmplx.Conj(at(b, col))
+				}
+			}
+
+			re, im := real(g), imag(g)
+			ws.block[a*stride+b] = re
+			ws.block[a*stride+n+b] = -im
+			ws.block[(n+a)*stride+b] = im
+			ws.block[(n+a)*stride+n+b] = re
+		}
+	}
+}
+
+func (ws *complexSVDWorkspace) singularValues(dst []float64) {
+	ok := impl.Dsyev(lapack.EVNone, blas.Upper, ws.blockN, ws.block, ws.blockN, ws.eig, ws.work, len(ws.work))
+	if !ok {
+		for i := range dst {
+			dst[i] = math.NaN()
+		}
+		return
+	}
+	scale := 1.0
+	for _, lambda := range ws.eig {
+		scale = max(scale, math.Abs(lambda))
+	}
+	for i := range dst {
+		lambda := nonnegativeGramEigenvalue(ws.eig[ws.blockN-1-2*i], scale)
+		dst[i] = math.Sqrt(lambda)
+	}
+}
+
+func nonnegativeGramEigenvalue(lambda, scale float64) float64 {
+	if lambda >= 0 {
+		return lambda
+	}
+	if lambda > -1e-12*max(1, scale) {
+		return 0
+	}
+	return lambda
+}

--- a/frequency_test.go
+++ b/frequency_test.go
@@ -695,18 +695,18 @@ func TestEvalFr_IODelay_Continuous(t *testing.T) {
 		t.Fatal(err)
 	}
 	sys.InputDelay = []float64{2.0}
-	
+
 	w := 5.0
 	s := complex(0, w)
 	val, err := sys.EvalFr(s)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	// Transfer function is 1/(s+1) * e^{-2s}
 	tf := 1.0 / (s + 1)
-	expected := tf * cmplx.Exp(-s * complex(2.0, 0))
-	
+	expected := tf * cmplx.Exp(-s*complex(2.0, 0))
+
 	if cmplx.Abs(val[0][0]-expected) > 1e-10 {
 		t.Errorf("EvalFr with I/O delay mismatch. got: %v, want: %v", val[0][0], expected)
 	}
@@ -724,14 +724,14 @@ func TestEvalFr_IODelay_Discrete(t *testing.T) {
 		t.Fatal(err)
 	}
 	sys.OutputDelay = []float64{3.0}
-	
+
 	w := 2.0
 	s := cmplx.Exp(complex(0, w*sys.Dt))
 	val, err := sys.EvalFr(s)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	// Transfer function is 1/(z-0.5) / z^3
 	tf := 1.0 / (s - 0.5)
 	expected := tf / (s * s * s)
@@ -1071,6 +1071,69 @@ func TestSigma_NonSquare(t *testing.T) {
 		if r.At(0, i) < 0 {
 			t.Errorf("negative sv[%d] = %v", i, r.At(0, i))
 		}
+	}
+}
+
+func TestSigmaMatchesFRDForCoupledMIMOResponse(t *testing.T) {
+	sys, err := NewFromSlices(3, 2, 2,
+		[]float64{
+			0, 1, 0,
+			-2, -3, 1,
+			0.5, -0.25, -1.5,
+		},
+		[]float64{
+			1, 0,
+			0, 1,
+			1, -1,
+		},
+		[]float64{
+			1, 0.5, -0.25,
+			0.2, 1, 0.75,
+		},
+		[]float64{
+			0.1, -0.2,
+			0.05, 0.3,
+		},
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	omega := []float64{0.2, 1.3, 4.0}
+	fromSystem, err := sys.Sigma(omega, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frd, err := sys.FRD(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromFRD, err := frd.Sigma()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fromSystem.NSV() != fromFRD.NSV() {
+		t.Fatalf("NSV System=%d FRD=%d", fromSystem.NSV(), fromFRD.NSV())
+	}
+	for k := range omega {
+		for sv := 0; sv < fromSystem.NSV(); sv++ {
+			got := fromSystem.At(k, sv)
+			want := fromFRD.At(k, sv)
+			if math.Abs(got-want) > 1e-10*math.Max(1, math.Abs(want)) {
+				t.Fatalf("omega[%d] sv[%d]: System.Sigma=%g FRD.Sigma=%g", k, sv, got, want)
+			}
+		}
+	}
+}
+
+func TestSigmaClampsGramEigenvalueRelativeToScale(t *testing.T) {
+	if got := nonnegativeGramEigenvalue(-1e3, 1e16); got != 0 {
+		t.Fatalf("relative tiny negative eigenvalue = %g, want 0", got)
+	}
+	if got := nonnegativeGramEigenvalue(-1e3, 1); got != -1e3 {
+		t.Fatalf("large negative eigenvalue = %g, want preserved negative", got)
 	}
 }
 

--- a/lft.go
+++ b/lft.go
@@ -187,60 +187,12 @@ func solveLFTLoop(D22M, DDelta *mat.Dense, w int) (*mat.Dense, error) {
 func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 	_, mM, pM := M.Dims()
 
-	savedInputDelay := make([]float64, nu)
-	if M.InputDelay != nil {
-		copy(savedInputDelay, M.InputDelay[:nu])
-	}
-	savedOutputDelay := make([]float64, ny)
-	if M.OutputDelay != nil {
-		copy(savedOutputDelay, M.OutputDelay[:ny])
-	}
-	hasExtInput := false
-	for _, v := range savedInputDelay {
-		if v != 0 {
-			hasExtInput = true
-			break
-		}
-	}
-	hasExtOutput := false
-	for _, v := range savedOutputDelay {
-		if v != 0 {
-			hasExtOutput = true
-			break
-		}
-	}
+	savedInputDelay := selectLeadingVisibleDelays(M.InputDelay, nu)
+	savedOutputDelay := selectLeadingVisibleDelays(M.OutputDelay, ny)
 
 	mCopy := M.Copy()
-	if mCopy.InputDelay != nil {
-		for i := 0; i < nu; i++ {
-			mCopy.InputDelay[i] = 0
-		}
-		allZero := true
-		for _, v := range mCopy.InputDelay {
-			if v != 0 {
-				allZero = false
-				break
-			}
-		}
-		if allZero {
-			mCopy.InputDelay = nil
-		}
-	}
-	if mCopy.OutputDelay != nil {
-		for i := 0; i < ny; i++ {
-			mCopy.OutputDelay[i] = 0
-		}
-		allZero := true
-		for _, v := range mCopy.OutputDelay {
-			if v != 0 {
-				allZero = false
-				break
-			}
-		}
-		if allZero {
-			mCopy.OutputDelay = nil
-		}
-	}
+	mCopy.InputDelay = clearLeadingDelays(mCopy.InputDelay, nu)
+	mCopy.OutputDelay = clearLeadingDelays(mCopy.OutputDelay, ny)
 
 	mLFT, err := mCopy.PullDelaysToLFT()
 	if err != nil {
@@ -356,11 +308,11 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 		if err != nil {
 			return nil, err
 		}
-		if hasExtInput {
-			sys.InputDelay = savedInputDelay
+		if savedInputDelay.hasNonzero {
+			sys.InputDelay = savedInputDelay.values
 		}
-		if hasExtOutput {
-			sys.OutputDelay = savedOutputDelay
+		if savedOutputDelay.hasNonzero {
+			sys.OutputDelay = savedOutputDelay.values
 		}
 		if M.InputName != nil {
 			sys.InputName = copyStringSlice(M.InputName[:nu])
@@ -388,7 +340,9 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 		D12iD = extractBlock(dH.D, 0, w, z, ND)
 		D21iD = extractBlock(dH.D, z, 0, ND, w)
 		GD12iD = mulDense(G, D12iD)
-		FD12iMw = mulDense(F, D12iMw)
+		if NM > 0 {
+			FD12iMw = mulDense(F, D12iMw)
+		}
 		FD22pD12iD = mulDense(F, mulDense(D22p, D12iD))
 	}
 
@@ -513,11 +467,11 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 	if err != nil {
 		return nil, err
 	}
-	if hasExtInput {
-		result.InputDelay = savedInputDelay
+	if savedInputDelay.hasNonzero {
+		result.InputDelay = savedInputDelay.values
 	}
-	if hasExtOutput {
-		result.OutputDelay = savedOutputDelay
+	if savedOutputDelay.hasNonzero {
+		result.OutputDelay = savedOutputDelay.values
 	}
 	if M.InputName != nil {
 		result.InputName = copyStringSlice(M.InputName[:nu])

--- a/response.go
+++ b/response.go
@@ -14,6 +14,15 @@ type TimeResponse struct {
 	OutputName []string
 }
 
+type timeResponsePlan struct {
+	original      *System
+	sim           *System
+	t             []float64
+	dt            float64
+	steps         int
+	wasContinuous bool
+}
+
 type DampInfo struct {
 	Pole complex128
 	Wn   float64
@@ -84,23 +93,37 @@ func autoTimeParams(sys *System) (dt, tFinal float64, err error) {
 }
 
 func prepareDiscrete(sys *System, tFinal, dt float64) (dsys *System, actualDt float64, steps int, wasContinuous bool, err error) {
+	plan, err := prepareAutoTimeResponse(sys, tFinal, dt)
+	if err != nil {
+		return nil, 0, 0, false, err
+	}
+	return plan.sim, plan.dt, plan.steps, plan.wasContinuous, nil
+}
+
+func prepareAutoTimeResponse(sys *System, tFinal, dt float64) (timeResponsePlan, error) {
 	if sys.IsDiscrete() {
-		actualDt = sys.Dt
+		actualDt := sys.Dt
 		if tFinal <= 0 {
+			var err error
 			_, tFinal, err = autoTimeParams(sys)
 			if err != nil {
-				return nil, 0, 0, false, err
+				return timeResponsePlan{}, err
 			}
 		}
-		steps = int(tFinal/actualDt) + 1
-		return sys, actualDt, steps, false, nil
+		steps := int(tFinal/actualDt) + 1
+		return timeResponsePlan{
+			original: sys,
+			sim:      sys,
+			t:        makeTimeVector(steps, actualDt),
+			dt:       actualDt,
+			steps:    steps,
+		}, nil
 	}
 
-	wasContinuous = true
 	if tFinal <= 0 || dt <= 0 {
 		autoDt, autoTf, err2 := autoTimeParams(sys)
 		if err2 != nil {
-			return nil, 0, 0, true, err2
+			return timeResponsePlan{}, err2
 		}
 		if tFinal <= 0 {
 			tFinal = autoTf
@@ -110,13 +133,20 @@ func prepareDiscrete(sys *System, tFinal, dt float64) (dsys *System, actualDt fl
 		}
 	}
 
-	dsys, err = sys.DiscretizeZOH(dt)
+	dsys, err := sys.DiscretizeZOH(dt)
 	if err != nil {
-		return nil, 0, 0, true, fmt.Errorf("auto-discretize: %w", err)
+		return timeResponsePlan{}, fmt.Errorf("auto-discretize: %w", err)
 	}
-	actualDt = dt
-	steps = int(tFinal/dt) + 1
-	return dsys, actualDt, steps, true, nil
+	actualDt := dt
+	steps := int(tFinal/dt) + 1
+	return timeResponsePlan{
+		original:      sys,
+		sim:           dsys,
+		t:             makeTimeVector(steps, actualDt),
+		dt:            actualDt,
+		steps:         steps,
+		wasContinuous: true,
+	}, nil
 }
 
 func makeTimeVector(steps int, dt float64) []float64 {
@@ -125,6 +155,76 @@ func makeTimeVector(steps int, dt float64) []float64 {
 		t[k] = float64(k) * dt
 	}
 	return t
+}
+
+func (p timeResponsePlan) response(Y *mat.Dense) *TimeResponse {
+	return &TimeResponse{T: p.t, Y: Y, OutputName: copyStringSlice(p.original.OutputName)}
+}
+
+func prepareLsimResponse(sys *System, u *mat.Dense, t []float64) (timeResponsePlan, *mat.Dense, error) {
+	if len(t) < 2 {
+		return timeResponsePlan{}, nil, fmt.Errorf("Lsim: need at least 2 time points: %w", ErrDimensionMismatch)
+	}
+
+	_, m, _ := sys.Dims()
+	ur, uc := u.Dims()
+	if ur != len(t) || uc != m {
+		return timeResponsePlan{}, nil, fmt.Errorf("Lsim: u must be %d×%d, got %d×%d: %w", len(t), m, ur, uc, ErrDimensionMismatch)
+	}
+
+	dt, err := validateUniformTimeGrid("Lsim", t)
+	if err != nil {
+		return timeResponsePlan{}, nil, err
+	}
+
+	var dsys *System
+	if sys.IsContinuous() {
+		dsys, err = sys.DiscretizeZOH(dt)
+		if err != nil {
+			return timeResponsePlan{}, nil, fmt.Errorf("Lsim: %w", err)
+		}
+	} else {
+		if math.Abs(sys.Dt-dt)/sys.Dt > 1e-6 {
+			return timeResponsePlan{}, nil, fmt.Errorf("Lsim: time grid spacing %g does not match system Dt %g: %w", dt, sys.Dt, ErrDimensionMismatch)
+		}
+		dsys = sys
+	}
+
+	plan := timeResponsePlan{
+		original:      sys,
+		sim:           dsys,
+		t:             t,
+		dt:            dt,
+		steps:         len(t),
+		wasContinuous: sys.IsContinuous(),
+	}
+	return plan, transposeSamplesToChannels(u, len(t), m), nil
+}
+
+func validateUniformTimeGrid(context string, t []float64) (float64, error) {
+	dt := t[1] - t[0]
+	if dt <= 0 {
+		return 0, fmt.Errorf("%s: time step must be positive, got %g: %w", context, dt, ErrDimensionMismatch)
+	}
+	for k := 2; k < len(t); k++ {
+		dk := t[k] - t[k-1]
+		if math.Abs(dk-dt)/dt > 1e-6 {
+			return 0, fmt.Errorf("%s: non-uniform time grid at index %d (dt=%g, expected %g); uniform grid required: %w", context, k, dk, dt, ErrDimensionMismatch)
+		}
+	}
+	return dt, nil
+}
+
+func transposeSamplesToChannels(u *mat.Dense, steps, inputs int) *mat.Dense {
+	uSim := mat.NewDense(inputs, steps, nil)
+	uRaw := u.RawMatrix()
+	uSimRaw := uSim.RawMatrix()
+	for i := 0; i < steps; i++ {
+		for j := 0; j < inputs; j++ {
+			uSimRaw.Data[j*uSimRaw.Stride+i] = uRaw.Data[i*uRaw.Stride+j]
+		}
+	}
+	return uSim
 }
 
 func (sys *System) DCGain() (*mat.Dense, error) {
@@ -210,68 +310,68 @@ func Damp(sys *System) ([]DampInfo, error) {
 }
 
 func Step(sys *System, tFinal float64) (*TimeResponse, error) {
-	dsys, dt, steps, _, err := prepareDiscrete(sys, tFinal, 0)
+	plan, err := prepareAutoTimeResponse(sys, tFinal, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	_, m, p := dsys.Dims()
+	_, m, p := plan.sim.Dims()
 	rows := p * m
-	Y := mat.NewDense(rows, steps, nil)
+	Y := mat.NewDense(rows, plan.steps, nil)
 
 	for j := 0; j < m; j++ {
-		u := mat.NewDense(m, steps, nil)
-		for k := 0; k < steps; k++ {
+		u := mat.NewDense(m, plan.steps, nil)
+		for k := 0; k < plan.steps; k++ {
 			u.Set(j, k, 1)
 		}
-		resp, err := dsys.Simulate(u, nil, nil)
+		resp, err := plan.sim.Simulate(u, nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("Step: input %d: %w", j, err)
 		}
 		if resp.Y != nil {
 			for i := 0; i < p; i++ {
-				for k := 0; k < steps; k++ {
+				for k := 0; k < plan.steps; k++ {
 					Y.Set(j*p+i, k, resp.Y.At(i, k))
 				}
 			}
 		}
 	}
 
-	return &TimeResponse{T: makeTimeVector(steps, dt), Y: Y, OutputName: copyStringSlice(sys.OutputName)}, nil
+	return plan.response(Y), nil
 }
 
 func Impulse(sys *System, tFinal float64) (*TimeResponse, error) {
-	dsys, dt, steps, wasContinuous, err := prepareDiscrete(sys, tFinal, 0)
+	plan, err := prepareAutoTimeResponse(sys, tFinal, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	_, m, p := dsys.Dims()
+	_, m, p := plan.sim.Dims()
 	rows := p * m
-	Y := mat.NewDense(rows, steps, nil)
+	Y := mat.NewDense(rows, plan.steps, nil)
 
 	amp := 1.0
-	if wasContinuous {
-		amp = 1.0 / dt
+	if plan.wasContinuous {
+		amp = 1.0 / plan.dt
 	}
 
 	for j := 0; j < m; j++ {
-		u := mat.NewDense(m, steps, nil)
+		u := mat.NewDense(m, plan.steps, nil)
 		u.Set(j, 0, amp)
-		resp, err := dsys.Simulate(u, nil, nil)
+		resp, err := plan.sim.Simulate(u, nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("Impulse: input %d: %w", j, err)
 		}
 		if resp.Y != nil {
 			for i := 0; i < p; i++ {
-				for k := 0; k < steps; k++ {
+				for k := 0; k < plan.steps; k++ {
 					Y.Set(j*p+i, k, resp.Y.At(i, k))
 				}
 			}
 		}
 	}
 
-	return &TimeResponse{T: makeTimeVector(steps, dt), Y: Y, OutputName: copyStringSlice(sys.OutputName)}, nil
+	return plan.response(Y), nil
 }
 
 func Initial(sys *System, x0 *mat.VecDense, tFinal float64) (*TimeResponse, error) {
@@ -279,72 +379,30 @@ func Initial(sys *System, x0 *mat.VecDense, tFinal float64) (*TimeResponse, erro
 		return nil, fmt.Errorf("Initial: x0 must not be nil: %w", ErrDimensionMismatch)
 	}
 
-	dsys, dt, steps, _, err := prepareDiscrete(sys, tFinal, 0)
+	plan, err := prepareAutoTimeResponse(sys, tFinal, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	_, m, _ := dsys.Dims()
-	u := mat.NewDense(m, steps, nil)
-	resp, err := dsys.Simulate(u, x0, nil)
+	_, m, _ := plan.sim.Dims()
+	u := mat.NewDense(m, plan.steps, nil)
+	resp, err := plan.sim.Simulate(u, x0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Initial: %w", err)
 	}
 
-	return &TimeResponse{T: makeTimeVector(steps, dt), Y: resp.Y, OutputName: copyStringSlice(sys.OutputName)}, nil
+	return plan.response(resp.Y), nil
 }
 
 func Lsim(sys *System, u *mat.Dense, t []float64, x0 *mat.VecDense) (*TimeResponse, error) {
-	if len(t) < 2 {
-		return nil, fmt.Errorf("Lsim: need at least 2 time points: %w", ErrDimensionMismatch)
+	plan, uSim, err := prepareLsimResponse(sys, u, t)
+	if err != nil {
+		return nil, err
 	}
-
-	_, m, _ := sys.Dims()
-	ur, uc := u.Dims()
-	if ur != len(t) || uc != m {
-		return nil, fmt.Errorf("Lsim: u must be %d×%d, got %d×%d: %w", len(t), m, ur, uc, ErrDimensionMismatch)
-	}
-
-	steps := len(t)
-	dt := t[1] - t[0]
-	if dt <= 0 {
-		return nil, fmt.Errorf("Lsim: time step must be positive, got %g: %w", dt, ErrDimensionMismatch)
-	}
-	for k := 2; k < steps; k++ {
-		dk := t[k] - t[k-1]
-		if math.Abs(dk-dt)/dt > 1e-6 {
-			return nil, fmt.Errorf("Lsim: non-uniform time grid at index %d (dt=%g, expected %g); uniform grid required: %w", k, dk, dt, ErrDimensionMismatch)
-		}
-	}
-
-	var dsys *System
-	var err error
-	if sys.IsContinuous() {
-		dsys, err = sys.DiscretizeZOH(dt)
-		if err != nil {
-			return nil, fmt.Errorf("Lsim: %w", err)
-		}
-	} else {
-		if math.Abs(sys.Dt-dt)/sys.Dt > 1e-6 {
-			return nil, fmt.Errorf("Lsim: time grid spacing %g does not match system Dt %g: %w", dt, sys.Dt, ErrDimensionMismatch)
-		}
-		dsys = sys
-	}
-
-	// Transpose u from len(t)×m to m×len(t) for Simulate
-	uSim := mat.NewDense(m, steps, nil)
-	uRaw := u.RawMatrix()
-	uSimRaw := uSim.RawMatrix()
-	for i := 0; i < steps; i++ {
-		for j := 0; j < m; j++ {
-			uSimRaw.Data[j*uSimRaw.Stride+i] = uRaw.Data[i*uRaw.Stride+j]
-		}
-	}
-
-	resp, err := dsys.Simulate(uSim, x0, nil)
+	resp, err := plan.sim.Simulate(uSim, x0, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Lsim: %w", err)
 	}
 
-	return &TimeResponse{T: t, Y: resp.Y, OutputName: copyStringSlice(sys.OutputName)}, nil
+	return plan.response(resp.Y), nil
 }

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -2,7 +2,6 @@ package controlsys
 
 import (
 	"fmt"
-	"math"
 
 	"gonum.org/v1/gonum/mat"
 )
@@ -20,9 +19,9 @@ func WithPadeOrder(n int) SafeFeedbackOption {
 	}
 }
 
-// WithThiranOrder is reserved for future fractional discrete-delay feedback
-// workflows. SafeFeedback currently absorbs exact integer discrete delays and
-// uses Pade approximation for continuous transport delays.
+// WithThiranOrder enables Thiran allpass modeling for fractional discrete
+// delays in SafeFeedback. Exact integer discrete delays remain state-space
+// delays; continuous-time delays use Pade approximation.
 func WithThiranOrder(n int) SafeFeedbackOption {
 	return func(c *safeFeedbackConfig) {
 		c.thiranOrder = n
@@ -171,34 +170,6 @@ func replaceDiscreteExternalDelaysWithThiran(sys *System, thiranOrder int) (*Sys
 	result.OutputDelay = nil
 	result.Delay = nil
 	return result, nil
-}
-
-func buildDiscreteSampleDelayBank(sampleDelay []float64, n int, dt float64, thiranOrder int) (*System, error) {
-	var bank *System
-	for i := 0; i < n; i++ {
-		tau := sampleDelay[i] * dt
-		var ch *System
-		var err error
-		if tau == 0 {
-			ch, err = NewGain(mat.NewDense(1, 1, []float64{1}), dt)
-		} else if math.Abs(sampleDelay[i]-math.Round(sampleDelay[i])) < 1e-9 {
-			ch, err = integerDelaySS(int(math.Round(sampleDelay[i])), dt)
-		} else {
-			ch, err = ThiranDelay(tau, thiranOrder, dt)
-		}
-		if err != nil {
-			return nil, err
-		}
-		if bank == nil {
-			bank = ch
-			continue
-		}
-		bank, err = Append(bank, ch)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return bank, nil
 }
 
 func replaceContinuousDelays(sys *System, padeOrder int) (*System, error) {


### PR DESCRIPTION
## Summary
- Centralize C2D and SafeFeedback delay-bank construction while preserving integer-delay exactness and Thiran handling for fractional discrete delays.
- Share complex singular-value calculation between System.Sigma and FRD.Sigma; add coupled MIMO parity coverage.
- Extract delay visibility helpers for LFT/connect workflows and centralize time-response preparation for Step, Impulse, Initial, and Lsim.
- Correct WithThiranOrder public documentation.

Fixes #96
Fixes #97
Fixes #98
Fixes #99
Fixes #100

## Tests
- go test -v -count=1
- go test -run '^$' -bench 'Benchmark(SystemFRD_MIMO_200|FRDSigma_MIMO_200|FRDSeries_MIMO_200|FRDFeedback_MIMO_200|FreqRespEst_MIMO|Sigma_MIMO|DiscretizeWithOpts_Thiran|DiscretizeWithOpts_IODelayThiran|SafeFeedback|FeedbackLFT|LFT$|Step_MIMO_N10|Impulse_MIMO_N10|Lsim_MIMO_N10|SimulateWithDelay_MIMO)$' -benchmem -count=3 > /private/tmp/controlsys-bench-after.txt
- benchstat /private/tmp/controlsys-bench-before.txt /private/tmp/controlsys-bench-after.txt

## Benchmark Notes
- No targeted benchmark showed a statistically significant regression.
- Geomean improved: sec/op -5.70%, B/op -4.97%, allocs/op -23.06%.
- FRDSigma_MIMO_200 improved from ~562.8µs/op and 408 allocs/op to ~212.4µs/op and 8 allocs/op.
