### PR TITLE
Deepen PRD 110 architecture seams

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -56,18 +56,18 @@ func Series(sys1, sys2 *System) (*System, error) {
 		return seriesLFT(sys1, sys2)
 	}
 
-	return seriesSimple(sys1, sys2)
+	return seriesSimple(sys1, sys2, topology.seriesDelayPlan())
 }
 
-func seriesSimple(sys1, sys2 *System) (*System, error) {
+func seriesSimple(sys1, sys2 *System, delayPlan interconnectionDelayPlan) (*System, error) {
 	n1, m1, _ := sys1.Dims()
 	n2, _, p2 := sys2.Dims()
 	n := n1 + n2
 	m := m1
 	p := p2
 
-	ioDelay := seriesDelay(sys1, sys2)
-	inDel, outDel, ioDelay := seriesInputOutputDelay(sys1, sys2, p, m, ioDelay)
+	ioDelay := delayPlan.ioDelay
+	inDel, outDel := delayPlan.inputDelay, delayPlan.outputDelay
 
 	buildSeries := func(A, B, C, D *mat.Dense) (*System, error) {
 		sys, err := buildSystem(A, B, C, D, sys1.Dt, ioDelay)
@@ -227,22 +227,22 @@ func Parallel(sys1, sys2 *System) (*System, error) {
 		return parallelLFT(sys1, sys2)
 	}
 
-	return parallelSimple(sys1, sys2)
+	return parallelSimple(sys1, sys2, topology.parallelDelayPlan())
 }
 
 func totalDelayMatrix(sys *System) *mat.Dense {
 	return newDelayTopology(sys).totalExternal(true)
 }
 
-func parallelSimple(sys1, sys2 *System) (*System, error) {
+func parallelSimple(sys1, sys2 *System, delayPlan interconnectionDelayPlan) (*System, error) {
 	n1, m1, p1 := sys1.Dims()
 	n2, _, _ := sys2.Dims()
 	n := n1 + n2
 	m := m1
 	p := p1
 
-	ioDelay := parallelDelay(sys1, sys2)
-	inDel, outDel, ioDelay := parallelInputOutputDelay(sys1, sys2, m, p, ioDelay)
+	ioDelay := delayPlan.ioDelay
+	inDel, outDel := delayPlan.inputDelay, delayPlan.outputDelay
 
 	buildParallel := func(A, B, C, D *mat.Dense) (*System, error) {
 		sys, err := buildSystem(A, B, C, D, sys1.Dt, ioDelay)

--- a/delay.go
+++ b/delay.go
@@ -1063,37 +1063,7 @@ func absorbOutputDelay(sys *System) (*System, error) {
 }
 
 func buildPadeBank(delays []float64, order int) (*System, error) {
-	var bank *System
-	for _, tau := range delays {
-		if tau == 0 {
-			g, err := NewGain(mat.NewDense(1, 1, []float64{1}), 0)
-			if err != nil {
-				return nil, err
-			}
-			if bank == nil {
-				bank = g
-			} else {
-				bank, err = Append(bank, g)
-				if err != nil {
-					return nil, err
-				}
-			}
-			continue
-		}
-		pd, err := PadeDelay(tau, order)
-		if err != nil {
-			return nil, fmt.Errorf("buildPadeBank: %w", err)
-		}
-		if bank == nil {
-			bank = pd
-		} else {
-			bank, err = Append(bank, pd)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	return bank, nil
+	return buildContinuousPadeDelayBank(delays, order)
 }
 
 func absorbInputDelayContinuous(sys *System, order int) (*System, error) {

--- a/delay_bank.go
+++ b/delay_bank.go
@@ -1,17 +1,28 @@
 package controlsys
 
 import (
+	"fmt"
 	"math"
 
 	"gonum.org/v1/gonum/mat"
 )
 
+type delayBankKind int
+
+const (
+	delayBankSample delayBankKind = iota
+	delayBankPade
+)
+
 type delayBankSpec struct {
 	sampleDelay             []float64
+	continuousDelay         []float64
 	channels                int
 	dt                      float64
 	thiranOrder             int
+	padeOrder               int
 	requiresFractionalModel bool
+	kind                    delayBankKind
 }
 
 func buildContinuousDelayBank(contDelay []float64, channels int, dt float64, thiranOrder int) (*System, error) {
@@ -34,6 +45,16 @@ func buildDiscreteSampleDelayBank(sampleDelay []float64, channels int, dt float6
 		channels:    channels,
 		dt:          dt,
 		thiranOrder: thiranOrder,
+		kind:        delayBankSample,
+	})
+}
+
+func buildContinuousPadeDelayBank(contDelay []float64, order int) (*System, error) {
+	return buildDelayBank(delayBankSpec{
+		continuousDelay: contDelay,
+		channels:        len(contDelay),
+		padeOrder:       order,
+		kind:            delayBankPade,
 	})
 }
 
@@ -44,7 +65,7 @@ func buildDelayBank(spec delayBankSpec) (*System, error) {
 
 	var bank *System
 	for i := 0; i < spec.channels; i++ {
-		ch, err := buildDelayChannel(spec.sampleDelay[i], spec.dt, spec.thiranOrder)
+		ch, err := buildDelayChannel(spec, i)
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +93,14 @@ func hasFractionalSampleDelay(sampleDelay []float64) bool {
 	return false
 }
 
-func buildDelayChannel(samples, dt float64, thiranOrder int) (*System, error) {
+func buildDelayChannel(spec delayBankSpec, channel int) (*System, error) {
+	if spec.kind == delayBankPade {
+		return buildPadeDelayChannel(spec.continuousDelay[channel], spec.padeOrder)
+	}
+	return buildSampleDelayChannel(spec.sampleDelay[channel], spec.dt, spec.thiranOrder)
+}
+
+func buildSampleDelayChannel(samples, dt float64, thiranOrder int) (*System, error) {
 	if samples == 0 {
 		return NewGain(mat.NewDense(1, 1, []float64{1}), dt)
 	}
@@ -80,6 +108,17 @@ func buildDelayChannel(samples, dt float64, thiranOrder int) (*System, error) {
 		return integerDelaySS(int(math.Round(samples)), dt)
 	}
 	return ThiranDelay(samples*dt, thiranOrder, dt)
+}
+
+func buildPadeDelayChannel(tau float64, order int) (*System, error) {
+	if tau == 0 {
+		return NewGain(mat.NewDense(1, 1, []float64{1}), 0)
+	}
+	pd, err := PadeDelay(tau, order)
+	if err != nil {
+		return nil, fmt.Errorf("buildPadeDelayBank: %w", err)
+	}
+	return pd, nil
 }
 
 func isIntegerSampleDelay(samples float64) bool {

--- a/delay_conversion_policy.go
+++ b/delay_conversion_policy.go
@@ -92,7 +92,6 @@ func (p delayConversionPolicy) replaceContinuousExternal(sys *System, context st
 		return sys.Copy(), nil
 	}
 
-	_, m, outputs := sys.Dims()
 	cur := sys.Copy()
 	if cur.Delay != nil {
 		decomp := decomposedDelayMatrix(cur.Delay)
@@ -105,42 +104,26 @@ func (p delayConversionPolicy) replaceContinuousExternal(sys *System, context st
 	}
 
 	result := &System{A: cur.A, B: cur.B, C: cur.C, D: cur.D, Dt: cur.Dt}
-	if cur.InputDelay != nil {
-		for j := m - 1; j >= 0; j-- {
-			tau := cur.InputDelay[j]
-			if tau == 0 {
-				continue
-			}
-			pade, err := PadeDelay(tau, p.padeOrder)
-			if err != nil {
-				return nil, err
-			}
-			diag, err := buildDiagWithPade(j, m, pade)
-			if err != nil {
-				return nil, err
-			}
-			result, err = Series(diag, result)
+	if delaySliceHasNonzero(cur.InputDelay) {
+		bank, err := buildContinuousPadeDelayBank(cur.InputDelay, p.padeOrder)
+		if err != nil {
+			return nil, err
+		}
+		if bank != nil {
+			result, err = Series(bank, result)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	if cur.OutputDelay != nil {
-		for i := outputs - 1; i >= 0; i-- {
-			tau := cur.OutputDelay[i]
-			if tau == 0 {
-				continue
-			}
-			pade, err := PadeDelay(tau, p.padeOrder)
-			if err != nil {
-				return nil, err
-			}
-			diag, err := buildDiagWithPade(i, outputs, pade)
-			if err != nil {
-				return nil, err
-			}
-			result, err = Series(result, diag)
+	if delaySliceHasNonzero(cur.OutputDelay) {
+		bank, err := buildContinuousPadeDelayBank(cur.OutputDelay, p.padeOrder)
+		if err != nil {
+			return nil, err
+		}
+		if bank != nil {
+			result, err = Series(result, bank)
 			if err != nil {
 				return nil, err
 			}

--- a/frd.go
+++ b/frd.go
@@ -236,13 +236,14 @@ func (f *FRD) Bode() *BodeResult {
 	pm := p * m
 	magDB := make([]float64, nw*pm)
 	phase := make([]float64, nw*pm)
+	mag := newSampledScalarResponse(magDB, omega, p, m)
+	phaseResp := newSampledScalarResponse(phase, omega, p, m)
 	for k := range omega {
 		for i := 0; i < p; i++ {
 			for j := 0; j < m; j++ {
-				off := (k*p+i)*m + j
 				h := f.Response[k][i][j]
-				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
-				phase[off] = cmplx.Phase(h) * 180 / math.Pi
+				mag.set(k, i, j, 20*math.Log10(cmplx.Abs(h)))
+				phaseResp.set(k, i, j, cmplx.Phase(h)*180/math.Pi)
 			}
 		}
 	}

--- a/freqrestest.go
+++ b/freqrestest.go
@@ -39,7 +39,7 @@ func (r *FreqRespEstResult) CoherenceAt(freq, output, input int) float64 {
 	if r.Coherence == nil {
 		return 0
 	}
-	return r.Coherence[newSampledComplexResponse(nil, r.Omega, r.H.P, r.H.M).offset(freq, output, input)]
+	return newSampledScalarResponse(r.Coherence, r.Omega, r.H.P, r.H.M).at(freq, output, input)
 }
 
 func (r *FreqRespEstResult) FRD() (*FRD, error) {

--- a/frequency.go
+++ b/frequency.go
@@ -47,11 +47,11 @@ type BodeResult struct {
 }
 
 func (b *BodeResult) MagDBAt(freq, output, input int) float64 {
-	return b.magDB[freq*b.p*b.m+output*b.m+input]
+	return newSampledScalarResponse(b.magDB, b.Omega, b.p, b.m).at(freq, output, input)
 }
 
 func (b *BodeResult) PhaseAt(freq, output, input int) float64 {
-	return b.phase[freq*b.p*b.m+output*b.m+input]
+	return newSampledScalarResponse(b.phase, b.Omega, b.p, b.m).at(freq, output, input)
 }
 
 func bodeResultFromResponse(omega []float64, data []complex128, p, m int, inputName, outputName []string) *BodeResult {
@@ -64,14 +64,15 @@ func bodeResultFromAccessor(omega []float64, p, m int, inputName, outputName []s
 	pm := p * m
 	magDB := make([]float64, nw*pm)
 	phase := make([]float64, nw*pm)
+	mag := newSampledScalarResponse(magDB, omega, p, m)
+	phaseResp := newSampledScalarResponse(phase, omega, p, m)
 
 	for k := range omega {
 		for i := 0; i < p; i++ {
 			for j := 0; j < m; j++ {
-				off := (k*p+i)*m + j
 				h := at(k, i, j)
-				magDB[off] = 20 * math.Log10(cmplx.Abs(h))
-				phase[off] = cmplx.Phase(h) * 180 / math.Pi
+				mag.set(k, i, j, 20*math.Log10(cmplx.Abs(h)))
+				phaseResp.set(k, i, j, cmplx.Phase(h)*180/math.Pi)
 			}
 		}
 	}
@@ -90,11 +91,12 @@ func bodeResultFromAccessor(omega []float64, p, m int, inputName, outputName []s
 }
 
 func unwrapBodePhase(phase []float64, p, m, nw int) {
+	response := newSampledScalarResponse(phase, nil, p, m)
 	for i := 0; i < p; i++ {
 		for j := 0; j < m; j++ {
 			for k := 1; k < nw; k++ {
-				cur := (k*p+i)*m + j
-				prev := ((k-1)*p+i)*m + j
+				cur := response.layout.offset(k, i, j)
+				prev := response.layout.offset(k-1, i, j)
 				diff := phase[cur] - phase[prev]
 				if diff > 180 {
 					phase[cur] -= 360
@@ -631,11 +633,11 @@ type NicholsResult struct {
 }
 
 func (r *NicholsResult) MagDBAt(freq, output, input int) float64 {
-	return r.magDB[freq*r.p*r.m+output*r.m+input]
+	return newSampledScalarResponse(r.magDB, r.Omega, r.p, r.m).at(freq, output, input)
 }
 
 func (r *NicholsResult) PhaseAt(freq, output, input int) float64 {
-	return r.phase[freq*r.p*r.m+output*r.m+input]
+	return newSampledScalarResponse(r.phase, r.Omega, r.p, r.m).at(freq, output, input)
 }
 
 func (sys *System) Nichols(omega []float64, nPoints int) (*NicholsResult, error) {
@@ -650,14 +652,14 @@ func (sys *System) Nichols(omega []float64, nPoints int) (*NicholsResult, error)
 	phase := bode.phase
 	p, m := bode.p, bode.m
 	nw := len(bode.Omega)
-	pm := p * m
+	phaseResp := newSampledScalarResponse(phase, bode.Omega, p, m)
 
 	for i := 0; i < p; i++ {
 		for j := 0; j < m; j++ {
-			base := phase[i*m+j]
+			base := phaseResp.at(0, i, j)
 			shift := math.Ceil(base/360) * 360
 			for k := 0; k < nw; k++ {
-				phase[k*pm+i*m+j] -= shift
+				phaseResp.set(k, i, j, phaseResp.at(k, i, j)-shift)
 			}
 		}
 	}

--- a/interconnection_topology.go
+++ b/interconnection_topology.go
@@ -10,31 +10,44 @@ type interconnectionTopology struct {
 	plan interconnectionPlan
 }
 
+type interconnectionDelayPlan struct {
+	inputDelay  []float64
+	outputDelay []float64
+	ioDelay     *mat.Dense
+	requiresLFT bool
+}
+
 func newInterconnectionTopology(sys1, sys2 *System) interconnectionTopology {
 	return interconnectionTopology{plan: newInterconnectionPlan(sys1, sys2)}
 }
 
 func (t interconnectionTopology) seriesRequiresLFT() bool {
+	return t.seriesDelayPlan().requiresLFT
+}
+
+func (t interconnectionTopology) seriesDelayPlan() interconnectionDelayPlan {
 	plan := t.plan
 	if plan.sys1.HasInternalDelay() || plan.sys2.HasInternalDelay() {
-		return true
+		return interconnectionDelayPlan{requiresLFT: true}
 	}
 	if !plan.sys1.HasDelay() && !plan.sys2.HasDelay() {
-		return false
+		return interconnectionDelayPlan{}
 	}
 	ioCheck := seriesDelay(plan.sys1, plan.sys2)
 	if ioCheck == nil && (plan.sys1.Delay != nil || plan.sys2.Delay != nil) {
-		return true
+		return interconnectionDelayPlan{requiresLFT: true}
 	}
 	if plan.sys1.OutputDelay == nil && plan.sys2.InputDelay == nil {
-		return false
+		inDel, outDel, ioDelay := seriesInputOutputDelay(plan.sys1, plan.sys2, plan.p2, plan.m1, ioCheck)
+		return interconnectionDelayPlan{inputDelay: inDel, outputDelay: outDel, ioDelay: ioDelay}
 	}
 	for k := 1; k < plan.p1; k++ {
 		if math.Abs(t.seriesIntermediateDelay(k)-t.seriesIntermediateDelay(0)) > delayTopologyTol {
-			return true
+			return interconnectionDelayPlan{requiresLFT: true}
 		}
 	}
-	return false
+	inDel, outDel, ioDelay := seriesInputOutputDelay(plan.sys1, plan.sys2, plan.p2, plan.m1, ioCheck)
+	return interconnectionDelayPlan{inputDelay: inDel, outputDelay: outDel, ioDelay: ioDelay}
 }
 
 func (t interconnectionTopology) seriesIntermediateDelay(k int) float64 {
@@ -50,17 +63,22 @@ func (t interconnectionTopology) seriesIntermediateDelay(k int) float64 {
 }
 
 func (t interconnectionTopology) parallelRequiresLFT() bool {
+	return t.parallelDelayPlan().requiresLFT
+}
+
+func (t interconnectionTopology) parallelDelayPlan() interconnectionDelayPlan {
 	plan := t.plan
 	if plan.sys1.HasInternalDelay() || plan.sys2.HasInternalDelay() {
-		return true
+		return interconnectionDelayPlan{requiresLFT: true}
 	}
 	if !plan.sys1.HasDelay() && !plan.sys2.HasDelay() {
-		return false
+		return interconnectionDelayPlan{}
 	}
 	td1 := t.totalDelayOrZero(plan.sys1)
 	td2 := t.totalDelayOrZero(plan.sys2)
 	if td1 == nil && td2 == nil {
-		return false
+		inDel, outDel, ioDelay := parallelInputOutputDelay(plan.sys1, plan.sys2, plan.m1, plan.p1, nil)
+		return interconnectionDelayPlan{inputDelay: inDel, outputDelay: outDel, ioDelay: ioDelay}
 	}
 	if td1 == nil {
 		td1 = mat.NewDense(plan.p1, plan.m1, nil)
@@ -68,7 +86,12 @@ func (t interconnectionTopology) parallelRequiresLFT() bool {
 	if td2 == nil {
 		td2 = mat.NewDense(plan.p1, plan.m1, nil)
 	}
-	return !mat.Equal(td1, td2)
+	if !mat.Equal(td1, td2) {
+		return interconnectionDelayPlan{requiresLFT: true}
+	}
+	ioDelay := parallelDelay(plan.sys1, plan.sys2)
+	inDel, outDel, ioDelay := parallelInputOutputDelay(plan.sys1, plan.sys2, plan.m1, plan.p1, ioDelay)
+	return interconnectionDelayPlan{inputDelay: inDel, outputDelay: outDel, ioDelay: ioDelay}
 }
 
 func (t interconnectionTopology) totalDelayOrZero(sys *System) *mat.Dense {

--- a/sampled_response.go
+++ b/sampled_response.go
@@ -3,7 +3,16 @@ package controlsys
 import "math/cmplx"
 
 type sampledComplexResponse struct {
-	data  []complex128
+	data   []complex128
+	layout sampledResponseLayout
+}
+
+type sampledScalarResponse struct {
+	data   []float64
+	layout sampledResponseLayout
+}
+
+type sampledResponseLayout struct {
 	omega []float64
 	p, m  int
 }
@@ -15,11 +24,27 @@ type sampledComplexGridResponse struct {
 }
 
 func newSampledComplexResponse(data []complex128, omega []float64, p, m int) sampledComplexResponse {
-	return sampledComplexResponse{data: data, omega: omega, p: p, m: m}
+	return sampledComplexResponse{data: data, layout: newSampledResponseLayout(omega, p, m)}
+}
+
+func newSampledScalarResponse(data []float64, omega []float64, p, m int) sampledScalarResponse {
+	return sampledScalarResponse{data: data, layout: newSampledResponseLayout(omega, p, m)}
+}
+
+func newSampledResponseLayout(omega []float64, p, m int) sampledResponseLayout {
+	return sampledResponseLayout{omega: omega, p: p, m: m}
+}
+
+func (l sampledResponseLayout) offset(freq, output, input int) int {
+	return freq*l.p*l.m + output*l.m + input
+}
+
+func (l sampledResponseLayout) blockOffset(freq int) int {
+	return freq * l.p * l.m
 }
 
 func (r sampledComplexResponse) offset(freq, output, input int) int {
-	return freq*r.p*r.m + output*r.m + input
+	return r.layout.offset(freq, output, input)
 }
 
 func (r sampledComplexResponse) at(freq, output, input int) complex128 {
@@ -27,24 +52,32 @@ func (r sampledComplexResponse) at(freq, output, input int) complex128 {
 }
 
 func (r sampledComplexResponse) blockOffset(freq int) int {
-	return freq * r.p * r.m
+	return r.layout.blockOffset(freq)
 }
 
 func (r sampledComplexResponse) singularValues(dst []float64, ws *complexSVDWorkspace, freq int) {
-	if r.p == 1 && r.m == 1 {
+	if r.layout.p == 1 && r.layout.m == 1 {
 		dst[0] = cmplx.Abs(r.data[freq])
 		return
 	}
-	ws.singularValuesFromFlat(dst, r.data, r.blockOffset(freq), r.p, r.m)
+	ws.singularValuesFromFlat(dst, r.data, r.blockOffset(freq), r.layout.p, r.layout.m)
 }
 
 func (r sampledComplexResponse) copyToGrid(dst [][][]complex128) {
-	for k := range r.omega {
+	for k := range r.layout.omega {
 		base := r.blockOffset(k)
-		for i := 0; i < r.p; i++ {
-			copy(dst[k][i], r.data[base+i*r.m:base+(i+1)*r.m])
+		for i := 0; i < r.layout.p; i++ {
+			copy(dst[k][i], r.data[base+i*r.layout.m:base+(i+1)*r.layout.m])
 		}
 	}
+}
+
+func (r sampledScalarResponse) at(freq, output, input int) float64 {
+	return r.data[r.layout.offset(freq, output, input)]
+}
+
+func (r sampledScalarResponse) set(freq, output, input int, value float64) {
+	r.data[r.layout.offset(freq, output, input)] = value
 }
 
 func newSampledComplexGridResponse(response [][][]complex128, omega []float64, p, m int) sampledComplexGridResponse {

--- a/simulate.go
+++ b/simulate.go
@@ -47,13 +47,13 @@ func (d simulationDispatcher) run(u *mat.Dense, x0 *mat.VecDense, opts *Simulate
 			if err != nil {
 				return nil, err
 			}
-			return merged.simulateWithInternalDelay(u, x0)
+			return merged.simulateWithInternalDelay(u, x0, opts)
 		}
-		return d.sys.simulateWithInternalDelay(u, x0)
+		return d.sys.simulateWithInternalDelay(u, x0, opts)
 	}
 
 	if d.sys.HasDelay() {
-		return d.sys.simulateWithDelay(u, x0)
+		return d.sys.simulateWithDelay(u, x0, opts)
 	}
 
 	return d.sys.simulateNoDelay(u, x0, opts)
@@ -216,8 +216,8 @@ func (sys *System) simulateNoDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simulat
 	}, nil
 }
 
-func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense) (*Response, error) {
-	problem := newSimulationProblem(sys, u, x0, nil)
+func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *SimulateOpts) (*Response, error) {
+	problem := newSimulationProblem(sys, u, x0, opts)
 	n, m, p, steps := problem.n, problem.m, problem.p, problem.steps
 
 	totalDelay := sys.TotalDelay()
@@ -231,7 +231,7 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense) (*Response,
 		return &Response{Y: nil, XFinal: xFinal}, nil
 	}
 
-	Y := mat.NewDense(p, steps, nil)
+	Y := problem.newY()
 
 	if n > 0 && x0 != nil {
 		x := mat.NewVecDense(n, nil)
@@ -330,8 +330,8 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense) (*Response,
 	return &Response{Y: Y, XFinal: xFinal}, nil
 }
 
-func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense) (*Response, error) {
-	problem := newSimulationProblem(sys, u, x0, nil)
+func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense, opts *SimulateOpts) (*Response, error) {
+	problem := newSimulationProblem(sys, u, x0, opts)
 	n, m, p, steps := problem.n, problem.m, problem.p, problem.steps
 	N := sys.internalDelayCount()
 
@@ -353,7 +353,7 @@ func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense) (*R
 		bufSize = 1
 	}
 
-	Y := mat.NewDense(p, steps, nil)
+	Y := problem.newY()
 	x := problem.newXFinal()
 
 	var zBuf []float64

--- a/simulate_test.go
+++ b/simulate_test.go
@@ -285,6 +285,30 @@ func TestSimulateWorkspaceReuse(t *testing.T) {
 	}
 }
 
+func TestSimulateWithExternalDelayUsesOutputBuffer(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(1, 1, []float64{0.5}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{2}),
+		mat.NewDense(1, 1, []float64{0.25}),
+		1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputDelay = []float64{1}
+
+	u := mat.NewDense(1, 4, []float64{1, 2, 3, 4})
+	yBuf := mat.NewDense(1, 4, nil)
+	resp, err := sys.Simulate(u, nil, &SimulateOpts{yBuf: yBuf})
+	if err != nil {
+		t.Fatalf("Simulate with external delay: %v", err)
+	}
+	if resp.Y != yBuf {
+		t.Fatalf("Simulate with external delay did not use provided output buffer")
+	}
+}
+
 func TestSimulateNilX0(t *testing.T) {
 	A := mat.NewDense(1, 1, []float64{0.9})
 	B := mat.NewDense(1, 1, []float64{1})


### PR DESCRIPTION
## Summary

- Deepens the sampled response layout so complex and scalar frequency-response data share the same internal indexing contract across FreqResponse, Bode, Nichols, Sigma, FRD, and FreqRespEst coherence.
- Deepens interconnection topology by producing direct-path delay plans for Series and Parallel, keeping delay-routing decisions out of matrix assembly.
- Consolidates continuous Pade channel-delay bank construction with the existing delay-bank path for exact sample and Thiran delay channels.
- Wires validated simulation options through external-delay and internal-delay simulation paths, with a regression test for delayed output-buffer reuse.

Closes #111
Closes #112
Closes #113
Closes #114
Closes #115

## Verification

- `go test -v -count=1`
- `git diff --check`
- Baseline/final focused benchmarks with `go test -run '^$' -bench 'Benchmark(SimulateWithDelay_SISO|SimulateWithDelay_MIMO|SimulateNoDelay|SimulateInternalDelay|Series|Parallel|Connect|FreqResponse$|Sigma_MIMO|FreqRespEst_MIMO|DiscretizeWithOpts_Thiran|SafeFeedback|AbsorbDelay)$' -benchmem -count=5`
- `benchstat /tmp/controlsys-prd110-before.txt /tmp/controlsys-prd110-after-final.txt`

Benchstat summary:

- geomean runtime: 15.26us -> 15.14us (-0.81%)
- geomean memory: 10.40KiB -> 10.34KiB (-0.55%)
- geomean allocations: 31.54 -> 30.66 (-2.79%)
- no meaningful regressions observed; `Parallel` improved from 13 allocs/op to 9 allocs/op in the focused benchmark.
