### PR TITLE
Deepen residual architecture seams

### DIFF
--- a/architecture_prd125_test.go
+++ b/architecture_prd125_test.go
@@ -61,6 +61,33 @@ func TestPRD125SampledTimeDomainWorkflowsPreserveOrientation(t *testing.T) {
 	}
 }
 
+func TestPRD125LsimAllowsZeroInputAutonomousSampledSignal(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{
+			0.5, 0.1,
+			0, 0.25,
+		}),
+		nil,
+		mat.NewDense(1, 2, []float64{1, 1}),
+		nil,
+		1.0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tGrid := []float64{0, 1, 2, 3}
+	u := mat.NewDense(len(tGrid), 1, nil).Slice(0, len(tGrid), 0, 0).(*mat.Dense)
+	x0 := mat.NewVecDense(2, []float64{4, 8})
+	resp, err := Lsim(sys, u, tGrid, x0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantY := mat.NewDense(1, 4, []float64{12, 4.8, 2.1, 0.975})
+	assertMatClose(t, "autonomous Lsim output", resp.Y, wantY, 1e-12)
+}
+
 func TestPRD125FreqRespEstUsesStridedSampledSignals(t *testing.T) {
 	dt := 0.05
 	steps := 512

--- a/architecture_prd125_test.go
+++ b/architecture_prd125_test.go
@@ -1,0 +1,173 @@
+package controlsys
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestPRD125SampledTimeDomainWorkflowsPreserveOrientation(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{
+			0.7, 0.2,
+			-0.1, 0.8,
+		}),
+		mat.NewDense(2, 2, []float64{
+			1.0, 0.3,
+			0.2, 0.7,
+		}),
+		mat.NewDense(2, 2, []float64{
+			1.0, -0.4,
+			0.5, 0.9,
+		}),
+		mat.NewDense(2, 2, []float64{
+			0.1, 0.05,
+			-0.02, 0.2,
+		}),
+		0.2,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.OutputName = []string{"temperature", "pressure"}
+
+	uSamplesByChannels := mat.NewDense(5, 2, []float64{
+		1, 0,
+		0, 1,
+		2, -1,
+		0.5, 0.25,
+		-1, 2,
+	})
+	uChannelsBySamples := mat.NewDense(2, 5, []float64{
+		1, 0, 2, 0.5, -1,
+		0, 1, -1, 0.25, 2,
+	})
+	tGrid := []float64{0, 0.2, 0.4, 0.6, 0.8}
+
+	sim, err := sys.Simulate(uChannelsBySamples, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lsim, err := Lsim(sys, uSamplesByChannels, tGrid, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMatClose(t, "Lsim output uses the same sampled signal orientation as Simulate", lsim.Y, sim.Y, 1e-12)
+	if got, want := lsim.OutputName, sys.OutputName; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("Lsim output names = %v, want %v", got, want)
+	}
+}
+
+func TestPRD125FreqRespEstUsesStridedSampledSignals(t *testing.T) {
+	dt := 0.05
+	steps := 512
+	baseInput := mat.NewDense(2, steps+3, nil)
+	baseOutput := mat.NewDense(2, steps+3, nil)
+	input := baseInput.Slice(0, 2, 1, steps+1).(*mat.Dense)
+	output := baseOutput.Slice(0, 2, 1, steps+1).(*mat.Dense)
+
+	rng := rand.New(rand.NewSource(125))
+	for k := 0; k < steps; k++ {
+		u0 := rng.NormFloat64()
+		u1 := rng.NormFloat64()
+		input.Set(0, k, u0)
+		input.Set(1, k, u1)
+		output.Set(0, k, 0.6*u0-0.2*u1)
+		output.Set(1, k, 0.1*u0+0.8*u1)
+	}
+
+	est, err := FreqRespEst(input, output, dt, &FreqRespEstOpts{NFFT: 128})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if est.H.P != 2 || est.H.M != 2 {
+		t.Fatalf("estimated response dims = %dx%d, want 2x2", est.H.P, est.H.M)
+	}
+	if coh := est.CoherenceAt(1, 0, 0); math.IsNaN(coh) || coh <= 0 {
+		t.Fatalf("coherence from strided sampled signal = %g, want positive finite", coh)
+	}
+}
+
+func TestPRD125ERAMarkovValidationPreservesPublicErrors(t *testing.T) {
+	_, err := ERA([]*mat.Dense{
+		mat.NewDense(2, 1, nil),
+		mat.NewDense(1, 1, nil),
+		mat.NewDense(2, 1, nil),
+	}, 1, 0.1)
+	if !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("ERA Markov dimension error = %v, want ErrDimensionMismatch", err)
+	}
+
+	_, err = ERA([]*mat.Dense{
+		mat.NewDense(1, 1, nil),
+		mat.NewDense(1, 1, nil),
+		mat.NewDense(1, 1, nil),
+	}, 1, 0)
+	if !errors.Is(err, ErrInvalidSampleTime) {
+		t.Fatalf("ERA sample time error = %v, want ErrInvalidSampleTime", err)
+	}
+}
+
+func TestPRD125MatrixEquationPublicErrorBehavior(t *testing.T) {
+	A := mat.NewDense(2, 2, []float64{
+		0, 1,
+		-2, -3,
+	})
+	B := mat.NewDense(2, 1, []float64{0, 1})
+	Qnonsym := mat.NewDense(2, 2, []float64{
+		1, 2,
+		0, 1,
+	})
+	R := mat.NewDense(1, 1, []float64{1})
+	if _, err := Care(A, B, Qnonsym, R, nil); !errors.Is(err, ErrNotSymmetric) {
+		t.Fatalf("Care nonsymmetric Q error = %v, want ErrNotSymmetric", err)
+	}
+
+	QnotPSD := mat.NewDense(2, 2, []float64{
+		1, 0,
+		0, -1,
+	})
+	if _, err := Dare(A, B, QnotPSD, R, nil); !errors.Is(err, ErrNotPSD) {
+		t.Fatalf("Dare non-PSD Q error = %v, want ErrNotPSD", err)
+	}
+
+	if _, err := Lyap(A, Qnonsym, nil); !errors.Is(err, ErrNotSymmetric) {
+		t.Fatalf("Lyap nonsymmetric Q error = %v, want ErrNotSymmetric", err)
+	}
+	if _, err := DLyap(A, mat.NewDense(1, 1, []float64{1}), nil); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("DLyap dimension error = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestPRD125MatrixEquationPublicNumericalBehavior(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{
+			0.7, 0.2,
+			-0.1, 0.6,
+		}),
+		mat.NewDense(2, 1, []float64{0.3, 1.0}),
+		mat.NewDense(1, 2, []float64{1.0, -0.25}),
+		mat.NewDense(1, 1, nil),
+		0.1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	Q := mat.NewDense(2, 2, []float64{1, 0.1, 0.1, 2})
+	R := mat.NewDense(1, 1, []float64{1.5})
+	if _, err := Dlqr(sys.A, sys.B, Q, R, nil); err != nil {
+		t.Fatalf("Dlqr with nonsymmetric A: %v", err)
+	}
+	if _, err := Kalman(sys, mat.NewDense(1, 1, []float64{0.2}), mat.NewDense(1, 1, []float64{0.4}), nil); err != nil {
+		t.Fatalf("Kalman with nonsymmetric A: %v", err)
+	}
+	if h2, err := H2Norm(sys); err != nil || h2 <= 0 || math.IsNaN(h2) {
+		t.Fatalf("H2Norm = %g, %v; want positive finite", h2, err)
+	}
+	if hsv, err := HSV(sys); err != nil || len(hsv) != 2 {
+		t.Fatalf("HSV = %v, %v; want two values", hsv, err)
+	}
+}

--- a/lyapunov.go
+++ b/lyapunov.go
@@ -73,25 +73,15 @@ func NewLyapunovWorkspace(n int) *LyapunovWorkspace {
 //
 // A is n×n, Q is n×n symmetric. Returns X (n×n symmetric).
 func Lyap(A, Q *mat.Dense, opts *LyapunovOpts) (*mat.Dense, error) {
-	n, nc := A.Dims()
-	if n != nc {
-		return nil, ErrDimensionMismatch
+	problem, err := newLyapunovProblem(A, Q, opts)
+	if err != nil {
+		return nil, err
 	}
-	qr, qc := Q.Dims()
-	if qr != n || qc != n {
-		return nil, ErrDimensionMismatch
-	}
+	n := problem.n
 	if n == 0 {
 		return &mat.Dense{}, nil
 	}
-	if !isSymmetric(Q, eps()*denseNorm(Q)) {
-		return nil, ErrNotSymmetric
-	}
-
-	var ws *LyapunovWorkspace
-	if opts != nil {
-		ws = opts.Workspace
-	}
+	ws := problem.ws
 
 	nn := n * n
 	aData := reuseSlice(&ws, nn, func(w *LyapunovWorkspace) *[]float64 { return &w.aData })
@@ -162,25 +152,15 @@ func Lyap(A, Q *mat.Dense, opts *LyapunovOpts) (*mat.Dense, error) {
 //
 // A is n×n, Q is n×n symmetric. Returns X (n×n symmetric).
 func DLyap(A, Q *mat.Dense, opts *LyapunovOpts) (*mat.Dense, error) {
-	n, nc := A.Dims()
-	if n != nc {
-		return nil, ErrDimensionMismatch
+	problem, err := newLyapunovProblem(A, Q, opts)
+	if err != nil {
+		return nil, err
 	}
-	qr, qc := Q.Dims()
-	if qr != n || qc != n {
-		return nil, ErrDimensionMismatch
-	}
+	n := problem.n
 	if n == 0 {
 		return &mat.Dense{}, nil
 	}
-	if !isSymmetric(Q, eps()*denseNorm(Q)) {
-		return nil, ErrNotSymmetric
-	}
-
-	var ws *LyapunovWorkspace
-	if opts != nil {
-		ws = opts.Workspace
-	}
+	ws := problem.ws
 
 	nn := n * n
 	aData := reuseSlice(&ws, nn, func(w *LyapunovWorkspace) *[]float64 { return &w.aData })

--- a/matrix_equation_problem.go
+++ b/matrix_equation_problem.go
@@ -1,0 +1,93 @@
+package controlsys
+
+import "gonum.org/v1/gonum/mat"
+
+type riccatiProblem struct {
+	A  *mat.Dense
+	B  *mat.Dense
+	Q  *mat.Dense
+	R  *mat.Dense
+	S  *mat.Dense
+	ws *RiccatiWorkspace
+	n  int
+	m  int
+}
+
+func newRiccatiProblem(A, B, Q, R *mat.Dense, opts *RiccatiOpts) (riccatiProblem, error) {
+	na, nac := A.Dims()
+	if na != nac {
+		return riccatiProblem{}, ErrDimensionMismatch
+	}
+	nb, m := B.Dims()
+	if nb != na {
+		return riccatiProblem{}, ErrDimensionMismatch
+	}
+	qr, qc := Q.Dims()
+	if qr != na || qc != na {
+		return riccatiProblem{}, ErrDimensionMismatch
+	}
+	rr, rc := R.Dims()
+	if rr != m || rc != m {
+		return riccatiProblem{}, ErrDimensionMismatch
+	}
+	if na == 0 {
+		return riccatiProblem{A: A, B: B, Q: Q, R: R, n: na, m: m}, nil
+	}
+	if !isSymmetric(Q, eps()*denseNorm(Q)) {
+		return riccatiProblem{}, ErrNotSymmetric
+	}
+	if !isSymmetric(R, eps()*denseNorm(R)) {
+		return riccatiProblem{}, ErrNotSymmetric
+	}
+	if !isPSD(Q) {
+		return riccatiProblem{}, ErrNotPSD
+	}
+
+	var S *mat.Dense
+	if opts != nil && opts.S != nil {
+		sr, sc := opts.S.Dims()
+		if sr != na || sc != m {
+			return riccatiProblem{}, ErrDimensionMismatch
+		}
+		S = opts.S
+	}
+
+	var ws *RiccatiWorkspace
+	if opts != nil && opts.Workspace != nil {
+		ws = opts.Workspace
+	} else {
+		ws = NewRiccatiWorkspace(na, m)
+	}
+
+	return riccatiProblem{A: A, B: B, Q: Q, R: R, S: S, ws: ws, n: na, m: m}, nil
+}
+
+type lyapunovProblem struct {
+	A  *mat.Dense
+	Q  *mat.Dense
+	ws *LyapunovWorkspace
+	n  int
+}
+
+func newLyapunovProblem(A, Q *mat.Dense, opts *LyapunovOpts) (lyapunovProblem, error) {
+	n, nc := A.Dims()
+	if n != nc {
+		return lyapunovProblem{}, ErrDimensionMismatch
+	}
+	qr, qc := Q.Dims()
+	if qr != n || qc != n {
+		return lyapunovProblem{}, ErrDimensionMismatch
+	}
+	if n == 0 {
+		return lyapunovProblem{A: A, Q: Q, n: n}, nil
+	}
+	if !isSymmetric(Q, eps()*denseNorm(Q)) {
+		return lyapunovProblem{}, ErrNotSymmetric
+	}
+
+	var ws *LyapunovWorkspace
+	if opts != nil {
+		ws = opts.Workspace
+	}
+	return lyapunovProblem{A: A, Q: Q, ws: ws, n: n}, nil
+}

--- a/response.go
+++ b/response.go
@@ -183,8 +183,12 @@ func (p timeResponsePlanner) lsim(u *mat.Dense, t []float64) (timeResponsePlan, 
 	}
 
 	_, m, _ := p.sys.Dims()
-	ur, uc := u.Dims()
-	if ur != len(t) || uc != m {
+	sig, err := validateLsimInputSignal("Lsim", u, len(t), m)
+	if err != nil {
+		ur, uc := 0, 0
+		if u != nil {
+			ur, uc = u.Dims()
+		}
 		return timeResponsePlan{}, nil, fmt.Errorf("Lsim: u must be %d×%d, got %d×%d: %w", len(t), m, ur, uc, ErrDimensionMismatch)
 	}
 
@@ -214,7 +218,7 @@ func (p timeResponsePlanner) lsim(u *mat.Dense, t []float64) (timeResponsePlan, 
 		steps:         len(t),
 		wasContinuous: p.sys.IsContinuous(),
 	}
-	return plan, transposeSamplesToChannels(u, len(t), m), nil
+	return plan, sig.channelsBySamplesDense(), nil
 }
 
 func validateUniformTimeGrid(context string, t []float64) (float64, error) {
@@ -232,15 +236,7 @@ func validateUniformTimeGrid(context string, t []float64) (float64, error) {
 }
 
 func transposeSamplesToChannels(u *mat.Dense, steps, inputs int) *mat.Dense {
-	uSim := mat.NewDense(inputs, steps, nil)
-	uRaw := u.RawMatrix()
-	uSimRaw := uSim.RawMatrix()
-	for i := 0; i < steps; i++ {
-		for j := 0; j < inputs; j++ {
-			uSimRaw.Data[j*uSimRaw.Stride+i] = uRaw.Data[i*uRaw.Stride+j]
-		}
-	}
-	return uSim
+	return newSampledSignal("Lsim", u, inputs, steps, sampledSamplesByChannels).channelsBySamplesDense()
 }
 
 func (sys *System) DCGain() (*mat.Dense, error) {

--- a/riccati.go
+++ b/riccati.go
@@ -94,51 +94,15 @@ type RiccatiResult struct {
 //
 // A is n×n, B is n×m, Q is n×n symmetric, R is m×m symmetric positive definite.
 func Care(A, B, Q, R *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) {
-	na, nac := A.Dims()
-	if na != nac {
-		return nil, ErrDimensionMismatch
+	problem, err := newRiccatiProblem(A, B, Q, R, opts)
+	if err != nil {
+		return nil, err
 	}
-	nb, m := B.Dims()
-	if nb != na {
-		return nil, ErrDimensionMismatch
-	}
-	qr, qc := Q.Dims()
-	if qr != na || qc != na {
-		return nil, ErrDimensionMismatch
-	}
-	rr, rc := R.Dims()
-	if rr != m || rc != m {
-		return nil, ErrDimensionMismatch
-	}
-	n := na
+	n, m := problem.n, problem.m
 	if n == 0 {
 		return &RiccatiResult{X: &mat.Dense{}, K: &mat.Dense{}, Eig: nil}, nil
 	}
-	if !isSymmetric(Q, eps()*denseNorm(Q)) {
-		return nil, ErrNotSymmetric
-	}
-	if !isSymmetric(R, eps()*denseNorm(R)) {
-		return nil, ErrNotSymmetric
-	}
-	if !isPSD(Q) {
-		return nil, ErrNotPSD
-	}
-
-	var S *mat.Dense
-	if opts != nil && opts.S != nil {
-		sr, sc := opts.S.Dims()
-		if sr != n || sc != m {
-			return nil, ErrDimensionMismatch
-		}
-		S = opts.S
-	}
-
-	var ws *RiccatiWorkspace
-	if opts != nil && opts.Workspace != nil {
-		ws = opts.Workspace
-	} else {
-		ws = NewRiccatiWorkspace(n, m)
-	}
+	S, ws := problem.S, problem.ws
 
 	// Cholesky factor R
 	rChol := ws.rChol[:m*m]
@@ -305,51 +269,15 @@ func Care(A, B, Q, R *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) {
 //
 // A is n×n, B is n×m, Q is n×n symmetric, R is m×m symmetric positive definite.
 func Dare(A, B, Q, R *mat.Dense, opts *RiccatiOpts) (*RiccatiResult, error) {
-	na, nac := A.Dims()
-	if na != nac {
-		return nil, ErrDimensionMismatch
+	problem, err := newRiccatiProblem(A, B, Q, R, opts)
+	if err != nil {
+		return nil, err
 	}
-	nb, m := B.Dims()
-	if nb != na {
-		return nil, ErrDimensionMismatch
-	}
-	qr, qc := Q.Dims()
-	if qr != na || qc != na {
-		return nil, ErrDimensionMismatch
-	}
-	rr, rc := R.Dims()
-	if rr != m || rc != m {
-		return nil, ErrDimensionMismatch
-	}
-	n := na
+	n, m := problem.n, problem.m
 	if n == 0 {
 		return &RiccatiResult{X: &mat.Dense{}, K: &mat.Dense{}, Eig: nil}, nil
 	}
-	if !isSymmetric(Q, eps()*denseNorm(Q)) {
-		return nil, ErrNotSymmetric
-	}
-	if !isSymmetric(R, eps()*denseNorm(R)) {
-		return nil, ErrNotSymmetric
-	}
-	if !isPSD(Q) {
-		return nil, ErrNotPSD
-	}
-
-	var S *mat.Dense
-	if opts != nil && opts.S != nil {
-		sr, sc := opts.S.Dims()
-		if sr != n || sc != m {
-			return nil, ErrDimensionMismatch
-		}
-		S = opts.S
-	}
-
-	var ws *RiccatiWorkspace
-	if opts != nil && opts.Workspace != nil {
-		ws = opts.Workspace
-	} else {
-		ws = NewRiccatiWorkspace(n, m)
-	}
+	S, ws := problem.S, problem.ws
 
 	// Cholesky factor R
 	rChol := ws.rChol[:m*m]

--- a/sampled_data.go
+++ b/sampled_data.go
@@ -1,62 +1,19 @@
 package controlsys
 
-import (
-	"fmt"
-
-	"gonum.org/v1/gonum/mat"
-)
+import "gonum.org/v1/gonum/mat"
 
 func validateSampledIO(context string, input, output *mat.Dense, dt float64) (m, p, n int, err error) {
-	if dt <= 0 {
-		return 0, 0, 0, ErrInvalidSampleTime
+	in, out, err := validateSampledSignalPair(context, input, output, dt)
+	if err != nil {
+		return 0, 0, 0, err
 	}
-	if input == nil || output == nil {
-		return 0, 0, 0, ErrInsufficientData
-	}
-	m, nIn := input.Dims()
-	p, nOut := output.Dims()
-	if nIn != nOut {
-		return 0, 0, 0, fmt.Errorf("%s: input has %d samples, output has %d: %w", context, nIn, nOut, ErrDimensionMismatch)
-	}
-	if nIn == 0 || m == 0 || p == 0 {
-		return 0, 0, 0, ErrInsufficientData
-	}
-	return m, p, nIn, nil
+	return in.channels, out.channels, in.samples, nil
 }
 
 func validateMarkovSequence(markov []*mat.Dense, order int, dt float64) (p, m int, err error) {
-	if len(markov) == 0 {
-		return 0, 0, fmt.Errorf("ERA: empty markov sequence: %w", ErrInsufficientData)
+	seq, err := validateMarkovSignalSequence(markov, order, dt)
+	if err != nil {
+		return 0, 0, err
 	}
-	if order <= 0 {
-		return 0, 0, fmt.Errorf("ERA: order must be positive: %w", ErrInvalidOrder)
-	}
-	if dt <= 0 {
-		return 0, 0, fmt.Errorf("ERA: %w", ErrInvalidSampleTime)
-	}
-	if markov[0] == nil {
-		return 0, 0, fmt.Errorf("ERA: markov[0] is nil: %w", ErrInsufficientData)
-	}
-
-	p, m = markov[0].Dims()
-	if p == 0 || m == 0 {
-		return 0, 0, fmt.Errorf("ERA: empty markov[0]: %w", ErrInsufficientData)
-	}
-	for i := 1; i < len(markov); i++ {
-		if markov[i] == nil {
-			return 0, 0, fmt.Errorf("ERA: markov[%d] is nil: %w", i, ErrInsufficientData)
-		}
-		ri, ci := markov[i].Dims()
-		if ri != p || ci != m {
-			return 0, 0, fmt.Errorf("ERA: markov[%d] is %dx%d, expected %dx%d: %w",
-				i, ri, ci, p, m, ErrDimensionMismatch)
-		}
-	}
-
-	minLen := 2*order + 1
-	if len(markov) < minLen {
-		return 0, 0, fmt.Errorf("ERA: need >= %d markov params for order %d, got %d: %w",
-			minLen, order, len(markov), ErrInsufficientData)
-	}
-	return p, m, nil
+	return seq.p, seq.m, nil
 }

--- a/sampled_signal.go
+++ b/sampled_signal.go
@@ -1,0 +1,132 @@
+package controlsys
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type sampledSignalOrientation int
+
+const (
+	sampledChannelsBySamples sampledSignalOrientation = iota
+	sampledSamplesByChannels
+)
+
+type sampledSignal struct {
+	context     string
+	data        *mat.Dense
+	channels    int
+	samples     int
+	orientation sampledSignalOrientation
+}
+
+func newSampledSignal(context string, data *mat.Dense, channels, samples int, orientation sampledSignalOrientation) sampledSignal {
+	return sampledSignal{context: context, data: data, channels: channels, samples: samples, orientation: orientation}
+}
+
+func validateSampledSignal(context string, data *mat.Dense, channels, samples int, orientation sampledSignalOrientation) (sampledSignal, error) {
+	if data == nil {
+		return sampledSignal{}, ErrInsufficientData
+	}
+	rows, cols := data.Dims()
+	wantRows, wantCols := channels, samples
+	if orientation == sampledSamplesByChannels {
+		wantRows, wantCols = samples, channels
+	}
+	if rows != wantRows || cols != wantCols {
+		return sampledSignal{}, fmt.Errorf("%s: sampled signal is %dx%d, want %dx%d: %w",
+			context, rows, cols, wantRows, wantCols, ErrDimensionMismatch)
+	}
+	if channels == 0 || samples == 0 {
+		return sampledSignal{}, ErrInsufficientData
+	}
+	return newSampledSignal(context, data, channels, samples, orientation), nil
+}
+
+func validateSampledSignalPair(context string, input, output *mat.Dense, dt float64) (sampledSignal, sampledSignal, error) {
+	if dt <= 0 {
+		return sampledSignal{}, sampledSignal{}, ErrInvalidSampleTime
+	}
+	if input == nil || output == nil {
+		return sampledSignal{}, sampledSignal{}, ErrInsufficientData
+	}
+	m, nIn := input.Dims()
+	p, nOut := output.Dims()
+	if nIn != nOut {
+		return sampledSignal{}, sampledSignal{}, fmt.Errorf("%s: input has %d samples, output has %d: %w", context, nIn, nOut, ErrDimensionMismatch)
+	}
+	in, err := validateSampledSignal(context, input, m, nIn, sampledChannelsBySamples)
+	if err != nil {
+		return sampledSignal{}, sampledSignal{}, err
+	}
+	out, err := validateSampledSignal(context, output, p, nOut, sampledChannelsBySamples)
+	if err != nil {
+		return sampledSignal{}, sampledSignal{}, err
+	}
+	return in, out, nil
+}
+
+func validateLsimInputSignal(context string, u *mat.Dense, steps, inputs int) (sampledSignal, error) {
+	return validateSampledSignal(context, u, inputs, steps, sampledSamplesByChannels)
+}
+
+func (s sampledSignal) channelsBySamplesDense() *mat.Dense {
+	if s.orientation == sampledChannelsBySamples {
+		return s.data
+	}
+	uSim := mat.NewDense(s.channels, s.samples, nil)
+	src := s.data.RawMatrix()
+	dst := uSim.RawMatrix()
+	for k := 0; k < s.samples; k++ {
+		for ch := 0; ch < s.channels; ch++ {
+			dst.Data[ch*dst.Stride+k] = src.Data[k*src.Stride+ch]
+		}
+	}
+	return uSim
+}
+
+type markovSequence struct {
+	terms []*mat.Dense
+	p     int
+	m     int
+	order int
+	dt    float64
+}
+
+func validateMarkovSignalSequence(markov []*mat.Dense, order int, dt float64) (markovSequence, error) {
+	if len(markov) == 0 {
+		return markovSequence{}, fmt.Errorf("ERA: empty markov sequence: %w", ErrInsufficientData)
+	}
+	if order <= 0 {
+		return markovSequence{}, fmt.Errorf("ERA: order must be positive: %w", ErrInvalidOrder)
+	}
+	if dt <= 0 {
+		return markovSequence{}, fmt.Errorf("ERA: %w", ErrInvalidSampleTime)
+	}
+	if markov[0] == nil {
+		return markovSequence{}, fmt.Errorf("ERA: markov[0] is nil: %w", ErrInsufficientData)
+	}
+
+	p, m := markov[0].Dims()
+	if p == 0 || m == 0 {
+		return markovSequence{}, fmt.Errorf("ERA: empty markov[0]: %w", ErrInsufficientData)
+	}
+	for i := 1; i < len(markov); i++ {
+		if markov[i] == nil {
+			return markovSequence{}, fmt.Errorf("ERA: markov[%d] is nil: %w", i, ErrInsufficientData)
+		}
+		ri, ci := markov[i].Dims()
+		if ri != p || ci != m {
+			return markovSequence{}, fmt.Errorf("ERA: markov[%d] is %dx%d, expected %dx%d: %w",
+				i, ri, ci, p, m, ErrDimensionMismatch)
+		}
+	}
+
+	minLen := 2*order + 1
+	if len(markov) < minLen {
+		return markovSequence{}, fmt.Errorf("ERA: need >= %d markov params for order %d, got %d: %w",
+			minLen, order, len(markov), ErrInsufficientData)
+	}
+	return markovSequence{terms: markov, p: p, m: m, order: order, dt: dt}, nil
+}

--- a/sampled_signal.go
+++ b/sampled_signal.go
@@ -38,7 +38,7 @@ func validateSampledSignal(context string, data *mat.Dense, channels, samples in
 		return sampledSignal{}, fmt.Errorf("%s: sampled signal is %dx%d, want %dx%d: %w",
 			context, rows, cols, wantRows, wantCols, ErrDimensionMismatch)
 	}
-	if channels == 0 || samples == 0 {
+	if samples == 0 || (channels == 0 && orientation == sampledChannelsBySamples) {
 		return sampledSignal{}, ErrInsufficientData
 	}
 	return newSampledSignal(context, data, channels, samples, orientation), nil
@@ -74,6 +74,9 @@ func validateLsimInputSignal(context string, u *mat.Dense, steps, inputs int) (s
 func (s sampledSignal) channelsBySamplesDense() *mat.Dense {
 	if s.orientation == sampledChannelsBySamples {
 		return s.data
+	}
+	if s.channels == 0 {
+		return mat.NewDense(1, s.samples, nil).Slice(0, 0, 0, s.samples).(*mat.Dense)
 	}
 	uSim := mat.NewDense(s.channels, s.samples, nil)
 	src := s.data.RawMatrix()


### PR DESCRIPTION
## Summary

- add a private sampled-signal module for sampled time-domain orientation, validation, strided access, Lsim-to-Simulate adaptation, FreqRespEst input/output validation, and ERA Markov sequence validation
- add a private matrix-equation preparation module shared by Riccati and Lyapunov entry points while preserving solver kernels and public behavior
- record the verification-first outcome for the closed interconnection assembly scope in #128 without reopening completed #118-#123 work
- add PRD #125 public regression tests for sampled signal orientation, strided frequency-response estimation, ERA errors, and matrix-equation behavior

## Validation

- `go test -run 'TestArchitecture|TestSimulate|TestLsim|TestFreqRespEst|TestERA|TestLqr|TestDlqr|TestCare|TestDare|TestLyap|TestDLyap|TestKalman|TestH2Norm|TestHSV|TestHinfNorm|TestConnect|TestLFT|TestFeedback' -count=1 ./...`
- `go test -run 'TestPRD125' -count=1 ./...`
- `go test -run 'TestPRD125|TestFreqRespEst|TestERA|TestLsim|TestSimulate|TestCare|TestDare|TestLyap|TestDLyap|TestKalman|TestH2Norm|TestHSV|TestHinfNorm' -count=1 ./...`
- `go test -v -count=1 ./...`
- `git diff --check`
- `benchstat /tmp/controlsys-prd125-before.bench /tmp/controlsys-prd125-after.bench` on affected hot paths:
  - runtime geomean: 346.1 us -> 345.3 us (-0.23%)
  - memory geomean: 28.72 KiB -> 28.72 KiB (+0.01%)
  - allocs geomean: 87.62 -> 87.63 (+0.00%)
  - no individual benchmark reported a statistically meaningful regression

Closes #126
Closes #127
Closes #128
Closes #129
