### PR TITLE
Deepen post-PR116 architecture seams

### DIFF
--- a/architecture_post_pr116_test.go
+++ b/architecture_post_pr116_test.go
@@ -1,0 +1,89 @@
+package controlsys
+
+import (
+	"math/cmplx"
+	"reflect"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestPostPR116CrossSeamConversionMetadataRationalAndFRD(t *testing.T) {
+	cont, err := New(
+		mat.NewDense(2, 2, []float64{-1, 2, -3, -4}),
+		mat.NewDense(2, 1, []float64{1, -2}),
+		mat.NewDense(1, 2, []float64{0.5, -1.5}),
+		mat.NewDense(1, 1, []float64{0.25}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cont.InputDelay = []float64{0.2}
+	cont.InputName = []string{"u"}
+	cont.OutputName = []string{"y"}
+	cont.StateName = []string{"x1", "x2"}
+
+	disc, err := cont.DiscretizeZOH(0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(disc.InputDelay, []float64{2}) {
+		t.Fatalf("discrete InputDelay = %v, want [2]", disc.InputDelay)
+	}
+	if !reflect.DeepEqual(disc.InputName, []string{"u"}) || !reflect.DeepEqual(disc.OutputName, []string{"y"}) {
+		t.Fatalf("discrete metadata InputName=%v OutputName=%v", disc.InputName, disc.OutputName)
+	}
+
+	back, err := disc.D2C("zoh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(back.InputDelay, []float64{0.2}) {
+		t.Fatalf("continuous InputDelay = %v, want [0.2]", back.InputDelay)
+	}
+
+	tf, err := cont.TransferFunction(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zpk, err := tf.TF.ZPK()
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundtripTF, err := zpk.TransferFunction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := complex(0.3, 1.1)
+	if cmplx.Abs(tf.TF.Eval(s)[0][0]-roundtripTF.Eval(s)[0][0]) > 1e-8 {
+		t.Fatalf("TF/ZPK roundtrip mismatch: %v vs %v", tf.TF.Eval(s)[0][0], roundtripTF.Eval(s)[0][0])
+	}
+
+	omega := []float64{0.1, 0.5, 1.0}
+	plantFRD, err := disc.FRD(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controllerFRD, err := NewFRD([][][]complex128{
+		{{0.5}},
+		{{0.4 + 0.1i}},
+		{{0.3 + 0.2i}},
+	}, omega, disc.Dt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controllerFRD.InputName = []string{"y"}
+	controllerFRD.OutputName = []string{"u"}
+
+	closedFRD, err := FRDFeedback(plantFRD, controllerFRD, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(closedFRD.InputName, []string{"u"}) {
+		t.Fatalf("closed FRD InputName = %v, want [u]", closedFRD.InputName)
+	}
+	if !reflect.DeepEqual(closedFRD.OutputName, []string{"y"}) {
+		t.Fatalf("closed FRD OutputName = %v, want [y]", closedFRD.OutputName)
+	}
+}

--- a/connect.go
+++ b/connect.go
@@ -251,9 +251,7 @@ func parallelSimple(sys1, sys2 *System, delayPlan interconnectionDelayPlan) (*Sy
 		}
 		sys.InputDelay = inDel
 		sys.OutputDelay = outDel
-		sys.InputName = copyStringSlice(sys1.InputName)
-		sys.OutputName = copyStringSlice(sys1.OutputName)
-		sys.StateName = concatStringSlices([][]string{sys1.StateName, sys2.StateName}, []int{n1, n2})
+		parallelMetadata(sys1, sys2, n1, n2).applyAllOwned(sys)
 		return sys, nil
 	}
 

--- a/convert.go
+++ b/convert.go
@@ -30,26 +30,9 @@ func (sys *System) Discretize(dt float64) (*System, error) {
 		return nil, err
 	}
 	out.Dt = dt
-	if sys.Delay != nil {
-		d, err := convertDelayToDiscrete(sys.Delay, dt)
-		if err != nil {
-			return nil, err
-		}
-		out.Delay = d
-	}
-	if sys.InputDelay != nil {
-		id, err := convertSliceDelayToDiscrete(sys.InputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.InputDelay = id
-	}
-	if sys.OutputDelay != nil {
-		od, err := convertSliceDelayToDiscrete(sys.OutputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.OutputDelay = od
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	if out, err = policy.applyDiscreteDelayFields(out, sys); err != nil {
+		return nil, err
 	}
 	propagateNames(out, sys)
 	return out, nil
@@ -68,35 +51,8 @@ func (sys *System) Undiscretize() (*System, error) {
 		return nil, err
 	}
 	out.Dt = 0
-	if sys.Delay != nil {
-		out.Delay = convertDelayToContinuous(sys.Delay, sys.Dt)
-	}
-	if sys.InputDelay != nil {
-		out.InputDelay = make([]float64, len(sys.InputDelay))
-		for i, d := range sys.InputDelay {
-			out.InputDelay[i] = d * sys.Dt
-		}
-	}
-	if sys.OutputDelay != nil {
-		out.OutputDelay = make([]float64, len(sys.OutputDelay))
-		for i, d := range sys.OutputDelay {
-			out.OutputDelay[i] = d * sys.Dt
-		}
-	}
-	if sys.LFT != nil {
-		tau := make([]float64, len(sys.LFT.Tau))
-		for i, d := range sys.LFT.Tau {
-			tau[i] = d * sys.Dt
-		}
-		out.LFT = &LFTDelay{
-			Tau: tau,
-			B2:  mat.DenseCopyOf(sys.LFT.B2),
-			C2:  mat.DenseCopyOf(sys.LFT.C2),
-			D12: mat.DenseCopyOf(sys.LFT.D12),
-			D21: mat.DenseCopyOf(sys.LFT.D21),
-			D22: mat.DenseCopyOf(sys.LFT.D22),
-		}
-	}
+	policy := newDelayConversionPolicy(sys.Dt, 0, 0)
+	policy.applyContinuousDelayFields(out, sys)
 	propagateNames(out, sys)
 	return out, nil
 }
@@ -377,6 +333,17 @@ func convertSliceDelayToDiscrete(delay []float64, dt float64, thiranOrder int) (
 	return out, nil
 }
 
+func convertSliceDelayToContinuous(delay []float64, dt float64) []float64 {
+	if delay == nil {
+		return nil
+	}
+	out := make([]float64, len(delay))
+	for i, d := range delay {
+		out[i] = d * dt
+	}
+	return out
+}
+
 func absorbFractionalDelays(disc *System, contInputDelay, contOutputDelay []float64, dt float64, thiranOrder int) (*System, error) {
 	_, m, p := disc.Dims()
 
@@ -483,26 +450,10 @@ func (sys *System) DiscretizeZOH(dt float64) (*System, error) {
 	Bd := mat.NewDense(n, m, bdData)
 
 	out := &System{A: Ad, B: Bd, C: C, D: D, Dt: dt}
-	if sys.Delay != nil {
-		d, err := convertDelayToDiscrete(sys.Delay, dt)
-		if err != nil {
-			return nil, err
-		}
-		out.Delay = d
-	}
-	if sys.InputDelay != nil {
-		id, err := convertSliceDelayToDiscrete(sys.InputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.InputDelay = id
-	}
-	if sys.OutputDelay != nil {
-		od, err := convertSliceDelayToDiscrete(sys.OutputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.OutputDelay = od
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	out, err := policy.applyDiscreteDelayFields(out, sys)
+	if err != nil {
+		return nil, err
 	}
 	propagateNames(out, sys)
 	return out, nil
@@ -521,21 +472,14 @@ func discretizeWithInternalDelay(sys *System, dt float64, opts C2DOptions) (*Sys
 	n, _, _ := sys.Dims()
 	N := sys.internalDelayCount()
 
-	discTau := make([]float64, N)
-	for j, tau := range sys.LFT.Tau {
-		samples := tau / dt
-		rounded := math.Round(samples)
-		if math.Abs(samples-rounded) < 1e-9 {
-			discTau[j] = rounded
-		} else {
-			return nil, fmt.Errorf("InternalDelay[%d]=%g not integer multiple of dt=%g: %w",
-				j, tau, dt, ErrFractionalDelay)
-		}
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	discTau, err := policy.convertInternalTauToDiscrete(sys.LFT.Tau)
+	if err != nil {
+		return nil, err
 	}
 
 	var disc *System
 	var Bd2 *mat.Dense
-	var err error
 
 	switch method {
 	case "zoh":
@@ -568,26 +512,8 @@ func discretizeWithInternalDelay(sys *System, dt float64, opts C2DOptions) (*Sys
 		D22: mat.DenseCopyOf(sys.LFT.D22),
 	}
 
-	if sys.Delay != nil {
-		d, convErr := convertDelayToDiscrete(sys.Delay, dt)
-		if convErr != nil {
-			return nil, convErr
-		}
-		disc.Delay = d
-	}
-	if sys.InputDelay != nil {
-		id, convErr := convertSliceDelayToDiscrete(sys.InputDelay, dt, 0)
-		if convErr != nil {
-			return nil, convErr
-		}
-		disc.InputDelay = id
-	}
-	if sys.OutputDelay != nil {
-		od, convErr := convertSliceDelayToDiscrete(sys.OutputDelay, dt, 0)
-		if convErr != nil {
-			return nil, convErr
-		}
-		disc.OutputDelay = od
+	if disc, err = policy.applyDiscreteDelayFields(disc, sys); err != nil {
+		return nil, err
 	}
 
 	propagateNames(disc, sys)
@@ -791,26 +717,10 @@ func (sys *System) DiscretizeImpulse(dt float64) (*System, error) {
 	Bd.Scale(dt, Bd)
 
 	out := &System{A: Ad, B: Bd, C: C, D: D, Dt: dt}
-	if sys.Delay != nil {
-		d, err := convertDelayToDiscrete(sys.Delay, dt)
-		if err != nil {
-			return nil, err
-		}
-		out.Delay = d
-	}
-	if sys.InputDelay != nil {
-		id, err := convertSliceDelayToDiscrete(sys.InputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.InputDelay = id
-	}
-	if sys.OutputDelay != nil {
-		od, err := convertSliceDelayToDiscrete(sys.OutputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.OutputDelay = od
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	out, err := policy.applyDiscreteDelayFields(out, sys)
+	if err != nil {
+		return nil, err
 	}
 	propagateNames(out, sys)
 	return out, nil
@@ -941,6 +851,11 @@ func fohPureGain(sys *System, m, p int, dt float64) (*System, error) {
 		D:  mat.NewDense(p, m, dData),
 		Dt: dt,
 	}
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	var err error
+	if out, err = policy.applyDiscreteDelayFields(out, sys); err != nil {
+		return nil, err
+	}
 	propagateNames(out, sys)
 	fohAugmentStateNames(out, sys, 0, m)
 	return out, nil
@@ -991,26 +906,10 @@ func buildFOHSystem(sys *System, n, m, p int, dt float64, adData, g0Data, g1Data
 		Dt: dt,
 	}
 
-	if sys.Delay != nil {
-		d, err := convertDelayToDiscrete(sys.Delay, dt)
-		if err != nil {
-			return nil, err
-		}
-		out.Delay = d
-	}
-	if sys.InputDelay != nil {
-		id, err := convertSliceDelayToDiscrete(sys.InputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.InputDelay = id
-	}
-	if sys.OutputDelay != nil {
-		od, err := convertSliceDelayToDiscrete(sys.OutputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		out.OutputDelay = od
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	var err error
+	if out, err = policy.applyDiscreteDelayFields(out, sys); err != nil {
+		return nil, err
 	}
 	propagateNames(out, sys)
 	fohAugmentStateNames(out, sys, n, m)
@@ -1178,26 +1077,9 @@ func (sys *System) DiscretizeMatched(dt float64) (*System, error) {
 	}
 	result := ssResult.Sys
 
-	if sys.Delay != nil {
-		d, err := convertDelayToDiscrete(sys.Delay, dt)
-		if err != nil {
-			return nil, err
-		}
-		result.Delay = d
-	}
-	if sys.InputDelay != nil {
-		id, err := convertSliceDelayToDiscrete(sys.InputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		result.InputDelay = id
-	}
-	if sys.OutputDelay != nil {
-		od, err := convertSliceDelayToDiscrete(sys.OutputDelay, dt, 0)
-		if err != nil {
-			return nil, err
-		}
-		result.OutputDelay = od
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	if result, err = policy.applyDiscreteDelayFields(result, sys); err != nil {
+		return nil, err
 	}
 	propagateNames(result, sys)
 	return result, nil
@@ -1214,7 +1096,7 @@ func matchedGain(sys *System, discZeros, discPoles []complex128, dt float64) (fl
 	denAt0 := den.Eval(0)
 	if cmplx.Abs(denAt0) > 1e-10 {
 		contDC := num.Eval(0) / denAt0
-		discDC := zpkEvalChannel(complex(1, 0), discZeros, discPoles, 1.0)
+		discDC := newRationalChannel(discZeros, discPoles, 1.0).eval(complex(1, 0))
 		if cmplx.Abs(discDC) < 1e-14 {
 			return matchedGainFallback(num, den, discZeros, discPoles, dt)
 		}
@@ -1229,13 +1111,13 @@ func matchedGainFallback(num, den Poly, discZeros, discPoles []complex128, dt fl
 	zMatch := complex(0, 1)
 
 	contVal := num.Eval(sMatch) / den.Eval(sMatch)
-	discVal := zpkEvalChannel(zMatch, discZeros, discPoles, 1.0)
+	discVal := newRationalChannel(discZeros, discPoles, 1.0).eval(zMatch)
 
 	if cmplx.Abs(discVal) < 1e-14 {
 		sMatch = complex(0, math.Pi/(4*dt))
 		zMatch = cmplx.Exp(complex(0, math.Pi/4))
 		contVal = num.Eval(sMatch) / den.Eval(sMatch)
-		discVal = zpkEvalChannel(zMatch, discZeros, discPoles, 1.0)
+		discVal = newRationalChannel(discZeros, discPoles, 1.0).eval(zMatch)
 	}
 	if cmplx.Abs(discVal) < 1e-14 {
 		return 0, fmt.Errorf("DiscretizeMatched: cannot determine gain: %w", ErrSingularTransform)
@@ -1323,21 +1205,8 @@ func (sys *System) d2cZOH() (*System, error) {
 }
 
 func d2cPropagateDelays(out, sys *System, dt float64) {
-	if sys.Delay != nil {
-		out.Delay = convertDelayToContinuous(sys.Delay, dt)
-	}
-	if sys.InputDelay != nil {
-		out.InputDelay = make([]float64, len(sys.InputDelay))
-		for i, d := range sys.InputDelay {
-			out.InputDelay[i] = d * dt
-		}
-	}
-	if sys.OutputDelay != nil {
-		out.OutputDelay = make([]float64, len(sys.OutputDelay))
-		for i, d := range sys.OutputDelay {
-			out.OutputDelay[i] = d * dt
-		}
-	}
+	policy := newDelayConversionPolicy(dt, 0, 0)
+	policy.applyContinuousDelayFields(out, sys)
 }
 
 func (sys *System) D2D(newDt float64, opts C2DOptions) (*System, error) {

--- a/delay_conversion_policy.go
+++ b/delay_conversion_policy.go
@@ -1,5 +1,12 @@
 package controlsys
 
+import (
+	"fmt"
+	"math"
+
+	"gonum.org/v1/gonum/mat"
+)
+
 type delayConversionPolicy struct {
 	dt          float64
 	thiranOrder int
@@ -8,6 +15,58 @@ type delayConversionPolicy struct {
 
 func newDelayConversionPolicy(dt float64, thiranOrder, padeOrder int) delayConversionPolicy {
 	return delayConversionPolicy{dt: dt, thiranOrder: thiranOrder, padeOrder: padeOrder}
+}
+
+func (p delayConversionPolicy) applyDiscreteDelayFields(disc, cont *System) (*System, error) {
+	var err error
+	if cont.Delay != nil {
+		disc.Delay, err = convertDelayToDiscrete(cont.Delay, p.dt)
+		if err != nil {
+			return nil, err
+		}
+	}
+	disc.InputDelay, err = convertSliceDelayToDiscrete(cont.InputDelay, p.dt, p.thiranOrder)
+	if err != nil {
+		return nil, err
+	}
+	disc.OutputDelay, err = convertSliceDelayToDiscrete(cont.OutputDelay, p.dt, p.thiranOrder)
+	if err != nil {
+		return nil, err
+	}
+	return disc, nil
+}
+
+func (p delayConversionPolicy) applyContinuousDelayFields(cont, disc *System) {
+	if disc.Delay != nil {
+		cont.Delay = convertDelayToContinuous(disc.Delay, p.dt)
+	}
+	cont.InputDelay = convertSliceDelayToContinuous(disc.InputDelay, p.dt)
+	cont.OutputDelay = convertSliceDelayToContinuous(disc.OutputDelay, p.dt)
+	if disc.LFT != nil {
+		cont.LFT = &LFTDelay{
+			Tau: convertSliceDelayToContinuous(disc.LFT.Tau, p.dt),
+			B2:  mat.DenseCopyOf(disc.LFT.B2),
+			C2:  mat.DenseCopyOf(disc.LFT.C2),
+			D12: mat.DenseCopyOf(disc.LFT.D12),
+			D21: mat.DenseCopyOf(disc.LFT.D21),
+			D22: mat.DenseCopyOf(disc.LFT.D22),
+		}
+	}
+}
+
+func (p delayConversionPolicy) convertInternalTauToDiscrete(tau []float64) ([]float64, error) {
+	out := make([]float64, len(tau))
+	for j, delay := range tau {
+		samples := delay / p.dt
+		rounded := math.Round(samples)
+		if math.Abs(samples-rounded) < 1e-9 {
+			out[j] = rounded
+			continue
+		}
+		return nil, fmt.Errorf("InternalDelay[%d]=%g not integer multiple of dt=%g: %w",
+			j, delay, p.dt, ErrFractionalDelay)
+	}
+	return out, nil
 }
 
 func (p delayConversionPolicy) applyDiscreteExternal(disc *System, contInputDelay, contOutputDelay []float64) (*System, error) {

--- a/frd.go
+++ b/frd.go
@@ -406,6 +406,9 @@ func FRDMargin(f *FRD) (*MarginResult, error) {
 }
 
 func frdGridsMatch(f1, f2 *FRD) error {
+	if f1.Dt != f2.Dt {
+		return fmt.Errorf("frd: sample times %g != %g: %w", f1.Dt, f2.Dt, ErrDomainMismatch)
+	}
 	if len(f1.Omega) != len(f2.Omega) {
 		return fmt.Errorf("frd: frequency grid lengths %d != %d", len(f1.Omega), len(f2.Omega))
 	}
@@ -417,8 +420,40 @@ func frdGridsMatch(f1, f2 *FRD) error {
 	return nil
 }
 
+type frdInterconnection struct {
+	left, right *FRD
+	omega       []float64
+	dt          float64
+	nw          int
+}
+
+func newFRDInterconnection(left, right *FRD) (frdInterconnection, error) {
+	if err := frdGridsMatch(left, right); err != nil {
+		return frdInterconnection{}, err
+	}
+	return frdInterconnection{
+		left:  left,
+		right: right,
+		omega: left.Omega,
+		dt:    left.Dt,
+		nw:    len(left.Omega),
+	}, nil
+}
+
+func (ic frdInterconnection) newResult(p, m int, inputName, outputName []string) (*FRD, []complex128) {
+	resp, data := newFRDResponseStorage(ic.nw, p, m)
+	return &FRD{
+		Response:   resp,
+		Omega:      append([]float64(nil), ic.omega...),
+		Dt:         ic.dt,
+		InputName:  inputName,
+		OutputName: outputName,
+	}, data
+}
+
 func FRDSeries(f1, f2 *FRD) (*FRD, error) {
-	if err := frdGridsMatch(f1, f2); err != nil {
+	ic, err := newFRDInterconnection(f1, f2)
+	if err != nil {
 		return nil, err
 	}
 	p1, m1 := f1.Dims()
@@ -427,16 +462,17 @@ func FRDSeries(f1, f2 *FRD) (*FRD, error) {
 		return nil, fmt.Errorf("frd series: f1 outputs %d != f2 inputs %d", p1, m2)
 	}
 
-	nw := len(f1.Omega)
-	resp, data := newFRDResponseStorage(nw, p2, m1)
-	for w := 0; w < nw; w++ {
+	md := frdSeriesMetadata(f1, f2)
+	result, data := ic.newResult(p2, m1, md.input, md.output)
+	for w := 0; w < ic.nw; w++ {
 		cMulNestedInto(data[w*p2*m1:(w+1)*p2*m1], f2.Response[w], f1.Response[w], p2, p1, m1)
 	}
-	return &FRD{Response: resp, Omega: append([]float64(nil), f1.Omega...), Dt: f1.Dt}, nil
+	return result, nil
 }
 
 func FRDParallel(f1, f2 *FRD) (*FRD, error) {
-	if err := frdGridsMatch(f1, f2); err != nil {
+	ic, err := newFRDInterconnection(f1, f2)
+	if err != nil {
 		return nil, err
 	}
 	p1, m1 := f1.Dims()
@@ -445,16 +481,17 @@ func FRDParallel(f1, f2 *FRD) (*FRD, error) {
 		return nil, fmt.Errorf("frd parallel: dims (%d,%d) != (%d,%d)", p1, m1, p2, m2)
 	}
 
-	nw := len(f1.Omega)
-	resp, data := newFRDResponseStorage(nw, p1, m1)
-	for w := 0; w < nw; w++ {
+	md := frdParallelMetadata(f1)
+	result, data := ic.newResult(p1, m1, md.input, md.output)
+	for w := 0; w < ic.nw; w++ {
 		cAddNestedInto(data[w*p1*m1:(w+1)*p1*m1], f1.Response[w], f2.Response[w], p1, m1)
 	}
-	return &FRD{Response: resp, Omega: append([]float64(nil), f1.Omega...), Dt: f1.Dt}, nil
+	return result, nil
 }
 
 func FRDFeedback(plant, controller *FRD, sign float64) (*FRD, error) {
-	if err := frdGridsMatch(plant, controller); err != nil {
+	ic, err := newFRDInterconnection(plant, controller)
+	if err != nil {
 		return nil, err
 	}
 	pp, pm := plant.Dims()
@@ -466,11 +503,11 @@ func FRDFeedback(plant, controller *FRD, sign float64) (*FRD, error) {
 		return nil, fmt.Errorf("frd feedback: plant inputs %d != controller outputs %d", pm, cp)
 	}
 
-	nw := len(plant.Omega)
-	resp, data := newFRDResponseStorage(nw, pp, pm)
+	md := frdFeedbackMetadata(plant)
+	result, data := ic.newResult(pp, pm, md.input, md.output)
 	ws := newFRDFeedbackWorkspace(pp, pm)
 
-	for w := 0; w < nw; w++ {
+	for w := 0; w < ic.nw; w++ {
 		copyComplexMatrixInto(ws.g, plant.Response[w], pp, pm)
 		copyComplexMatrixInto(ws.k, controller.Response[w], cp, pp)
 		cMulInto(ws.kg, ws.k, ws.g, cp, pp, pm)
@@ -489,7 +526,7 @@ func FRDFeedback(plant, controller *FRD, sign float64) (*FRD, error) {
 		cMulInto(data[w*pp*pm:(w+1)*pp*pm], ws.g, ws.inv, pp, ws.n, pm)
 	}
 
-	return &FRD{Response: resp, Omega: append([]float64(nil), plant.Omega...), Dt: plant.Dt}, nil
+	return result, nil
 }
 
 type frdFeedbackWorkspace struct {

--- a/frd_test.go
+++ b/frd_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"math/cmplx"
+	"reflect"
 	"testing"
 
 	"gonum.org/v1/gonum/mat"
@@ -467,6 +468,61 @@ func TestFRDSeries_MIMO(t *testing.T) {
 	}
 }
 
+func TestFRDInterconnectionsPreserveSignalMetadata(t *testing.T) {
+	f1, err := NewFRD([][][]complex128{
+		{{1, 2}, {3, 4}},
+	}, []float64{1}, 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f1.InputName = []string{"u1", "u2"}
+	f1.OutputName = []string{"v1", "v2"}
+	f2, err := NewFRD([][][]complex128{
+		{{5, 6}, {7, 8}},
+	}, []float64{1}, 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2.InputName = []string{"v1", "v2"}
+	f2.OutputName = []string{"y1", "y2"}
+
+	series, err := FRDSeries(f1, f2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(series.InputName, []string{"u1", "u2"}) {
+		t.Fatalf("series InputName = %v, want [u1 u2]", series.InputName)
+	}
+	if !reflect.DeepEqual(series.OutputName, []string{"y1", "y2"}) {
+		t.Fatalf("series OutputName = %v, want [y1 y2]", series.OutputName)
+	}
+	if series.Dt != 0.1 {
+		t.Fatalf("series Dt = %v, want 0.1", series.Dt)
+	}
+
+	parallel, err := FRDParallel(f1, f1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(parallel.InputName, []string{"u1", "u2"}) {
+		t.Fatalf("parallel InputName = %v, want [u1 u2]", parallel.InputName)
+	}
+	if !reflect.DeepEqual(parallel.OutputName, []string{"v1", "v2"}) {
+		t.Fatalf("parallel OutputName = %v, want [v1 v2]", parallel.OutputName)
+	}
+
+	feedback, err := FRDFeedback(f1, f2, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(feedback.InputName, []string{"u1", "u2"}) {
+		t.Fatalf("feedback InputName = %v, want [u1 u2]", feedback.InputName)
+	}
+	if !reflect.DeepEqual(feedback.OutputName, []string{"v1", "v2"}) {
+		t.Fatalf("feedback OutputName = %v, want [v1 v2]", feedback.OutputName)
+	}
+}
+
 func TestFRDParallel_MIMO(t *testing.T) {
 	f1, err := NewFRD([][][]complex128{
 		{{1 + 1i, 2 - 1i}, {3 + 0i, -1 + 2i}},
@@ -543,6 +599,20 @@ func TestFRDFeedback_Singular(t *testing.T) {
 	}
 	if _, err := FRDFeedback(plant, controller, -1); err == nil {
 		t.Fatal("expected singular FRD feedback error")
+	}
+}
+
+func TestFRDInterconnectionRejectsSampleTimeMismatch(t *testing.T) {
+	f1, err := NewFRD([][][]complex128{{{1}}}, []float64{1}, 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := NewFRD([][][]complex128{{{1}}}, []float64{1}, 0.2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := FRDParallel(f1, f2); !errors.Is(err, ErrDomainMismatch) {
+		t.Fatalf("FRDParallel sample-time mismatch error = %v, want ErrDomainMismatch", err)
 	}
 }
 

--- a/lft.go
+++ b/lft.go
@@ -55,12 +55,7 @@ func lftExtract(M *System, nu, ny int) (*System, error) {
 		if err != nil {
 			return nil, err
 		}
-		if M.InputName != nil {
-			result.InputName = copyStringSlice(M.InputName[:nu])
-		}
-		if M.OutputName != nil {
-			result.OutputName = copyStringSlice(M.OutputName[:ny])
-		}
+		lftVisibleMetadata(M, nu, ny).applyIOOwned(result)
 		return result, nil
 	}
 
@@ -70,12 +65,7 @@ func lftExtract(M *System, nu, ny int) (*System, error) {
 	if err != nil {
 		return nil, err
 	}
-	if M.InputName != nil {
-		result.InputName = copyStringSlice(M.InputName[:nu])
-	}
-	if M.OutputName != nil {
-		result.OutputName = copyStringSlice(M.OutputName[:ny])
-	}
+	lftVisibleMetadata(M, nu, ny).applyIOOwned(result)
 	return result, nil
 }
 
@@ -121,12 +111,7 @@ func lftSimple(M, Delta *System, nu, ny int) (*System, error) {
 		if err != nil {
 			return nil, err
 		}
-		if M.InputName != nil {
-			result.InputName = copyStringSlice(M.InputName[:nu])
-		}
-		if M.OutputName != nil {
-			result.OutputName = copyStringSlice(M.OutputName[:ny])
-		}
+		lftVisibleMetadata(M, nu, ny).applyIOOwned(result)
 		return result, nil
 	}
 
@@ -171,12 +156,7 @@ func lftSimple(M, Delta *System, nu, ny int) (*System, error) {
 	if err != nil {
 		return nil, err
 	}
-	if M.InputName != nil {
-		result.InputName = copyStringSlice(M.InputName[:nu])
-	}
-	if M.OutputName != nil {
-		result.OutputName = copyStringSlice(M.OutputName[:ny])
-	}
+	lftVisibleMetadata(M, nu, ny).applyIOOwned(result)
 	return result, nil
 }
 
@@ -314,12 +294,7 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 		if savedOutputDelay.hasNonzero {
 			sys.OutputDelay = savedOutputDelay.values
 		}
-		if M.InputName != nil {
-			sys.InputName = copyStringSlice(M.InputName[:nu])
-		}
-		if M.OutputName != nil {
-			sys.OutputName = copyStringSlice(M.OutputName[:ny])
-		}
+		lftVisibleMetadata(M, nu, ny).applyIOOwned(sys)
 		return sys, nil
 	}
 
@@ -473,11 +448,6 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 	if savedOutputDelay.hasNonzero {
 		result.OutputDelay = savedOutputDelay.values
 	}
-	if M.InputName != nil {
-		result.InputName = copyStringSlice(M.InputName[:nu])
-	}
-	if M.OutputName != nil {
-		result.OutputName = copyStringSlice(M.OutputName[:ny])
-	}
+	lftVisibleMetadata(M, nu, ny).applyIOOwned(result)
 	return result, nil
 }

--- a/polynomial_channel.go
+++ b/polynomial_channel.go
@@ -2,6 +2,70 @@ package controlsys
 
 import "fmt"
 
+type rationalChannel struct {
+	zeros []complex128
+	poles []complex128
+	gain  float64
+}
+
+func newRationalChannel(zeros, poles []complex128, gain float64) rationalChannel {
+	return rationalChannel{zeros: zeros, poles: poles, gain: gain}
+}
+
+func rationalChannelFromPolynomials(num, den []float64) (rationalChannel, error) {
+	num = trimLeadingFloatZeros(num)
+	if len(num) == 1 && num[0] == 0 {
+		return rationalChannel{gain: 0}, nil
+	}
+	zeros, err := Poly(num).Roots()
+	if err != nil {
+		return rationalChannel{}, err
+	}
+	poles, err := Poly(den).Roots()
+	if err != nil {
+		return rationalChannel{}, err
+	}
+	return rationalChannel{
+		zeros: zeros,
+		poles: poles,
+		gain:  channelPolynomialGain(num, den),
+	}, nil
+}
+
+func (ch rationalChannel) eval(s complex128) complex128 {
+	if ch.gain == 0 {
+		return 0
+	}
+	nz := len(ch.zeros)
+	np := len(ch.poles)
+	h := complex(ch.gain, 0)
+
+	shared := min(nz, np)
+	for k := 0; k < shared; k++ {
+		h *= (s - ch.zeros[k]) / (s - ch.poles[k])
+	}
+	for k := shared; k < nz; k++ {
+		h *= s - ch.zeros[k]
+	}
+	for k := shared; k < np; k++ {
+		h /= s - ch.poles[k]
+	}
+	return h
+}
+
+func (ch rationalChannel) numeratorForCommonPoles(commonPoles []complex128) []float64 {
+	if ch.gain == 0 {
+		return []float64{0}
+	}
+	missing := poleSetDifference(commonPoles, ch.poles)
+	poly := polyFromComplexRoots(sortConjugatePairs(ch.zeros))
+	if len(missing) > 0 {
+		missingPoly := polyFromComplexRoots(sortConjugatePairs(missing))
+		poly = poly.Mul(missingPoly)
+	}
+	return []float64(poly.Scale(ch.gain))
+}
+
 func trimLeadingFloatZeros(p []float64) []float64 {
 	i := 0
 	for i < len(p) && p[i] == 0 {

--- a/signal_metadata.go
+++ b/signal_metadata.go
@@ -7,6 +7,11 @@ type signalMetadata struct {
 	notes  string
 }
 
+type frdMetadata struct {
+	input  []string
+	output []string
+}
+
 func metadataFromSystem(sys *System) signalMetadata {
 	return signalMetadata{
 		input:  sys.InputName,
@@ -64,6 +69,25 @@ func controllerMetadata(measurementNames, controlNames []string) signalMetadata 
 	}
 }
 
+func parallelMetadata(left, right *System, n1, n2 int) signalMetadata {
+	return signalMetadata{
+		input:  copyStringSlice(left.InputName),
+		output: copyStringSlice(left.OutputName),
+		state:  concatStringSlices([][]string{left.StateName, right.StateName}, []int{n1, n2}),
+	}
+}
+
+func lftVisibleMetadata(sys *System, inputs, outputs int) signalMetadata {
+	md := signalMetadata{notes: sys.Notes}
+	if sys.InputName != nil {
+		md.input = copyStringSlice(sys.InputName[:inputs])
+	}
+	if sys.OutputName != nil {
+		md.output = copyStringSlice(sys.OutputName[:outputs])
+	}
+	return md
+}
+
 func fohStateMetadata(src *System, n, m int) []string {
 	if src.StateName == nil && src.InputName == nil {
 		return nil
@@ -78,4 +102,25 @@ func fohStateMetadata(src *System, n, m int) []string {
 		}
 	}
 	return names
+}
+
+func frdSeriesMetadata(left, right *FRD) frdMetadata {
+	return frdMetadata{
+		input:  copyStringSlice(left.InputName),
+		output: copyStringSlice(right.OutputName),
+	}
+}
+
+func frdParallelMetadata(left *FRD) frdMetadata {
+	return frdMetadata{
+		input:  copyStringSlice(left.InputName),
+		output: copyStringSlice(left.OutputName),
+	}
+}
+
+func frdFeedbackMetadata(plant *FRD) frdMetadata {
+	return frdMetadata{
+		input:  copyStringSlice(plant.InputName),
+		output: copyStringSlice(plant.OutputName),
+	}
 }

--- a/zpk.go
+++ b/zpk.go
@@ -103,27 +103,7 @@ func (z *ZPK) Eval(s complex128) [][]complex128 {
 }
 
 func zpkEvalChannel(s complex128, zeros, poles []complex128, gain float64) complex128 {
-	if gain == 0 {
-		return 0
-	}
-	nz := len(zeros)
-	np := len(poles)
-	h := complex(gain, 0)
-
-	shared := nz
-	if np < shared {
-		shared = np
-	}
-	for k := 0; k < shared; k++ {
-		h *= (s - zeros[k]) / (s - poles[k])
-	}
-	for k := shared; k < nz; k++ {
-		h *= s - zeros[k]
-	}
-	for k := shared; k < np; k++ {
-		h /= s - poles[k]
-	}
-	return h
+	return newRationalChannel(zeros, poles, gain).eval(s)
 }
 
 func (z *ZPK) FreqResponse(omega []float64) (*FreqResponseMatrix, error) {
@@ -167,17 +147,8 @@ func (z *ZPK) TransferFunction() (*TransferFunc, error) {
 		tf.Den[i] = []float64(polyFromComplexRoots(sortConjugatePairs(commonPoles)))
 		tf.Num[i] = make([][]float64, m)
 		for j := 0; j < m; j++ {
-			if z.Gain[i][j] == 0 {
-				tf.Num[i][j] = []float64{0}
-				continue
-			}
-			missing := poleSetDifference(commonPoles, z.Poles[i][j])
-			zeroPoly := polyFromComplexRoots(sortConjugatePairs(z.Zeros[i][j]))
-			if len(missing) > 0 {
-				missingPoly := polyFromComplexRoots(sortConjugatePairs(missing))
-				zeroPoly = zeroPoly.Mul(missingPoly)
-			}
-			tf.Num[i][j] = []float64(zeroPoly.Scale(z.Gain[i][j]))
+			ch := newRationalChannel(z.Zeros[i][j], z.Poles[i][j], z.Gain[i][j])
+			tf.Num[i][j] = ch.numeratorForCommonPoles(commonPoles)
 		}
 	}
 	tf.InputName = copyStringSlice(z.InputName)
@@ -198,29 +169,17 @@ func (tf *TransferFunc) ZPK() (*ZPK, error) {
 	}
 
 	for i := 0; i < p; i++ {
-		rowPoles, err := Poly(tf.Den[i]).Roots()
-		if err != nil {
-			return nil, err
-		}
-
 		z.Zeros[i] = make([][]complex128, m)
 		z.Poles[i] = make([][]complex128, m)
 		z.Gain[i] = make([]float64, m)
 		for j := 0; j < m; j++ {
-			z.Poles[i][j] = copyComplex(rowPoles)
-
-			num := trimLeadingFloatZeros(tf.Num[i][j])
-			if len(num) == 1 && num[0] == 0 {
-				z.Gain[i][j] = 0
-				continue
-			}
-
-			zeros, err := Poly(num).Roots()
+			ch, err := rationalChannelFromPolynomials(tf.Num[i][j], tf.Den[i])
 			if err != nil {
 				return nil, err
 			}
-			z.Zeros[i][j] = zeros
-			z.Gain[i][j] = channelPolynomialGain(num, tf.Den[i])
+			z.Zeros[i][j] = ch.zeros
+			z.Poles[i][j] = copyComplex(ch.poles)
+			z.Gain[i][j] = ch.gain
 		}
 	}
 	z.InputName = copyStringSlice(tf.InputName)


### PR DESCRIPTION
## Summary

- centralize direct C2D/D2C delay field conversion through the existing delay conversion policy
- deepen signal metadata and rational channel seams used by LFT, parallel interconnection, TF/ZPK, matched discretization, and FRD workflows
- add FRD interconnection metadata/sample-time behavior and a cross-seam public regression test

## Validation

- `go test -v -count=1`
- `benchstat /tmp/controlsys-before.bench /tmp/controlsys-after.bench` on focused touched hot paths:
  - runtime geomean: 35.01 us -> 33.62 us (-3.98%)
  - memory geomean: 48.19 KiB -> 48.19 KiB (-0.00%)
  - allocs geomean: 15.98 -> 15.98 (+0.00%)

Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
