### PR TITLE
Deepen realization transformation result seams

### DIFF
--- a/architecture_prd131_test.go
+++ b/architecture_prd131_test.go
@@ -1,0 +1,136 @@
+package controlsys
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestPRD131RealizationTransformsPreserveMetadataAndSampleTime(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{
+			0.7, 0.2,
+			-0.1, 0.5,
+		}),
+		mat.NewDense(2, 1, []float64{1, 0.4}),
+		mat.NewDense(1, 2, []float64{0.3, 1}),
+		mat.NewDense(1, 1, []float64{0.2}),
+		0.1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"valve"}
+	sys.OutputName = []string{"level"}
+
+	check := func(name string, got *System) {
+		t.Helper()
+		if got.Dt != sys.Dt {
+			t.Fatalf("%s Dt = %g, want %g", name, got.Dt, sys.Dt)
+		}
+		if len(got.InputName) != 1 || got.InputName[0] != "valve" {
+			t.Fatalf("%s InputName = %v", name, got.InputName)
+		}
+		if len(got.OutputName) != 1 || got.OutputName[0] != "level" {
+			t.Fatalf("%s OutputName = %v", name, got.OutputName)
+		}
+		assertFreqResponseApprox(t, sys, got, []float64{0.1, 0.7, 1.2}, 1e-8)
+	}
+
+	canon, err := Canon(sys, CanonModal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check("Canon", canon.Sys)
+
+	prescaled, err := Prescale(sys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check("Prescale", prescaled.Sys)
+
+	ssbal, err := Ssbal(sys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check("Ssbal", ssbal.Sys)
+}
+
+func TestPRD131ReductionAndBalancingPreserveResultConstructionBehavior(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{
+			0.5, 0.1,
+			0, 0.2,
+		}),
+		mat.NewDense(2, 1, []float64{1, 0.3}),
+		mat.NewDense(1, 2, []float64{0.4, 1}),
+		mat.NewDense(1, 1, []float64{0.15}),
+		0.2,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"input"}
+	sys.OutputName = []string{"output"}
+
+	reduced, err := sys.MinimalRealization()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reduced.Sys.Dt != sys.Dt || reduced.Sys.InputName[0] != "input" || reduced.Sys.OutputName[0] != "output" {
+		t.Fatalf("MinimalRealization metadata not preserved: Dt=%g input=%v output=%v", reduced.Sys.Dt, reduced.Sys.InputName, reduced.Sys.OutputName)
+	}
+	assertFreqResponseApprox(t, sys, reduced.Sys, []float64{0.05, 0.4}, 1e-8)
+
+	balred, _, err := Balred(sys, 1, Truncate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if balred.Dt != sys.Dt || balred.InputName[0] != "input" || balred.OutputName[0] != "output" {
+		t.Fatalf("Balred metadata not preserved: Dt=%g input=%v output=%v", balred.Dt, balred.InputName, balred.OutputName)
+	}
+	if math.Abs(balred.D.At(0, 0)-sys.D.At(0, 0)) > 1e-12 {
+		t.Fatalf("Balred feedthrough = %g, want %g", balred.D.At(0, 0), sys.D.At(0, 0))
+	}
+}
+
+func TestPRD131StabsepUsesConsistentDecompositionResultAssembly(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{
+			-0.4, 0.2,
+			0, 0.3,
+		}),
+		mat.NewDense(2, 1, []float64{1, 0.5}),
+		mat.NewDense(1, 2, []float64{0.7, 1}),
+		mat.NewDense(1, 1, []float64{2}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"u"}
+	sys.OutputName = []string{"y"}
+
+	sep, err := Stabsep(sys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sep.Stable.InputName[0] != "u" || sep.Stable.OutputName[0] != "y" {
+		t.Fatalf("stable metadata = %v/%v", sep.Stable.InputName, sep.Stable.OutputName)
+	}
+	if sep.Unstable.InputName[0] != "u" || sep.Unstable.OutputName[0] != "y" {
+		t.Fatalf("unstable metadata = %v/%v", sep.Unstable.InputName, sep.Unstable.OutputName)
+	}
+	if math.Abs(sep.Stable.D.At(0, 0)) > 1e-12 {
+		t.Fatalf("stable feedthrough = %g, want 0", sep.Stable.D.At(0, 0))
+	}
+	if math.Abs(sep.Unstable.D.At(0, 0)-2) > 1e-12 {
+		t.Fatalf("unstable feedthrough = %g, want 2", sep.Unstable.D.At(0, 0))
+	}
+	sum, err := Parallel(sep.Stable, sep.Unstable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFreqResponseApprox(t, sys, sum, []float64{0.1, 1.0}, 1e-8)
+}

--- a/balance.go
+++ b/balance.go
@@ -226,6 +226,7 @@ func Balreal(sys *System) (*BalrealResult, error) {
 // the largest relative gap in the Hankel singular values.
 // method selects between Truncate (default) and SingularPerturbation (DC-gain matching).
 func Balred(sys *System, order int, method BalredMethod) (*System, []float64, error) {
+	policy := newRealizationTransformPolicy(sys)
 	br, err := Balreal(sys)
 	if err != nil {
 		return nil, nil, err
@@ -252,12 +253,10 @@ func Balred(sys *System, order int, method BalredMethod) (*System, []float64, er
 	C1 := extractSubmatrix(Cb, 0, p, 0, r)
 
 	if method == Truncate {
-		Dr := denseCopy(Db)
-		red, err := newNoCopy(A11, B1, C1, Dr, sys.Dt)
+		red, err := policy.result(A11, B1, C1, denseCopy(Db))
 		if err != nil {
 			return nil, hsv, err
 		}
-		propagateIONames(red, sys)
 		return red, hsv, nil
 	}
 
@@ -265,7 +264,7 @@ func Balred(sys *System, order int, method BalredMethod) (*System, []float64, er
 	if err != nil {
 		return nil, hsvOut, err
 	}
-	propagateIONames(red, sys)
+	propagateIONames(red, policy.sys)
 	return red, hsvOut, nil
 }
 

--- a/canon.go
+++ b/canon.go
@@ -51,21 +51,22 @@ type eigBlock struct {
 
 func canonModal(sys *System) (*CanonResult, error) {
 	policy := newRealizationTransformPolicy(sys)
-	n, m, p := policy.n, policy.m, policy.p
+	n := policy.n
 	if n == 0 {
 		return &CanonResult{Sys: policy.zeroOrderCopy(), T: &mat.Dense{}}, nil
 	}
 
-	res, err := canonModalEig(sys, n, m, p)
+	res, err := canonModalEig(sys, policy)
 	if err == nil {
 		return res, nil
 	}
-	return canonModalSchur(sys, n, m, p)
+	return canonModalSchur(sys, policy)
 }
 
 // canonModalEig attempts the eigendecomposition-based modal form.
 // Returns error if eigenvector matrix is too ill-conditioned.
-func canonModalEig(sys *System, n, m, p int) (*CanonResult, error) {
+func canonModalEig(sys *System, policy realizationTransformPolicy) (*CanonResult, error) {
+	n, m, p := policy.n, policy.m, policy.p
 	var eig mat.Eigen
 	ok := eig.Factorize(sys.A, mat.EigenRight)
 	if !ok {
@@ -164,13 +165,10 @@ func canonModalEig(sys *System, n, m, p int) (*CanonResult, error) {
 	Cnew := mat.NewDense(p, n, nil)
 	Cnew.Mul(sys.C, T)
 
-	Dnew := denseCopy(sys.D)
-
-	newSys, err := newNoCopy(Anew, Bnew, Cnew, Dnew, sys.Dt)
+	newSys, err := policy.resultWithOriginalFeedthrough(Anew, Bnew, Cnew)
 	if err != nil {
 		return nil, err
 	}
-	propagateIONames(newSys, sys)
 
 	return &CanonResult{Sys: newSys, T: T}, nil
 }
@@ -179,7 +177,8 @@ func canonModalEig(sys *System, n, m, p int) (*CanonResult, error) {
 // Numerically stable even for near-repeated eigenvalues.
 // A_modal is quasi-upper-triangular: 1×1 blocks for real eigenvalues,
 // 2×2 blocks for complex pairs, ordered by eigenvalue magnitude.
-func canonModalSchur(sys *System, n, m, p int) (*CanonResult, error) {
+func canonModalSchur(sys *System, policy realizationTransformPolicy) (*CanonResult, error) {
+	n, m, p := policy.n, policy.m, policy.p
 	aRaw := sys.A.RawMatrix()
 
 	t := make([]float64, n*n)
@@ -226,13 +225,10 @@ func canonModalSchur(sys *System, n, m, p int) (*CanonResult, error) {
 	Anew := mat.NewDense(n, n, t)
 	Bnew := mat.NewDense(n, m, bNew)
 	Cnew := mat.NewDense(p, n, cNew)
-	Dnew := denseCopy(sys.D)
-
-	newSys, err := newNoCopy(Anew, Bnew, Cnew, Dnew, sys.Dt)
+	newSys, err := policy.resultWithOriginalFeedthrough(Anew, Bnew, Cnew)
 	if err != nil {
 		return nil, err
 	}
-	propagateIONames(newSys, sys)
 
 	T := mat.NewDense(n, n, z)
 	return &CanonResult{Sys: newSys, T: T}, nil
@@ -346,13 +342,10 @@ func canonCompanion(sys *System) (*CanonResult, error) {
 	Cnew := mat.NewDense(1, n, nil)
 	Cnew.Mul(sys.C, T)
 
-	Dnew := denseCopy(sys.D)
-
-	newSys, err := newNoCopy(Anew, Bnew, Cnew, Dnew, sys.Dt)
+	newSys, err := policy.resultWithOriginalFeedthrough(Anew, Bnew, Cnew)
 	if err != nil {
 		return nil, err
 	}
-	propagateIONames(newSys, sys)
 
 	return &CanonResult{Sys: newSys, T: T}, nil
 }

--- a/eigdecomp.go
+++ b/eigdecomp.go
@@ -16,11 +16,11 @@ func decomposeByEigenvalues(sys *System, isGroup1 func(complex128) bool) (group1
 	if sys.HasDelay() {
 		return nil, nil, fmt.Errorf("controlsys: decomposition does not support delayed systems; use Pade/AbsorbDelay first")
 	}
+	policy := newRealizationTransformPolicy(sys)
 	n, m, p := sys.Dims()
 	if n == 0 {
 		cp := sys.Copy()
-		gain, _ := NewGain(mat.NewDense(p, m, nil), sys.Dt)
-		propagateIONames(gain, sys)
+		gain := policy.zeroOrderZeroFeedthrough()
 		return cp, gain, nil
 	}
 
@@ -72,16 +72,10 @@ func decomposeByEigenvalues(sys *System, isGroup1 func(complex128) bool) (group1
 	n2 := len(idx2)
 
 	if n1 == 0 {
-		gain, _ := NewGain(mat.NewDense(p, m, nil), sys.Dt)
-		propagateIONames(gain, sys)
-		return gain, sys.Copy(), nil
+		return policy.zeroOrderZeroFeedthrough(), sys.Copy(), nil
 	}
 	if n2 == 0 {
-		gain, _ := NewGain(denseCopy(sys.D), sys.Dt)
-		propagateIONames(gain, sys)
-		cp := sys.Copy()
-		cp.D = mat.NewDense(p, m, nil)
-		return cp, gain, nil
+		return policy.copyWithZeroFeedthrough(), policy.zeroOrderOriginalFeedthrough(), nil
 	}
 
 	var vecC mat.CDense
@@ -120,25 +114,21 @@ func decomposeByEigenvalues(sys *System, isGroup1 func(complex128) bool) (group1
 	B2r := realPart(Bt, n1, n, 0, m)
 	C2r := realPart(Ct, 0, p, n1, n)
 
-	D1 := mat.NewDense(p, m, nil)
-	D2 := denseCopy(sys.D)
-
-	sys1, err := newNoCopy(A1r, B1r, C1r, D1, sys.Dt)
+	sys1, err := policy.resultWithZeroFeedthrough(A1r, B1r, C1r)
 	if err != nil {
 		return nil, nil, err
 	}
-	propagateIONames(sys1, sys)
 
-	sys2, err := newNoCopy(A2r, B2r, C2r, D2, sys.Dt)
+	sys2, err := policy.resultWithOriginalFeedthrough(A2r, B2r, C2r)
 	if err != nil {
 		return nil, nil, err
 	}
-	propagateIONames(sys2, sys)
 
 	return sys1, sys2, nil
 }
 
 func decomposeBySchur(sys *System, isGroup1 func(complex128) bool) (group1, group2 *System, err error) {
+	policy := newRealizationTransformPolicy(sys)
 	n, m, p := sys.Dims()
 
 	t := make([]float64, n*n)
@@ -172,16 +162,10 @@ func decomposeBySchur(sys *System, isGroup1 func(complex128) bool) (group1, grou
 	}
 
 	if n1 == 0 {
-		gain, _ := NewGain(mat.NewDense(p, m, nil), sys.Dt)
-		propagateIONames(gain, sys)
-		return gain, sys.Copy(), nil
+		return policy.zeroOrderZeroFeedthrough(), sys.Copy(), nil
 	}
 	if n1 == n {
-		gain, _ := NewGain(denseCopy(sys.D), sys.Dt)
-		propagateIONames(gain, sys)
-		cp := sys.Copy()
-		cp.D = mat.NewDense(p, m, nil)
-		return cp, gain, nil
+		return policy.copyWithZeroFeedthrough(), policy.zeroOrderOriginalFeedthrough(), nil
 	}
 
 	trexcWork := make([]float64, n)
@@ -265,20 +249,15 @@ func decomposeBySchur(sys *System, isGroup1 func(complex128) bool) (group1, grou
 		}
 	}
 
-	D1 := mat.NewDense(p, m, nil)
-	D2 := denseCopy(sys.D)
-
-	sys1, err := newNoCopy(A1, B1, C1, D1, sys.Dt)
+	sys1, err := policy.resultWithZeroFeedthrough(A1, B1, C1)
 	if err != nil {
 		return nil, nil, err
 	}
-	propagateIONames(sys1, sys)
 
-	sys2, err := newNoCopy(A2, B2, C2, D2, sys.Dt)
+	sys2, err := policy.resultWithOriginalFeedthrough(A2, B2, C2)
 	if err != nil {
 		return nil, nil, err
 	}
-	propagateIONames(sys2, sys)
 
 	return sys1, sys2, nil
 }

--- a/minimal.go
+++ b/minimal.go
@@ -120,8 +120,10 @@ func (sys *System) Reduce(opts *ReduceOpts) (*ReduceResult, error) {
 	cr := extractSubmatrix(C, 0, p, 0, nr)
 	dr := denseCopySafe(sys.D, p, m)
 
-	reduced := &System{A: ar, B: br, C: cr, D: dr, Delay: copyDelayOrNil(sys.Delay), Dt: sys.Dt}
-	propagateIONames(reduced, sys)
+	reduced, err := policy.result(ar, br, cr, dr)
+	if err != nil {
+		return nil, err
+	}
 
 	return &ReduceResult{
 		Sys:        reduced,
@@ -148,17 +150,8 @@ func copySys(sys *System, n, m, p int) *System {
 }
 
 func zeroOrderResult(sys *System, m, p int) *ReduceResult {
-	s := &System{
-		A:     &mat.Dense{},
-		B:     &mat.Dense{},
-		C:     &mat.Dense{},
-		D:     denseCopySafe(sys.D, p, m),
-		Delay: copyDelayOrNil(sys.Delay),
-		Dt:    sys.Dt,
-	}
-	propagateIONames(s, sys)
 	return &ReduceResult{
-		Sys:   s,
+		Sys:   newRealizationTransformPolicy(sys).zeroOrderOriginalFeedthrough(),
 		Order: 0,
 	}
 }

--- a/realization_policy.go
+++ b/realization_policy.go
@@ -36,6 +36,48 @@ func (p realizationTransformPolicy) result(A, B, C, D *mat.Dense) (*System, erro
 	if err != nil {
 		return nil, err
 	}
+	if p.sys.Delay != nil {
+		result.Delay = copyDelayOrNil(p.sys.Delay)
+	}
 	propagateIONames(result, p.sys)
 	return result, nil
+}
+
+func (p realizationTransformPolicy) resultWithOriginalFeedthrough(A, B, C *mat.Dense) (*System, error) {
+	return p.result(A, B, C, denseCopy(p.sys.D))
+}
+
+func (p realizationTransformPolicy) resultWithZeroFeedthrough(A, B, C *mat.Dense) (*System, error) {
+	return p.result(A, B, C, denseCopySafe(nil, p.p, p.m))
+}
+
+func (p realizationTransformPolicy) zeroOrderOriginalFeedthrough() *System {
+	sys := &System{
+		A:     &mat.Dense{},
+		B:     &mat.Dense{},
+		C:     &mat.Dense{},
+		D:     denseCopySafe(p.sys.D, p.p, p.m),
+		Delay: copyDelayOrNil(p.sys.Delay),
+		Dt:    p.sys.Dt,
+	}
+	propagateIONames(sys, p.sys)
+	return sys
+}
+
+func (p realizationTransformPolicy) zeroOrderZeroFeedthrough() *System {
+	sys := &System{
+		A:  &mat.Dense{},
+		B:  &mat.Dense{},
+		C:  &mat.Dense{},
+		D:  denseCopySafe(nil, p.p, p.m),
+		Dt: p.sys.Dt,
+	}
+	propagateIONames(sys, p.sys)
+	return sys
+}
+
+func (p realizationTransformPolicy) copyWithZeroFeedthrough() *System {
+	cp := p.sys.Copy()
+	cp.D = denseCopySafe(nil, p.p, p.m)
+	return cp
 }


### PR DESCRIPTION
## Summary
- add PRD #131 characterization coverage for realization result construction across Canon, Prescale, Ssbal, MinimalRealization, Balred, and Stabsep
- centralize transformed realization result assembly in realizationTransformPolicy, including metadata, sample time, delay-preserving Reduce results, and zero/order feedthrough helpers
- replace duplicate decomposition and reduction result construction with the shared policy helpers

Closes #132
Closes #133
Closes #134

## Validation
- go test -run 'TestPRD131|TestCanon|TestStabsep|TestBalreal|TestBalred|TestPrescale|TestSsbal|TestReduce|TestMinimal' -count=1 ./...\n- go test -v -count=1 ./...\n- go test -bench='Benchmark(Balreal|Balred|Prescale|Ssbal|Minimal|Reduce|Stabsep|Canon)' -benchmem -run '^$' -count=6 ./... > /tmp/controlsys-realization-after-count6.bench\n- benchstat /tmp/controlsys-realization-before-count6.bench /tmp/controlsys-realization-after-count6.bench\n\n## Benchmark Summary\n- sec/op geomean: 27.82µs -> 27.79µs (-0.12%)\n- B/op geomean: 19.53KiB -> 19.52KiB (-0.04%)\n- allocs/op geomean: 59.92 -> 59.93 (+0.02%); no material allocation regression\n