### PR TITLE
Add MATLAB parity tracer APIs

### DIFF
--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -429,6 +429,37 @@ func BenchmarkTunableGainSampleCurrentSystem_4x4(b *testing.B) {
 	}
 }
 
+func BenchmarkGeneralizedCurrentSystem_SISO(b *testing.B) {
+	k, _ := NewTunableReal("K", 2, TunableBounds{Lower: 0, Upper: 10})
+	block := NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)
+	gm, err := NewGeneralizedModel("loop", block)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := gm.CurrentSystem(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGeneralizedClosedLoop_SISO(b *testing.B) {
+	plant := benchSysNonSym(4, 1, 1)
+	k, _ := NewTunableReal("K", 2, TunableBounds{Lower: 0, Upper: 10})
+	block := NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)
+	gm, err := NewGeneralizedClosedLoop("loop", plant, block, "u")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := gm.ComplementarySensitivity("u"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -47,6 +47,24 @@ func benchFRDFromSys(sys *System, nw int) *FRD {
 	return f
 }
 
+func benchModelArray(b *testing.B, count, n, m, p int) *ModelArray {
+	b.Helper()
+	models := make([]*System, count)
+	for i := range models {
+		if i%7 == 3 {
+			continue
+		}
+		sys := benchSysNonSym(n, m, p)
+		sys.A.Set(0, 0, sys.A.At(0, 0)-float64(i)*0.01)
+		models[i] = sys
+	}
+	arr, err := NewModelArray([]int{count}, models)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return arr
+}
+
 // --------------- FRD stack ---------------
 
 func BenchmarkSystemFRD_SISO_200(b *testing.B)   { benchSystemFRD(b, 2, 1, 1, 200) }
@@ -189,6 +207,34 @@ func BenchmarkFRDPeakGain_MIMO_2000(b *testing.B) {
 	}
 }
 
+func BenchmarkModelArrayFreqResponse_MIMO_16x200(b *testing.B) {
+	arr := benchModelArray(b, 16, 10, 3, 4)
+	omega := logspace(-2, 3, 200)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := arr.FreqResponse(omega); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkModelArrayFreqResponseManualLoop_MIMO_16x200(b *testing.B) {
+	arr := benchModelArray(b, 16, 10, 3, 4)
+	models := arr.models
+	omega := logspace(-2, 3, 200)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sys := range models {
+			if sys == nil {
+				continue
+			}
+			if _, err := sys.FreqResponse(omega); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
 // --------------- Time-response wrappers ---------------
 
 func BenchmarkStep_SISO_N2(b *testing.B)  { benchStep(b, 2, 1, 1) }
@@ -217,6 +263,32 @@ func benchStepInfo(b *testing.B, n, m, p int) {
 	for i := 0; i < b.N; i++ {
 		if _, err := StepInfo(resp, nil); err != nil {
 			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkModelArrayStep_MIMO_16(b *testing.B) {
+	arr := benchModelArray(b, 16, 10, 3, 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := arr.Step(10); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkModelArrayStepManualLoop_MIMO_16(b *testing.B) {
+	arr := benchModelArray(b, 16, 10, 3, 4)
+	models := arr.models
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, sys := range models {
+			if sys == nil {
+				continue
+			}
+			if _, err := Step(sys, 10); err != nil {
+				b.Fatal(err)
+			}
 		}
 	}
 }

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -519,6 +519,36 @@ func BenchmarkSystune_MIMO(b *testing.B) {
 	}
 }
 
+func BenchmarkPhysicalAssembly_8Components(b *testing.B) {
+	components := make([]PhysicalComponent, 8)
+	for i := range components {
+		sys := benchDescriptorSystem(b, 4, 1, 1)
+		sys.InputName = []string{"force"}
+		sys.OutputName = []string{"position"}
+		sys.StateName = autoLabel("x", 4)
+		components[i] = NewPhysicalComponent(
+			fmt.Sprintf("c%d", i),
+			sys,
+			[]PhysicalPort{{Name: "mount", Kind: PhysicalPortDisplacement, Dimension: 1}},
+		)
+	}
+	connections := make([]PhysicalConnection, 0, len(components)-1)
+	for i := 0; i < len(components)-1; i++ {
+		connections = append(connections, PhysicalConnection{
+			FromComponent: fmt.Sprintf("c%d", i),
+			FromPort:      "mount",
+			ToComponent:   fmt.Sprintf("c%d", i+1),
+			ToPort:        "mount",
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := AssemblePhysical("chain", components, connections); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -382,6 +382,38 @@ func benchCanon(b *testing.B, form CanonForm, n int) {
 	}
 }
 
+func BenchmarkDescriptorToExplicit_N10(b *testing.B) {
+	sys := benchDescriptorSystem(b, 10, 2, 2)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sys.ToExplicit(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFixedInputReduction_N10(b *testing.B) {
+	sys := benchSysNonSym(10, 4, 2)
+	fixed := map[int]float64{1: 0.5, 3: -2}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sys.FixedInputReduction(fixed, "offset"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
+	b.Helper()
+	sys := benchSysNonSym(n, m, p)
+	E := mat.NewDense(n, n, nil)
+	for i := 0; i < n; i++ {
+		E.Set(i, i, 1+0.1*float64(i+1))
+	}
+	sys.E = E
+	return sys
+}
+
 func BenchmarkStabsep_N2(b *testing.B)   { benchStabsep(b, 2) }
 func BenchmarkStabsep_N10(b *testing.B)  { benchStabsep(b, 10) }
 func BenchmarkStabsep_N50(b *testing.B)  { benchStabsep(b, 50) }

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -460,6 +460,28 @@ func BenchmarkGeneralizedClosedLoop_SISO(b *testing.B) {
 	}
 }
 
+func BenchmarkTuningGoalWeightedGain_SISO(b *testing.B) {
+	sys := benchSysNonSym(4, 1, 1)
+	goal := NewWeightedGainGoal("gain", 10)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := goal.Evaluate(sys); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTuningGoalWeightedGain_MIMO(b *testing.B) {
+	sys := benchSysNonSym(8, 3, 3)
+	goal := NewWeightedGainGoal("gain", 10)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := goal.Evaluate(sys); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -549,6 +549,31 @@ func BenchmarkPhysicalAssembly_8Components(b *testing.B) {
 	}
 }
 
+func BenchmarkPassivity_SISO(b *testing.B) {
+	sys := makeSISO(-1, 1, 1, 0)
+	opts := &PassivityOptions{Omega: logspace(-2, 2, 200)}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Passive(sys, opts); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFRDPassivity_MIMO(b *testing.B) {
+	sys := benchSysNonSym(4, 2, 2)
+	frd, err := sys.FRD(logspace(-2, 2, 200))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := FRDPassive(frd, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -482,6 +482,43 @@ func BenchmarkTuningGoalWeightedGain_MIMO(b *testing.B) {
 	}
 }
 
+func BenchmarkSystune_SISO(b *testing.B) {
+	plant := benchSysNonSym(2, 1, 1)
+	k, _ := NewTunableReal("K", 0.5, TunableBounds{Lower: 0.1, Upper: 3})
+	controller := NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)
+	model, err := NewGeneralizedClosedLoop("loop", plant, controller, "u")
+	if err != nil {
+		b.Fatal(err)
+	}
+	goals := []TuningGoal{NewWeightedGainGoal("gain", 10)}
+	opts := &SystuneOptions{GridPoints: 5}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Systune(model, goals, opts); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSystune_MIMO(b *testing.B) {
+	plant := benchSysNonSym(2, 2, 2)
+	k1, _ := NewTunableReal("K1", 0.5, TunableBounds{Lower: 0.1, Upper: 2})
+	k2, _ := NewTunableReal("K2", 0.5, TunableBounds{Lower: 0.1, Upper: 2})
+	controller := NewTunableGain("Kblock", [][]*TunableReal{{k1, fixedBenchReal("z12", 0)}, {fixedBenchReal("z21", 0), k2}}, 0)
+	model, err := NewGeneralizedClosedLoop("loop", plant, controller, "u")
+	if err != nil {
+		b.Fatal(err)
+	}
+	goals := []TuningGoal{NewWeightedGainGoal("gain", 10)}
+	opts := &SystuneOptions{GridPoints: 3}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Systune(model, goals, opts); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)
@@ -491,6 +528,12 @@ func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	}
 	sys.E = E
 	return sys
+}
+
+func fixedBenchReal(name string, value float64) *TunableReal {
+	param, _ := NewTunableReal(name, value, TunableBounds{})
+	param.SetFixed(true)
+	return param
 }
 
 func benchTunableGain(b *testing.B, p, m int) *TunableGain {

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -549,6 +549,17 @@ func BenchmarkPhysicalAssembly_8Components(b *testing.B) {
 	}
 }
 
+func BenchmarkModalTruncate_N50_Order10(b *testing.B) {
+	sys := benchSysNonSym(50, 2, 2)
+	opts := &ModalTruncateOptions{Order: 10}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ModalTruncate(sys, opts); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkPassivity_SISO(b *testing.B) {
 	sys := makeSISO(-1, 1, 1, 0)
 	opts := &PassivityOptions{Omega: logspace(-2, 2, 200)}

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -1,6 +1,7 @@
 package controlsys
 
 import (
+	"fmt"
 	"math"
 	"testing"
 
@@ -403,6 +404,31 @@ func BenchmarkFixedInputReduction_N10(b *testing.B) {
 	}
 }
 
+func BenchmarkTunableGainCurrentSystem_4x4(b *testing.B) {
+	block := benchTunableGain(b, 4, 4)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := block.CurrentSystem(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkTunableGainSampleCurrentSystem_4x4(b *testing.B) {
+	block := benchTunableGain(b, 4, 4)
+	values := map[string]float64{"p_0_0": 2.5, "p_3_3": -1.5}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sampled, err := block.Sample(values)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := sampled.CurrentSystem(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)
@@ -412,6 +438,26 @@ func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	}
 	sys.E = E
 	return sys
+}
+
+func benchTunableGain(b *testing.B, p, m int) *TunableGain {
+	b.Helper()
+	params := make([][]*TunableReal, p)
+	for i := range params {
+		params[i] = make([]*TunableReal, m)
+		for j := range params[i] {
+			param, err := NewTunableReal(
+				fmt.Sprintf("p_%d_%d", i, j),
+				float64(i-j),
+				TunableBounds{Lower: -10, Upper: 10},
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			params[i][j] = param
+		}
+	}
+	return NewTunableGain("gain", params, 0)
 }
 
 func BenchmarkStabsep_N2(b *testing.B)   { benchStabsep(b, 2) }

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -157,6 +157,38 @@ func benchFRDFeedback(b *testing.B, n, m, p, nw int) {
 	}
 }
 
+func BenchmarkFRDAbs_MIMO_2000(b *testing.B) {
+	frd := benchFRDFromSys(benchSysNonSym(10, 3, 4), 2000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		frd.Abs()
+	}
+}
+
+func BenchmarkFRDSelectFrequencies_MIMO_2000(b *testing.B) {
+	frd := benchFRDFromSys(benchSysNonSym(10, 3, 4), 2000)
+	indices := make([]int, 0, 1000)
+	for i := 0; i < 2000; i += 2 {
+		indices = append(indices, i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := frd.SelectFrequencies(indices); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFRDPeakGain_MIMO_2000(b *testing.B) {
+	frd := benchFRDFromSys(benchSysNonSym(10, 3, 4), 2000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := frd.PeakGain(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // --------------- Time-response wrappers ---------------
 
 func BenchmarkStep_SISO_N2(b *testing.B)  { benchStep(b, 2, 1, 1) }
@@ -169,6 +201,23 @@ func benchStep(b *testing.B, n, m, p int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Step(sys, 10)
+	}
+}
+
+func BenchmarkStepInfo_SISO_N10(b *testing.B) { benchStepInfo(b, 10, 1, 1) }
+func BenchmarkStepInfo_MIMO_N10(b *testing.B) { benchStepInfo(b, 10, 3, 4) }
+
+func benchStepInfo(b *testing.B, n, m, p int) {
+	sys := benchSysNonSym(n, m, p)
+	resp, err := Step(sys, 10)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := StepInfo(resp, nil); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 

--- a/docs/lpv-ltv-sparse-scope.md
+++ b/docs/lpv-ltv-sparse-scope.md
@@ -1,0 +1,52 @@
+# LPV, LTV, Sparse, and Large-Scale Model Scope
+
+This note records the scope decision for MATLAB parity families that do not fit
+the current dense LTI-first architecture without explicit design work.
+
+## Decision Summary
+
+| Family | Scope | Rationale |
+| --- | --- | --- |
+| LPV models | Later | Requires parameter-grid semantics, interpolation policy, array-aware validation, and scheduling metadata. The new `ModelArray` tracer is the right precursor, but LPV should not share the dense `System` type directly. |
+| LTV models | Later | Requires time-varying state update callbacks or sampled trajectories, simulation-only semantics, and separate guarantees from LTI frequency-domain APIs. |
+| Sparse first-order state-space | Later | Valuable for large models, but current algorithms assume dense `mat.Dense`, dense LAPACK, and dense transfer/frequency conversion. |
+| Sparse second-order models | Out of scope for now | Needs a second-order mechanical model abstraction and sparse solvers before public API exposure. |
+| Large-scale reduction workflows | Later | Should follow sparse first-order support and must not overload existing dense `Balred`, `Modred`, or `Stabsep` semantics. |
+
+## API Boundaries
+
+Dense-only APIs should remain dense-only until sparse implementations have
+separate types and benchmark gates:
+
+- `System`, `New`, `NewDescriptor`, `TransferFunction`, `FreqResponse`, `Balred`, `Modred`, `Stabsep`, `Systune`, and Riccati/synthesis helpers.
+- Dense delay and internal-delay APIs should not accept sparse models without a separate delay representation review.
+
+Future extension points:
+
+- `LPVModel` built on explicit scheduling variables and gridded `ModelArray` storage.
+- `LTVModel` with sampled or callback-based state matrices and simulation-first APIs.
+- `SparseSystem` using sparse matrices and sparse-compatible analysis/reduction methods.
+- `LargeScaleReductionOptions` separate from dense reduction options.
+
+## Required Performance Gates Before Implementation
+
+No LPV, LTV, sparse, or large-scale implementation PR should start until these
+targets are accepted in a follow-up PRD:
+
+- LPV: evaluate a 10x10 scheduling grid of 20-state, 2x2 dense models with less
+  than 2x memory overhead versus storing the underlying model array, and with
+  interpolation overhead below 25 percent versus direct model selection.
+- LTV: simulate 10,000 time steps of a 20-state, 2-input, 2-output sampled LTV
+  model with less than 30 percent overhead versus a direct hand-written loop.
+- Sparse first-order: frequency response of a 10,000-state sparse model with
+  under 1 GB peak RSS and at least 5x lower memory than dense materialization.
+- Sparse second-order: no implementation until second-order model equations,
+  units/physical semantics, and sparse solver requirements are specified.
+- Large-scale reduction: reduce a 5,000-state sparse stable model without dense
+  matrix materialization and with explicit error diagnostics.
+
+## Follow-Up Work
+
+Create separate PRDs for LPV and sparse first-order support after representative
+fixtures and benchmarks exist. Keep LTV and large-scale reduction as research
+items until the sparse model boundary is proven.

--- a/frd.go
+++ b/frd.go
@@ -208,6 +208,180 @@ func (f *FRD) At(freqIdx, i, j int) complex128 {
 	return f.Response[freqIdx][i][j]
 }
 
+type FRDResponseMapper func(freq int, omega float64, h [][]complex128) ([][]complex128, error)
+
+type FRDPeakGainResult struct {
+	Gain      float64
+	Frequency float64
+	Index     int
+}
+
+func (f *FRD) Abs() *FRD {
+	p, m := f.Dims()
+	nw := len(f.Omega)
+	response, data := newFRDResponseStorage(nw, p, m)
+	pm := p * m
+	for k := 0; k < nw; k++ {
+		base := k * pm
+		for i := 0; i < p; i++ {
+			for j := 0; j < m; j++ {
+				data[base+i*m+j] = complex(cmplx.Abs(f.Response[k][i][j]), 0)
+			}
+		}
+	}
+	return f.withResponse(response)
+}
+
+func (f *FRD) SelectFrequencies(indices []int) (*FRD, error) {
+	p, m := f.Dims()
+	response, data := newFRDResponseStorage(len(indices), p, m)
+	omega := make([]float64, len(indices))
+	prev := -1
+	pm := p * m
+	for out, idx := range indices {
+		if idx < 0 || idx >= len(f.Omega) {
+			return nil, fmt.Errorf("FRD SelectFrequencies: index %d out of range: %w", idx, ErrDimensionMismatch)
+		}
+		if idx <= prev {
+			return nil, fmt.Errorf("FRD SelectFrequencies: indices must be strictly increasing: %w", ErrDimensionMismatch)
+		}
+		prev = idx
+		omega[out] = f.Omega[idx]
+		copyComplexMatrixInto(data[out*pm:(out+1)*pm], f.Response[idx], p, m)
+	}
+	return f.withResponseAndOmega(response, omega), nil
+}
+
+func (f *FRD) SelectFrequencyRange(minOmega, maxOmega float64) (*FRD, error) {
+	if minOmega > maxOmega {
+		return nil, fmt.Errorf("FRD SelectFrequencyRange: min frequency exceeds max frequency: %w", ErrDimensionMismatch)
+	}
+	var indices []int
+	for k, w := range f.Omega {
+		if w >= minOmega && w <= maxOmega {
+			indices = append(indices, k)
+		}
+	}
+	return f.SelectFrequencies(indices)
+}
+
+func (f *FRD) MapResponse(mapper FRDResponseMapper) (*FRD, error) {
+	if mapper == nil {
+		return nil, fmt.Errorf("FRD MapResponse: mapper must not be nil: %w", ErrDimensionMismatch)
+	}
+	p, m := f.Dims()
+	response, data := newFRDResponseStorage(len(f.Omega), p, m)
+	pm := p * m
+	for k, w := range f.Omega {
+		mapped, err := mapper(k, w, f.EvalFr(k))
+		if err != nil {
+			return nil, fmt.Errorf("FRD MapResponse: frequency index %d: %w", k, err)
+		}
+		if len(mapped) != p {
+			return nil, fmt.Errorf("FRD MapResponse: frequency index %d has %d rows, want %d: %w", k, len(mapped), p, ErrDimensionMismatch)
+		}
+		for i := range mapped {
+			if len(mapped[i]) != m {
+				return nil, fmt.Errorf("FRD MapResponse: frequency index %d row %d has %d cols, want %d: %w", k, i, len(mapped[i]), m, ErrDimensionMismatch)
+			}
+		}
+		copyComplexMatrixInto(data[k*pm:(k+1)*pm], mapped, p, m)
+	}
+	return f.withResponse(response), nil
+}
+
+func (f *FRD) PeakGain() (*FRDPeakGainResult, error) {
+	p, m := f.Dims()
+	nw := len(f.Omega)
+	if nw == 0 || p == 0 || m == 0 {
+		return nil, fmt.Errorf("FRD PeakGain: no frequency response data: %w", ErrInsufficientData)
+	}
+	result := &FRDPeakGainResult{Gain: math.Inf(-1), Index: -1}
+	if p == 1 && m == 1 {
+		for k := 0; k < nw; k++ {
+			gain := cmplx.Abs(f.Response[k][0][0])
+			if gain > result.Gain {
+				result.Gain = gain
+				result.Frequency = f.Omega[k]
+				result.Index = k
+			}
+		}
+		return result, nil
+	}
+	ws := newComplexSVDWorkspace(p, m)
+	sv := make([]float64, min(p, m))
+	for k := 0; k < nw; k++ {
+		ws.singularValuesFromNested(sv, f.Response[k], p, m)
+		if sv[0] > result.Gain {
+			result.Gain = sv[0]
+			result.Frequency = f.Omega[k]
+			result.Index = k
+		}
+	}
+	return result, nil
+}
+
+func FRDConcat(first *FRD, rest ...*FRD) (*FRD, error) {
+	if first == nil {
+		return nil, fmt.Errorf("FRDConcat: first model must not be nil: %w", ErrDimensionMismatch)
+	}
+	p, m := first.Dims()
+	total := len(first.Omega)
+	for idx, f := range rest {
+		if f == nil {
+			return nil, fmt.Errorf("FRDConcat: model %d must not be nil: %w", idx+1, ErrDimensionMismatch)
+		}
+		fp, fm := f.Dims()
+		if fp != p || fm != m {
+			return nil, fmt.Errorf("FRDConcat: model %d has dimensions %dx%d, want %dx%d: %w", idx+1, fp, fm, p, m, ErrDimensionMismatch)
+		}
+		if f.Dt != first.Dt {
+			return nil, fmt.Errorf("FRDConcat: model %d sample time %g does not match %g: %w", idx+1, f.Dt, first.Dt, ErrDomainMismatch)
+		}
+		total += len(f.Omega)
+	}
+	response, data := newFRDResponseStorage(total, p, m)
+	omega := make([]float64, 0, total)
+	pm := p * m
+	pos := 0
+	appendModel := func(f *FRD) error {
+		for k, w := range f.Omega {
+			if len(omega) > 0 && w <= omega[len(omega)-1] {
+				return fmt.Errorf("FRDConcat: frequencies must be strictly increasing across models: %w", ErrDimensionMismatch)
+			}
+			omega = append(omega, w)
+			copyComplexMatrixInto(data[pos*pm:(pos+1)*pm], f.Response[k], p, m)
+			pos++
+		}
+		return nil
+	}
+	if err := appendModel(first); err != nil {
+		return nil, err
+	}
+	for _, f := range rest {
+		if err := appendModel(f); err != nil {
+			return nil, err
+		}
+	}
+	return first.withResponseAndOmega(response, omega), nil
+}
+
+func (f *FRD) withResponse(response [][][]complex128) *FRD {
+	omega := make([]float64, len(f.Omega))
+	copy(omega, f.Omega)
+	return f.withResponseAndOmega(response, omega)
+}
+
+func (f *FRD) withResponseAndOmega(response [][][]complex128, omega []float64) *FRD {
+	return &FRD{
+		Response:   response,
+		Omega:      omega,
+		Dt:         f.Dt,
+		InputName:  copyStringSlice(f.InputName),
+		OutputName: copyStringSlice(f.OutputName),
+	}
+}
+
 // EvalFr returns the p*m complex response at frequency omega[freqIdx].
 func (f *FRD) EvalFr(freqIdx int) [][]complex128 {
 	p, m := f.Dims()

--- a/frd_test.go
+++ b/frd_test.go
@@ -167,6 +167,110 @@ func TestFRD_OwnsConstructedAndExportedSampledResponseData(t *testing.T) {
 	}
 }
 
+func TestFRDConvenienceOperationsPreserveGridAndMetadata(t *testing.T) {
+	frd, err := NewFRD([][][]complex128{
+		{{3 + 4i, 1 - 1i}, {0 + 2i, -2}},
+		{{1 + 0i, 0 + 3i}, {4 + 0i, 0 - 1i}},
+		{{0 + 2i, 2 + 0i}, {1 + 1i, -30 + 40i}},
+	}, []float64{0.5, 1, 2}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frd.InputName = []string{"u1", "u2"}
+	frd.OutputName = []string{"y1", "y2"}
+
+	abs := frd.Abs()
+	if abs.At(0, 0, 0) != 5 {
+		t.Fatalf("Abs response[0][0][0] = %v, want 5", abs.At(0, 0, 0))
+	}
+	if abs.Omega[2] != 2 || abs.InputName[1] != "u2" || abs.OutputName[0] != "y1" {
+		t.Fatalf("Abs did not preserve frequency grid or metadata")
+	}
+
+	selected, err := frd.SelectFrequencies([]int{0, 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected.NumFrequencies() != 2 || selected.Omega[1] != 2 {
+		t.Fatalf("selected grid = %v, want [0.5 2]", selected.Omega)
+	}
+	if selected.At(1, 1, 1) != -30+40i {
+		t.Fatalf("selected response = %v, want -30+40i", selected.At(1, 1, 1))
+	}
+
+	ranged, err := frd.SelectFrequencyRange(0.75, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(ranged.Omega, []float64{1, 2}) {
+		t.Fatalf("range grid = %v, want [1 2]", ranged.Omega)
+	}
+
+	mapped, err := frd.MapResponse(func(freq int, omega float64, h [][]complex128) ([][]complex128, error) {
+		out := make([][]complex128, len(h))
+		for i := range h {
+			out[i] = make([]complex128, len(h[i]))
+			for j := range h[i] {
+				out[i][j] = complex(omega, 0) * h[i][j] * complex(float64(freq+1), 0)
+			}
+		}
+		return out, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mapped.At(1, 0, 1) != 0+6i {
+		t.Fatalf("mapped response = %v, want 0+6i", mapped.At(1, 0, 1))
+	}
+
+	peak, err := frd.PeakGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if peak.Frequency != 2 {
+		t.Fatalf("peak frequency = %g, want 2", peak.Frequency)
+	}
+	if peak.Gain <= 5 {
+		t.Fatalf("peak gain = %g, want above 5 for MIMO sample", peak.Gain)
+	}
+}
+
+func TestFRDConcatValidatesCompatibilityAndFrequencyOrder(t *testing.T) {
+	left, err := NewFRD([][][]complex128{{{1}}, {{2}}}, []float64{1, 2}, 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := NewFRD([][][]complex128{{{3}}, {{4}}}, []float64{3, 4}, 0.1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	joined, err := FRDConcat(left, right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(joined.Omega, []float64{1, 2, 3, 4}) {
+		t.Fatalf("joined omega = %v, want [1 2 3 4]", joined.Omega)
+	}
+	if joined.At(3, 0, 0) != 4 {
+		t.Fatalf("joined final response = %v, want 4", joined.At(3, 0, 0))
+	}
+
+	_, err = FRDConcat(left, left)
+	if !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("duplicate frequency error = %v, want ErrDimensionMismatch", err)
+	}
+
+	differentDt, err := NewFRD([][][]complex128{{{5}}}, []float64{3}, 0.2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = FRDConcat(left, differentDt)
+	if !errors.Is(err, ErrDomainMismatch) {
+		t.Fatalf("domain mismatch error = %v, want ErrDomainMismatch", err)
+	}
+}
+
 func TestFRD_Discrete(t *testing.T) {
 	sys, err := New(
 		mat.NewDense(1, 1, []float64{0.5}),

--- a/generalized.go
+++ b/generalized.go
@@ -1,0 +1,177 @@
+package controlsys
+
+import "fmt"
+
+type NumericBlock interface {
+	CurrentSystem() (*System, error)
+}
+
+type fixedSystemBlock struct {
+	sys *System
+}
+
+func (b fixedSystemBlock) CurrentSystem() (*System, error) {
+	if b.sys == nil {
+		return nil, fmt.Errorf("fixed system block is nil: %w", ErrDimensionMismatch)
+	}
+	return b.sys.Copy(), nil
+}
+
+type GeneralizedModel struct {
+	name           string
+	block          NumericBlock
+	inputName      []string
+	outputName     []string
+	analysisPoints map[string]AnalysisPoint
+}
+
+type AnalysisPoint struct {
+	Name string
+}
+
+func NewGeneralizedModel(name string, block any) (*GeneralizedModel, error) {
+	if name == "" {
+		return nil, fmt.Errorf("NewGeneralizedModel: name is empty: %w", ErrDimensionMismatch)
+	}
+	numeric, err := numericBlockFromAny(block)
+	if err != nil {
+		return nil, err
+	}
+	return &GeneralizedModel{name: name, block: numeric, analysisPoints: make(map[string]AnalysisPoint)}, nil
+}
+
+func numericBlockFromAny(block any) (NumericBlock, error) {
+	switch b := block.(type) {
+	case NumericBlock:
+		return b, nil
+	case *System:
+		return fixedSystemBlock{sys: b}, nil
+	default:
+		return nil, fmt.Errorf("unsupported generalized block %T: %w", block, ErrDimensionMismatch)
+	}
+}
+
+func (g *GeneralizedModel) SetInputName(names ...string) {
+	g.inputName = copyStringSlice(names)
+}
+
+func (g *GeneralizedModel) SetOutputName(names ...string) {
+	g.outputName = copyStringSlice(names)
+}
+
+func (g *GeneralizedModel) InsertAnalysisPoint(name string) {
+	if g.analysisPoints == nil {
+		g.analysisPoints = make(map[string]AnalysisPoint)
+	}
+	g.analysisPoints[name] = AnalysisPoint{Name: name}
+}
+
+func (g *GeneralizedModel) HasAnalysisPoint(name string) bool {
+	if g == nil {
+		return false
+	}
+	_, ok := g.analysisPoints[name]
+	return ok
+}
+
+func (g *GeneralizedModel) AnalysisPoint(name string) (AnalysisPoint, error) {
+	if g == nil {
+		return AnalysisPoint{}, fmt.Errorf("GeneralizedModel.AnalysisPoint: nil model: %w", ErrDimensionMismatch)
+	}
+	ap, ok := g.analysisPoints[name]
+	if !ok {
+		return AnalysisPoint{}, fmt.Errorf("%q: %w", name, ErrSignalNotFound)
+	}
+	return ap, nil
+}
+
+func (g *GeneralizedModel) CurrentSystem() (*System, error) {
+	if g == nil || g.block == nil {
+		return nil, fmt.Errorf("GeneralizedModel.CurrentSystem: nil model: %w", ErrDimensionMismatch)
+	}
+	sys, err := g.block.CurrentSystem()
+	if err != nil {
+		return nil, err
+	}
+	if g.inputName != nil {
+		sys.InputName = copyStringSlice(g.inputName)
+	}
+	if g.outputName != nil {
+		sys.OutputName = copyStringSlice(g.outputName)
+	}
+	return sys, nil
+}
+
+type GeneralizedClosedLoop struct {
+	name           string
+	plant          *System
+	controller     NumericBlock
+	analysisPoints map[string]AnalysisPoint
+}
+
+func NewGeneralizedClosedLoop(name string, plant *System, controller any, analysisPoint string) (*GeneralizedClosedLoop, error) {
+	ctrl, err := numericBlockFromAny(controller)
+	if err != nil {
+		return nil, err
+	}
+	if plant == nil {
+		return nil, fmt.Errorf("NewGeneralizedClosedLoop: nil plant: %w", ErrDimensionMismatch)
+	}
+	g := &GeneralizedClosedLoop{
+		name:           name,
+		plant:          plant.Copy(),
+		controller:     ctrl,
+		analysisPoints: make(map[string]AnalysisPoint),
+	}
+	g.analysisPoints[analysisPoint] = AnalysisPoint{Name: analysisPoint}
+	return g, nil
+}
+
+func (g *GeneralizedClosedLoop) AnalysisPoint(name string) (AnalysisPoint, error) {
+	if g == nil {
+		return AnalysisPoint{}, fmt.Errorf("GeneralizedClosedLoop.AnalysisPoint: nil model: %w", ErrDimensionMismatch)
+	}
+	ap, ok := g.analysisPoints[name]
+	if !ok {
+		return AnalysisPoint{}, fmt.Errorf("%q: %w", name, ErrSignalNotFound)
+	}
+	return ap, nil
+}
+
+func (g *GeneralizedClosedLoop) OpenLoop(name string) (*System, error) {
+	if _, err := g.AnalysisPoint(name); err != nil {
+		return nil, err
+	}
+	controller, err := g.controller.CurrentSystem()
+	if err != nil {
+		return nil, err
+	}
+	return Series(controller, g.plant)
+}
+
+func (g *GeneralizedClosedLoop) ClosedLoop(name string) (*System, error) {
+	return g.ComplementarySensitivity(name)
+}
+
+func (g *GeneralizedClosedLoop) ComplementarySensitivity(name string) (*System, error) {
+	L, err := g.OpenLoop(name)
+	if err != nil {
+		return nil, err
+	}
+	return Feedback(L, nil, -1)
+}
+
+func (g *GeneralizedClosedLoop) Sensitivity(name string) (*System, error) {
+	T, err := g.ComplementarySensitivity(name)
+	if err != nil {
+		return nil, err
+	}
+	one, err := NewGain(eyeDense(1), T.Dt)
+	if err != nil {
+		return nil, err
+	}
+	negT := T.Copy()
+	negT.C.Scale(-1, negT.C)
+	negT.D.Scale(-1, negT.D)
+	return Parallel(one, negT)
+}

--- a/generalized.go
+++ b/generalized.go
@@ -106,6 +106,7 @@ type GeneralizedClosedLoop struct {
 	name           string
 	plant          *System
 	controller     NumericBlock
+	controllerRaw  any
 	analysisPoints map[string]AnalysisPoint
 }
 
@@ -121,6 +122,7 @@ func NewGeneralizedClosedLoop(name string, plant *System, controller any, analys
 		name:           name,
 		plant:          plant.Copy(),
 		controller:     ctrl,
+		controllerRaw:  controller,
 		analysisPoints: make(map[string]AnalysisPoint),
 	}
 	g.analysisPoints[analysisPoint] = AnalysisPoint{Name: analysisPoint}

--- a/generalized_test.go
+++ b/generalized_test.go
@@ -1,0 +1,92 @@
+package controlsys
+
+import (
+	"errors"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestGeneralizedModelCurrentValueAndAnalysisPoint(t *testing.T) {
+	k, _ := NewTunableReal("K", 2, TunableBounds{Lower: 0, Upper: 10})
+	controller := NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)
+	gm, err := NewGeneralizedModel("loop", controller)
+	if err != nil {
+		t.Fatalf("NewGeneralizedModel: %v", err)
+	}
+	gm.SetInputName("error")
+	gm.SetOutputName("actuator")
+	gm.InsertAnalysisPoint("plant_input")
+
+	sys, err := gm.CurrentSystem()
+	if err != nil {
+		t.Fatalf("CurrentSystem: %v", err)
+	}
+	if sys.D.At(0, 0) != 2 {
+		t.Fatalf("current gain = %g, want 2", sys.D.At(0, 0))
+	}
+	if !sameStrings(sys.InputName, []string{"error"}) || !sameStrings(sys.OutputName, []string{"actuator"}) {
+		t.Fatalf("metadata = %v/%v", sys.InputName, sys.OutputName)
+	}
+	if !gm.HasAnalysisPoint("plant_input") {
+		t.Fatal("analysis point not found")
+	}
+	if _, err := gm.AnalysisPoint("missing"); !errors.Is(err, ErrSignalNotFound) {
+		t.Fatalf("missing analysis point err = %v, want ErrSignalNotFound", err)
+	}
+}
+
+func TestGeneralizedClosedLoopAnalysisHelpers(t *testing.T) {
+	plant, err := New(
+		mat.NewDense(2, 2, []float64{-1, 0.4, -2, -3}),
+		mat.NewDense(2, 1, []float64{1, -0.5}),
+		mat.NewDense(1, 2, []float64{2, -1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k, _ := NewTunableReal("K", 1.5, TunableBounds{Lower: 0.1, Upper: 5})
+	controller := NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)
+	loop, err := NewGeneralizedClosedLoop("cl", plant, controller, "u")
+	if err != nil {
+		t.Fatalf("NewGeneralizedClosedLoop: %v", err)
+	}
+
+	L, err := loop.OpenLoop("u")
+	if err != nil {
+		t.Fatalf("OpenLoop: %v", err)
+	}
+	T, err := loop.ComplementarySensitivity("u")
+	if err != nil {
+		t.Fatalf("ComplementarySensitivity: %v", err)
+	}
+	S, err := loop.Sensitivity("u")
+	if err != nil {
+		t.Fatalf("Sensitivity: %v", err)
+	}
+	CL, err := loop.ClosedLoop("u")
+	if err != nil {
+		t.Fatalf("ClosedLoop: %v", err)
+	}
+	if _, m, p := L.Dims(); m != 1 || p != 1 {
+		t.Fatalf("open-loop dims = (_, %d, %d), want SISO", m, p)
+	}
+	omega := []float64{0.2, 1.0}
+	tResp, _ := T.FreqResponse(omega)
+	clResp, _ := CL.FreqResponse(omega)
+	for i := range omega {
+		if cmplx.Abs(tResp.At(i, 0, 0)-clResp.At(i, 0, 0)) > 1e-10 {
+			t.Fatalf("closed-loop and complementary sensitivity differ at %g", omega[i])
+		}
+	}
+	sResp, _ := S.FreqResponse(omega)
+	for i := range omega {
+		sum := sResp.At(i, 0, 0) + tResp.At(i, 0, 0)
+		if cmplx.Abs(sum-1) > 1e-8 {
+			t.Fatalf("S+T = %v at %g, want 1", sum, omega[i])
+		}
+	}
+}

--- a/modal_reduction.go
+++ b/modal_reduction.go
@@ -1,0 +1,94 @@
+package controlsys
+
+import (
+	"math"
+	"sort"
+)
+
+type ModalTruncateOptions struct {
+	Order       int
+	MaxRealPart float64
+}
+
+type ModalReductionResult struct {
+	Sys    *System
+	Order  int
+	Method string
+	Kept   []int
+}
+
+func ModalTruncate(sys *System, opts *ModalTruncateOptions) (*ModalReductionResult, error) {
+	if opts == nil {
+		opts = &ModalTruncateOptions{}
+	}
+	policy := newRealizationTransformPolicy(sys)
+	if err := policy.requireStandard("ModalTruncate"); err != nil {
+		return nil, err
+	}
+	if err := policy.requireDelayFree("ModalTruncate"); err != nil {
+		return nil, err
+	}
+	n, _, _ := sys.Dims()
+	if n == 0 {
+		return &ModalReductionResult{Sys: sys.Copy(), Order: 0, Method: "modal-truncate"}, nil
+	}
+	order := opts.Order
+	if order == 0 {
+		order = modalAutoOrder(sys, opts.MaxRealPart)
+	}
+	if order < 1 || order > n {
+		return nil, ErrInvalidOrder
+	}
+	if order == n {
+		return &ModalReductionResult{Sys: sys.Copy(), Order: n, Method: "modal-truncate", Kept: rangeInts(n)}, nil
+	}
+	elim := make([]int, 0, n-order)
+	for i := order; i < n; i++ {
+		elim = append(elim, i)
+	}
+	reduced, err := Modred(sys, elim, Truncate)
+	if err != nil {
+		return nil, err
+	}
+	return &ModalReductionResult{Sys: reduced, Order: order, Method: "modal-truncate", Kept: rangeInts(order)}, nil
+}
+
+func modalAutoOrder(sys *System, maxRealPart float64) int {
+	poles, err := sys.Poles()
+	if err != nil || len(poles) == 0 {
+		return 0
+	}
+	if maxRealPart == 0 {
+		maxRealPart = math.Inf(1)
+	}
+	type poleScore struct {
+		index int
+		real  float64
+	}
+	scores := make([]poleScore, len(poles))
+	for i, p := range poles {
+		scores[i] = poleScore{index: i, real: real(p)}
+	}
+	sort.Slice(scores, func(i, j int) bool { return scores[i].real > scores[j].real })
+	order := 0
+	for _, score := range scores {
+		if score.real >= maxRealPart {
+			order++
+		}
+	}
+	if order == 0 {
+		order = len(poles) / 2
+		if order == 0 {
+			order = 1
+		}
+	}
+	return order
+}
+
+func rangeInts(n int) []int {
+	out := make([]int, n)
+	for i := range out {
+		out[i] = i
+	}
+	return out
+}

--- a/modal_reduction_test.go
+++ b/modal_reduction_test.go
@@ -1,0 +1,38 @@
+package controlsys
+
+import "testing"
+
+func TestModalTruncateReducesOrderAndPreservesMetadata(t *testing.T) {
+	sys := benchSysNonSym(4, 1, 1)
+	sys.InputName = []string{"u"}
+	sys.OutputName = []string{"y"}
+	sys.StateName = []string{"x1", "x2", "x3", "x4"}
+
+	result, err := ModalTruncate(sys, &ModalTruncateOptions{Order: 2})
+	if err != nil {
+		t.Fatalf("ModalTruncate: %v", err)
+	}
+	if result.Method != "modal-truncate" || result.Order != 2 {
+		t.Fatalf("metadata = %#v", result)
+	}
+	if n, _, _ := result.Sys.Dims(); n != 2 {
+		t.Fatalf("reduced order = %d, want 2", n)
+	}
+	if !sameStrings(result.Sys.InputName, []string{"u"}) || !sameStrings(result.Sys.OutputName, []string{"y"}) {
+		t.Fatalf("names = %v/%v", result.Sys.InputName, result.Sys.OutputName)
+	}
+}
+
+func TestModalTruncateAutoOrderAndInvalidOptions(t *testing.T) {
+	sys := benchSysNonSym(4, 1, 1)
+	result, err := ModalTruncate(sys, &ModalTruncateOptions{MaxRealPart: -1.0})
+	if err != nil {
+		t.Fatalf("ModalTruncate auto: %v", err)
+	}
+	if result.Order == 0 || result.Order >= 4 {
+		t.Fatalf("auto order = %d, want partial reduction", result.Order)
+	}
+	if _, err := ModalTruncate(sys, &ModalTruncateOptions{Order: 5}); err != ErrInvalidOrder {
+		t.Fatalf("invalid order err = %v, want ErrInvalidOrder", err)
+	}
+}

--- a/model_array.go
+++ b/model_array.go
@@ -1,0 +1,300 @@
+package controlsys
+
+import "fmt"
+
+type ModelArray struct {
+	models     []*System
+	shape      []int
+	n          int
+	m          int
+	p          int
+	dt         float64
+	inputName  []string
+	outputName []string
+}
+
+type ModelArrayFreqResponse struct {
+	Shape     []int
+	Responses []*FreqResponseMatrix
+	Void      []bool
+	Omega     []float64
+	P         int
+	M         int
+}
+
+type ModelArrayTimeResponse struct {
+	Shape     []int
+	Responses []*TimeResponse
+	Void      []bool
+}
+
+func NewModelArray(shape []int, models []*System) (*ModelArray, error) {
+	if len(shape) == 0 {
+		return nil, fmt.Errorf("NewModelArray: shape is empty: %w", ErrDimensionMismatch)
+	}
+	total := 1
+	for _, dim := range shape {
+		if dim <= 0 {
+			return nil, fmt.Errorf("NewModelArray: invalid shape dimension %d: %w", dim, ErrDimensionMismatch)
+		}
+		total *= dim
+	}
+	if total != len(models) {
+		return nil, fmt.Errorf("NewModelArray: shape product %d != %d models: %w", total, len(models), ErrDimensionMismatch)
+	}
+
+	arr := &ModelArray{
+		models: make([]*System, len(models)),
+		shape:  copyIntSlice(shape),
+	}
+	var ref *System
+	for _, sys := range models {
+		if sys == nil {
+			continue
+		}
+		if err := sys.Validate(); err != nil {
+			return nil, fmt.Errorf("NewModelArray: %w", err)
+		}
+		if ref == nil {
+			ref = sys
+			arr.n, arr.m, arr.p = sys.Dims()
+			arr.dt = sys.Dt
+			arr.inputName = copyStringSlice(sys.InputName)
+			arr.outputName = copyStringSlice(sys.OutputName)
+			continue
+		}
+		if err := validateModelArrayCompatible(ref, sys); err != nil {
+			return nil, fmt.Errorf("NewModelArray: %w", err)
+		}
+	}
+	for i, sys := range models {
+		if sys != nil {
+			arr.models[i] = sys.Copy()
+		}
+	}
+	return arr, nil
+}
+
+func StackModelArrays(arrays ...*ModelArray) (*ModelArray, error) {
+	if len(arrays) == 0 {
+		return nil, fmt.Errorf("StackModelArrays: no arrays: %w", ErrDimensionMismatch)
+	}
+	var ref *ModelArray
+	total := 0
+	for _, arr := range arrays {
+		if arr == nil {
+			return nil, fmt.Errorf("StackModelArrays: nil array: %w", ErrDimensionMismatch)
+		}
+		if ref == nil {
+			ref = arr
+		} else if err := validateModelArrayHeadersCompatible(ref, arr); err != nil {
+			return nil, fmt.Errorf("StackModelArrays: %w", err)
+		}
+		total += arr.Len()
+	}
+	models := make([]*System, 0, total)
+	for _, arr := range arrays {
+		for _, sys := range arr.models {
+			if sys == nil {
+				models = append(models, nil)
+			} else {
+				models = append(models, sys.Copy())
+			}
+		}
+	}
+	return NewModelArray([]int{total}, models)
+}
+
+func (a *ModelArray) Shape() []int {
+	if a == nil {
+		return nil
+	}
+	return copyIntSlice(a.shape)
+}
+
+func (a *ModelArray) Len() int {
+	if a == nil {
+		return 0
+	}
+	return len(a.models)
+}
+
+func (a *ModelArray) Dims() (n, m, p int) {
+	if a == nil {
+		return 0, 0, 0
+	}
+	return a.n, a.m, a.p
+}
+
+func (a *ModelArray) InputName() []string {
+	if a == nil {
+		return nil
+	}
+	return copyStringSlice(a.inputName)
+}
+
+func (a *ModelArray) OutputName() []string {
+	if a == nil {
+		return nil
+	}
+	return copyStringSlice(a.outputName)
+}
+
+func (a *ModelArray) Model(index ...int) (*System, bool, error) {
+	if a == nil {
+		return nil, false, fmt.Errorf("ModelArray.Model: nil array: %w", ErrDimensionMismatch)
+	}
+	flat, err := a.flatIndex(index)
+	if err != nil {
+		return nil, false, err
+	}
+	return a.ModelFlat(flat)
+}
+
+func (a *ModelArray) ModelFlat(index int) (*System, bool, error) {
+	if a == nil {
+		return nil, false, fmt.Errorf("ModelArray.ModelFlat: nil array: %w", ErrDimensionMismatch)
+	}
+	if index < 0 || index >= len(a.models) {
+		return nil, false, fmt.Errorf("ModelArray.ModelFlat: index %d out of range: %w", index, ErrDimensionMismatch)
+	}
+	sys := a.models[index]
+	if sys == nil {
+		return nil, false, nil
+	}
+	return sys.Copy(), true, nil
+}
+
+func (a *ModelArray) SelectFlat(indices ...int) (*ModelArray, error) {
+	if a == nil {
+		return nil, fmt.Errorf("ModelArray.SelectFlat: nil array: %w", ErrDimensionMismatch)
+	}
+	models := make([]*System, len(indices))
+	for i, idx := range indices {
+		if idx < 0 || idx >= len(a.models) {
+			return nil, fmt.Errorf("ModelArray.SelectFlat: index %d out of range: %w", idx, ErrDimensionMismatch)
+		}
+		if a.models[idx] != nil {
+			models[i] = a.models[idx].Copy()
+		}
+	}
+	return NewModelArray([]int{len(indices)}, models)
+}
+
+func (a *ModelArray) FreqResponse(omega []float64) (*ModelArrayFreqResponse, error) {
+	if a == nil {
+		return nil, fmt.Errorf("ModelArray.FreqResponse: nil array: %w", ErrDimensionMismatch)
+	}
+	out := &ModelArrayFreqResponse{
+		Shape:     copyIntSlice(a.shape),
+		Responses: make([]*FreqResponseMatrix, len(a.models)),
+		Void:      make([]bool, len(a.models)),
+		Omega:     copyFloatSlice(omega),
+		P:         a.p,
+		M:         a.m,
+	}
+	for i, sys := range a.models {
+		if sys == nil {
+			out.Void[i] = true
+			continue
+		}
+		resp, err := sys.FreqResponse(omega)
+		if err != nil {
+			return nil, fmt.Errorf("ModelArray.FreqResponse[%d]: %w", i, err)
+		}
+		out.Responses[i] = resp
+	}
+	return out, nil
+}
+
+func (a *ModelArray) Step(tFinal float64) (*ModelArrayTimeResponse, error) {
+	if a == nil {
+		return nil, fmt.Errorf("ModelArray.Step: nil array: %w", ErrDimensionMismatch)
+	}
+	out := &ModelArrayTimeResponse{
+		Shape:     copyIntSlice(a.shape),
+		Responses: make([]*TimeResponse, len(a.models)),
+		Void:      make([]bool, len(a.models)),
+	}
+	for i, sys := range a.models {
+		if sys == nil {
+			out.Void[i] = true
+			continue
+		}
+		resp, err := Step(sys, tFinal)
+		if err != nil {
+			return nil, fmt.Errorf("ModelArray.Step[%d]: %w", i, err)
+		}
+		out.Responses[i] = resp
+	}
+	return out, nil
+}
+
+func (a *ModelArray) flatIndex(index []int) (int, error) {
+	if len(index) != len(a.shape) {
+		return 0, fmt.Errorf("ModelArray.Model: got %d indices for rank %d: %w", len(index), len(a.shape), ErrDimensionMismatch)
+	}
+	flat := 0
+	stride := 1
+	for dim := len(a.shape) - 1; dim >= 0; dim-- {
+		idx := index[dim]
+		if idx < 0 || idx >= a.shape[dim] {
+			return 0, fmt.Errorf("ModelArray.Model: index %d out of range for dimension %d: %w", idx, dim, ErrDimensionMismatch)
+		}
+		flat += idx * stride
+		stride *= a.shape[dim]
+	}
+	return flat, nil
+}
+
+func validateModelArrayCompatible(ref, sys *System) error {
+	_, rm, rp := ref.Dims()
+	_, sm, sp := sys.Dims()
+	if rm != sm || rp != sp {
+		return fmt.Errorf("model dimensions (%d,%d) != (%d,%d): %w", sp, sm, rp, rm, ErrDimensionMismatch)
+	}
+	if ref.Dt != sys.Dt {
+		return fmt.Errorf("sample time %g != %g: %w", sys.Dt, ref.Dt, ErrDimensionMismatch)
+	}
+	if !stringSlicesCompatible(ref.InputName, sys.InputName) || !stringSlicesCompatible(ref.OutputName, sys.OutputName) {
+		return fmt.Errorf("signal names differ: %w", ErrDimensionMismatch)
+	}
+	return nil
+}
+
+func validateModelArrayHeadersCompatible(ref, arr *ModelArray) error {
+	if ref.m != arr.m || ref.p != arr.p {
+		return fmt.Errorf("model dimensions (%d,%d) != (%d,%d): %w", arr.p, arr.m, ref.p, ref.m, ErrDimensionMismatch)
+	}
+	if ref.dt != arr.dt {
+		return fmt.Errorf("sample time %g != %g: %w", arr.dt, ref.dt, ErrDimensionMismatch)
+	}
+	if !stringSlicesCompatible(ref.inputName, arr.inputName) || !stringSlicesCompatible(ref.outputName, arr.outputName) {
+		return fmt.Errorf("signal names differ: %w", ErrDimensionMismatch)
+	}
+	return nil
+}
+
+func stringSlicesCompatible(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func copyIntSlice(s []int) []int {
+	if s == nil {
+		return nil
+	}
+	out := make([]int, len(s))
+	copy(out, s)
+	return out
+}

--- a/model_array_test.go
+++ b/model_array_test.go
@@ -1,0 +1,197 @@
+package controlsys
+
+import (
+	"errors"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestModelArrayPreservesShapeMetadataAndVoidEntries(t *testing.T) {
+	sys1 := modelArrayTestSystem(t, 0, []float64{-1, 2, -3, -4})
+	sys2 := modelArrayTestSystem(t, 0, []float64{-2, 1, -4, -5})
+	if err := sys1.SetInputName("command"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sys1.SetOutputName("position"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sys2.SetInputName("command"); err != nil {
+		t.Fatal(err)
+	}
+	if err := sys2.SetOutputName("position"); err != nil {
+		t.Fatal(err)
+	}
+
+	arr, err := NewModelArray([]int{2, 2}, []*System{sys1, nil, sys2, nil})
+	if err != nil {
+		t.Fatalf("NewModelArray: %v", err)
+	}
+
+	if got, want := arr.Shape(), []int{2, 2}; !sameInts(got, want) {
+		t.Fatalf("Shape() = %v, want %v", got, want)
+	}
+	if got := arr.Len(); got != 4 {
+		t.Fatalf("Len() = %d, want 4", got)
+	}
+	if _, m, p := arr.Dims(); m != 1 || p != 1 {
+		t.Fatalf("Dims() = (_, %d, %d), want (_, 1, 1)", m, p)
+	}
+	if got, ok, err := arr.Model(0, 1); err != nil || ok || got != nil {
+		t.Fatalf("void Model(0,1) = (%v, %v, %v), want nil,false,nil", got, ok, err)
+	}
+	got, ok, err := arr.Model(1, 0)
+	if err != nil || !ok {
+		t.Fatalf("Model(1,0) ok=%v err=%v, want ok", ok, err)
+	}
+	got.A.Set(0, 0, 99)
+	if sys2.A.At(0, 0) == 99 {
+		t.Fatal("Model returned aliased system")
+	}
+	if got := arr.InputName(); !sameStrings(got, []string{"command"}) {
+		t.Fatalf("InputName() = %v", got)
+	}
+	if got := arr.OutputName(); !sameStrings(got, []string{"position"}) {
+		t.Fatalf("OutputName() = %v", got)
+	}
+}
+
+func TestModelArraySelectAndStack(t *testing.T) {
+	a := modelArrayTestSystem(t, 0.1, []float64{0.8, 0.2, -0.1, 0.6})
+	b := modelArrayTestSystem(t, 0.1, []float64{0.7, 0.1, -0.2, 0.5})
+	c := modelArrayTestSystem(t, 0.1, []float64{0.6, 0.3, -0.3, 0.4})
+
+	left, err := NewModelArray([]int{2}, []*System{a, nil})
+	if err != nil {
+		t.Fatalf("left array: %v", err)
+	}
+	right, err := NewModelArray([]int{1}, []*System{b})
+	if err != nil {
+		t.Fatalf("right array: %v", err)
+	}
+	selected, err := left.SelectFlat(1, 0)
+	if err != nil {
+		t.Fatalf("SelectFlat: %v", err)
+	}
+	if got, ok, err := selected.ModelFlat(0); err != nil || ok || got != nil {
+		t.Fatalf("selected void = (%v, %v, %v), want nil,false,nil", got, ok, err)
+	}
+	if _, ok, err := selected.ModelFlat(1); err != nil || !ok {
+		t.Fatalf("selected model ok=%v err=%v, want ok", ok, err)
+	}
+
+	stacked, err := StackModelArrays(left, right)
+	if err != nil {
+		t.Fatalf("StackModelArrays: %v", err)
+	}
+	if got, want := stacked.Shape(), []int{3}; !sameInts(got, want) {
+		t.Fatalf("stacked Shape() = %v, want %v", got, want)
+	}
+
+	incompatible, err := NewModelArray([]int{1}, []*System{c})
+	if err != nil {
+		t.Fatal(err)
+	}
+	incompatible.models[0].Dt = 0.2
+	if _, err := StackModelArrays(left, incompatible); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("StackModelArrays incompatible err = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestModelArrayRejectsInvalidCompatibility(t *testing.T) {
+	sys := modelArrayTestSystem(t, 0, []float64{-1, 2, -3, -4})
+	badDt := modelArrayTestSystem(t, 0.1, []float64{0.8, 0.2, -0.1, 0.6})
+	badDims, err := NewGain(mat.NewDense(2, 1, []float64{1, 2}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewModelArray([]int{2}, []*System{sys, badDt}); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("mixed sample time err = %v, want ErrDimensionMismatch", err)
+	}
+	if _, err := NewModelArray([]int{2}, []*System{sys, badDims}); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("mixed dimensions err = %v, want ErrDimensionMismatch", err)
+	}
+	if _, err := NewModelArray([]int{2, 2}, []*System{sys}); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("shape/product mismatch err = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestModelArrayBatchResponsesPreserveResultShape(t *testing.T) {
+	sys1 := modelArrayTestSystem(t, 0, []float64{-1, 2, -3, -4})
+	sys2 := modelArrayTestSystem(t, 0, []float64{-2, 1, -4, -5})
+	arr, err := NewModelArray([]int{3}, []*System{sys1, nil, sys2})
+	if err != nil {
+		t.Fatalf("NewModelArray: %v", err)
+	}
+
+	fresp, err := arr.FreqResponse([]float64{0.5, 1.0})
+	if err != nil {
+		t.Fatalf("FreqResponse: %v", err)
+	}
+	if got, want := fresp.Shape, []int{3}; !sameInts(got, want) {
+		t.Fatalf("freq shape = %v, want %v", got, want)
+	}
+	if got := len(fresp.Responses); got != 3 {
+		t.Fatalf("len(freq responses) = %d, want 3", got)
+	}
+	if fresp.Responses[1] != nil || !fresp.Void[1] {
+		t.Fatalf("void freq response = (%v, %v), want nil,true", fresp.Responses[1], fresp.Void[1])
+	}
+	if got := fresp.Responses[0].At(0, 0, 0); got == 0 {
+		t.Fatal("first frequency response is zero; expected evaluated model")
+	}
+
+	step, err := arr.Step(0.2)
+	if err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if got, want := step.Shape, []int{3}; !sameInts(got, want) {
+		t.Fatalf("step shape = %v, want %v", got, want)
+	}
+	if step.Responses[1] != nil || !step.Void[1] {
+		t.Fatalf("void step response = (%v, %v), want nil,true", step.Responses[1], step.Void[1])
+	}
+	if got := len(step.Responses[0].T); got == 0 {
+		t.Fatal("first step response has no time samples")
+	}
+}
+
+func modelArrayTestSystem(t *testing.T, dt float64, a []float64) *System {
+	t.Helper()
+	sys, err := New(
+		mat.NewDense(2, 2, a),
+		mat.NewDense(2, 1, []float64{1, -2}),
+		mat.NewDense(1, 2, []float64{3, -1}),
+		mat.NewDense(1, 1, []float64{0.25}),
+		dt,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return sys
+}
+
+func sameInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/passivity.go
+++ b/passivity.go
@@ -1,0 +1,125 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+)
+
+type PassivityOptions struct {
+	Omega []float64
+	Tol   float64
+}
+
+type PassivityResult struct {
+	Passive          bool
+	MinHermitianPart float64
+	Frequency        float64
+}
+
+func Passive(sys *System, opts *PassivityOptions) (*PassivityResult, error) {
+	if sys == nil {
+		return nil, fmt.Errorf("Passive: nil system: %w", ErrDimensionMismatch)
+	}
+	if err := newDescriptorPolicy(sys).requireStandard("Passive"); err != nil {
+		return nil, err
+	}
+	if sys.HasDelay() {
+		return nil, fmt.Errorf("Passive: delayed systems are not supported: %w", ErrDescriptorUnsupported)
+	}
+	stable, err := sys.IsStable()
+	if err != nil {
+		return nil, err
+	}
+	if !stable {
+		return nil, fmt.Errorf("Passive: %w", ErrUnstable)
+	}
+	omega, tol := passivityGrid(opts)
+	frd, err := sys.FRD(omega)
+	if err != nil {
+		return nil, err
+	}
+	return FRDPassive(frd, &PassivityOptions{Tol: tol})
+}
+
+func FRDPassive(frd *FRD, opts *PassivityOptions) (*PassivityResult, error) {
+	if frd == nil || len(frd.Response) == 0 {
+		return nil, fmt.Errorf("FRDPassive: insufficient data: %w", ErrInsufficientData)
+	}
+	p, m := len(frd.Response[0]), len(frd.Response[0][0])
+	if p != m {
+		return nil, fmt.Errorf("FRDPassive: model must be square, got %dx%d: %w", p, m, ErrDimensionMismatch)
+	}
+	_, tol := passivityGrid(opts)
+	result := &PassivityResult{Passive: true, MinHermitianPart: math.Inf(1)}
+	for k, h := range frd.Response {
+		minPart := minHermitianPart(h)
+		if minPart < result.MinHermitianPart {
+			result.MinHermitianPart = minPart
+			if k < len(frd.Omega) {
+				result.Frequency = frd.Omega[k]
+			}
+		}
+	}
+	result.Passive = result.MinHermitianPart >= -tol
+	return result, nil
+}
+
+func SpectralFactor(sys *System) (*System, error) {
+	if sys == nil {
+		return nil, fmt.Errorf("SpectralFactor: nil system: %w", ErrDimensionMismatch)
+	}
+	if err := newDescriptorPolicy(sys).requireStandard("SpectralFactor"); err != nil {
+		return nil, err
+	}
+	if sys.HasDelay() {
+		return nil, fmt.Errorf("SpectralFactor: delayed systems are not supported: %w", ErrDescriptorUnsupported)
+	}
+	n, m, p := sys.Dims()
+	if n != 0 {
+		return nil, fmt.Errorf("SpectralFactor: only static gain models are supported by this tracer: %w", ErrDimensionMismatch)
+	}
+	if m != p {
+		return nil, fmt.Errorf("SpectralFactor: model must be square, got %dx%d: %w", p, m, ErrDimensionMismatch)
+	}
+	D := newDense(p, m)
+	for i := 0; i < p; i++ {
+		for j := 0; j < m; j++ {
+			if i != j && sys.D.At(i, j) != 0 {
+				return nil, fmt.Errorf("SpectralFactor: only diagonal positive static gains are supported: %w", ErrDimensionMismatch)
+			}
+			if i == j {
+				v := sys.D.At(i, j)
+				if v < 0 {
+					return nil, fmt.Errorf("SpectralFactor: negative diagonal value: %w", ErrNotPSD)
+				}
+				D.Set(i, j, math.Sqrt(v))
+			}
+		}
+	}
+	return NewGain(D, sys.Dt)
+}
+
+func passivityGrid(opts *PassivityOptions) ([]float64, float64) {
+	tol := 1e-9
+	if opts != nil && opts.Tol > 0 {
+		tol = opts.Tol
+	}
+	if opts != nil && len(opts.Omega) > 0 {
+		return opts.Omega, tol
+	}
+	return logspace(-2, 2, 120), tol
+}
+
+func minHermitianPart(h [][]complex128) float64 {
+	if len(h) == 1 && len(h[0]) == 1 {
+		return real(h[0][0])
+	}
+	minDiag := math.Inf(1)
+	for i := range h {
+		v := real(h[i][i])
+		if v < minDiag {
+			minDiag = v
+		}
+	}
+	return minDiag
+}

--- a/passivity_test.go
+++ b/passivity_test.go
@@ -1,0 +1,64 @@
+package controlsys
+
+import (
+	"errors"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestPassivityDenseAndFRD(t *testing.T) {
+	passive := makeSISO(-1, 1, 1, 0)
+	result, err := Passive(passive, nil)
+	if err != nil {
+		t.Fatalf("Passive: %v", err)
+	}
+	if !result.Passive || result.MinHermitianPart < 0 {
+		t.Fatalf("expected passive result, got %#v", result)
+	}
+
+	nonpassive := makeSISO(-1, 1, -1, 0)
+	bad, err := Passive(nonpassive, nil)
+	if err != nil {
+		t.Fatalf("Passive nonpassive: %v", err)
+	}
+	if bad.Passive {
+		t.Fatalf("expected nonpassive result, got %#v", bad)
+	}
+
+	frd, err := passive.FRD([]float64{0.1, 1, 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	frdResult, err := FRDPassive(frd, nil)
+	if err != nil {
+		t.Fatalf("FRDPassive: %v", err)
+	}
+	if !frdResult.Passive {
+		t.Fatalf("expected passive FRD result, got %#v", frdResult)
+	}
+}
+
+func TestSpectralFactorStaticGainAndUnsupportedCases(t *testing.T) {
+	sys, err := NewGain(mat.NewDense(1, 1, []float64{4}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	factor, err := SpectralFactor(sys)
+	if err != nil {
+		t.Fatalf("SpectralFactor: %v", err)
+	}
+	if factor.D.At(0, 0) != 2 {
+		t.Fatalf("factor D = %g, want 2", factor.D.At(0, 0))
+	}
+
+	dynamic := makeSISO(-1, 1, 1, 0)
+	if _, err := SpectralFactor(dynamic); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("dynamic spectral factor err = %v, want ErrDimensionMismatch", err)
+	}
+	delayed := sys.Copy()
+	delayed.InputDelay = []float64{1}
+	if _, err := SpectralFactor(delayed); !errors.Is(err, ErrDescriptorUnsupported) {
+		t.Fatalf("delayed spectral factor err = %v, want ErrDescriptorUnsupported", err)
+	}
+}

--- a/physical_assembly.go
+++ b/physical_assembly.go
@@ -1,0 +1,114 @@
+package controlsys
+
+import "fmt"
+
+type PhysicalPortKind int
+
+const (
+	PhysicalPortDisplacement PhysicalPortKind = iota
+	PhysicalPortEffort
+)
+
+type PhysicalPort struct {
+	Name      string
+	Kind      PhysicalPortKind
+	Dimension int
+}
+
+type PhysicalComponent struct {
+	Name   string
+	System *System
+	Ports  []PhysicalPort
+}
+
+type PhysicalConnection struct {
+	FromComponent string
+	FromPort      string
+	ToComponent   string
+	ToPort        string
+	Grounded      bool
+}
+
+func NewPhysicalComponent(name string, sys *System, ports []PhysicalPort) PhysicalComponent {
+	return PhysicalComponent{Name: name, System: sys.Copy(), Ports: append([]PhysicalPort(nil), ports...)}
+}
+
+func AssemblePhysical(name string, components []PhysicalComponent, connections []PhysicalConnection) (*System, error) {
+	if len(components) == 0 {
+		return nil, fmt.Errorf("AssemblePhysical: no components: %w", ErrDimensionMismatch)
+	}
+	byName := make(map[string]PhysicalComponent, len(components))
+	for _, component := range components {
+		if component.Name == "" || component.System == nil {
+			return nil, fmt.Errorf("AssemblePhysical: invalid component: %w", ErrDimensionMismatch)
+		}
+		if _, exists := byName[component.Name]; exists {
+			return nil, fmt.Errorf("AssemblePhysical: duplicate component %q: %w", component.Name, ErrDimensionMismatch)
+		}
+		byName[component.Name] = component
+	}
+	for _, conn := range connections {
+		from, err := lookupPhysicalPort(byName, conn.FromComponent, conn.FromPort)
+		if err != nil {
+			return nil, err
+		}
+		if conn.Grounded {
+			continue
+		}
+		to, err := lookupPhysicalPort(byName, conn.ToComponent, conn.ToPort)
+		if err != nil {
+			return nil, err
+		}
+		if from.Kind != to.Kind || from.Dimension != to.Dimension {
+			return nil, fmt.Errorf("AssemblePhysical: incompatible ports %s.%s and %s.%s: %w",
+				conn.FromComponent, conn.FromPort, conn.ToComponent, conn.ToPort, ErrDimensionMismatch)
+		}
+	}
+
+	systems := make([]*System, len(components))
+	for i, component := range components {
+		sys := component.System.Copy()
+		prefixSystemMetadata(sys, component.Name)
+		systems[i] = sys
+	}
+	if len(systems) == 1 {
+		return systems[0], nil
+	}
+	assembled := systems[0]
+	for _, sys := range systems[1:] {
+		next, err := Append(assembled, sys)
+		if err != nil {
+			return nil, err
+		}
+		assembled = next
+	}
+	return assembled, nil
+}
+
+func lookupPhysicalPort(components map[string]PhysicalComponent, componentName, portName string) (PhysicalPort, error) {
+	component, ok := components[componentName]
+	if !ok {
+		return PhysicalPort{}, fmt.Errorf("AssemblePhysical: component %q not found: %w", componentName, ErrSignalNotFound)
+	}
+	for _, port := range component.Ports {
+		if port.Name == portName {
+			if port.Dimension <= 0 {
+				return PhysicalPort{}, fmt.Errorf("AssemblePhysical: invalid port dimension: %w", ErrDimensionMismatch)
+			}
+			return port, nil
+		}
+	}
+	return PhysicalPort{}, fmt.Errorf("AssemblePhysical: port %q not found on %q: %w", portName, componentName, ErrSignalNotFound)
+}
+
+func prefixSystemMetadata(sys *System, prefix string) {
+	for i, name := range sys.InputName {
+		sys.InputName[i] = prefix + "." + name
+	}
+	for i, name := range sys.OutputName {
+		sys.OutputName[i] = prefix + "." + name
+	}
+	for i, name := range sys.StateName {
+		sys.StateName[i] = prefix + "." + name
+	}
+}

--- a/physical_assembly_test.go
+++ b/physical_assembly_test.go
@@ -1,0 +1,78 @@
+package controlsys
+
+import (
+	"errors"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestPhysicalAssemblyGroundedDescriptorComponent(t *testing.T) {
+	component := physicalTestComponent(t, "mass")
+	asm, err := AssemblePhysical("grounded", []PhysicalComponent{component}, []PhysicalConnection{
+		{FromComponent: "mass", FromPort: "mount", Grounded: true},
+	})
+	if err != nil {
+		t.Fatalf("AssemblePhysical: %v", err)
+	}
+	if !asm.IsDescriptor() {
+		t.Fatal("assembled descriptor component should remain descriptor")
+	}
+	if !matEqual(asm.A, component.System.A, 1e-12) || !matEqual(asm.E, component.System.E, 1e-12) {
+		t.Fatalf("assembled matrices do not match component")
+	}
+	if !sameStrings(asm.StateName, []string{"mass.x1", "mass.x2"}) {
+		t.Fatalf("state names = %v", asm.StateName)
+	}
+}
+
+func TestPhysicalAssemblyTwoComponentCoupling(t *testing.T) {
+	left := physicalTestComponent(t, "left")
+	right := physicalTestComponent(t, "right")
+	asm, err := AssemblePhysical("pair", []PhysicalComponent{left, right}, []PhysicalConnection{
+		{FromComponent: "left", FromPort: "mount", ToComponent: "right", ToPort: "mount"},
+	})
+	if err != nil {
+		t.Fatalf("AssemblePhysical: %v", err)
+	}
+	if n, m, p := asm.Dims(); n != 4 || m != 2 || p != 2 {
+		t.Fatalf("dims = (%d,%d,%d), want (4,2,2)", n, m, p)
+	}
+	if asm.A.At(0, 1) != left.System.A.At(0, 1) || asm.A.At(2, 3) != right.System.A.At(0, 1) {
+		t.Fatalf("block diagonal A not preserved: %v", mat.Formatted(asm.A))
+	}
+	if !sameStrings(asm.InputName, []string{"left.force", "right.force"}) {
+		t.Fatalf("input names = %v", asm.InputName)
+	}
+}
+
+func TestPhysicalAssemblyRejectsIncompatiblePorts(t *testing.T) {
+	left := physicalTestComponent(t, "left")
+	right := physicalTestComponent(t, "right")
+	right.Ports[0].Kind = PhysicalPortEffort
+	_, err := AssemblePhysical("bad", []PhysicalComponent{left, right}, []PhysicalConnection{
+		{FromComponent: "left", FromPort: "mount", ToComponent: "right", ToPort: "mount"},
+	})
+	if !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("incompatible port err = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func physicalTestComponent(t *testing.T, name string) PhysicalComponent {
+	t.Helper()
+	sys, err := NewDescriptor(
+		mat.NewDense(2, 2, []float64{-1, 0.5, -2, -3}),
+		mat.NewDense(2, 1, []float64{1, -1}),
+		mat.NewDense(1, 2, []float64{2, -0.5}),
+		mat.NewDense(1, 1, []float64{0}),
+		mat.NewDense(2, 2, []float64{2, 0, 0.1, 3}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sys.InputName = []string{"force"}
+	sys.OutputName = []string{"position"}
+	sys.StateName = []string{"x1", "x2"}
+	return NewPhysicalComponent(name, sys, []PhysicalPort{{Name: "mount", Kind: PhysicalPortDisplacement, Dimension: 1}})
+}

--- a/response_info.go
+++ b/response_info.go
@@ -1,0 +1,212 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+)
+
+type StepInfoOptions struct {
+	RiseTimeLimits    [2]float64
+	SettlingThreshold float64
+	SteadyStateValue  []float64
+}
+
+type StepInfoResult struct {
+	Metrics    []StepMetric
+	OutputName []string
+}
+
+type StepMetric struct {
+	RiseTime         float64
+	SettlingTime     float64
+	Overshoot        float64
+	Undershoot       float64
+	Peak             float64
+	PeakTime         float64
+	SteadyStateValue float64
+	Settled          bool
+}
+
+func StepInfo(resp *TimeResponse, opts *StepInfoOptions) (*StepInfoResult, error) {
+	if resp == nil || resp.Y == nil {
+		return nil, fmt.Errorf("StepInfo: response must not be nil: %w", ErrDimensionMismatch)
+	}
+	rows, cols := resp.Y.Dims()
+	if cols != len(resp.T) {
+		return nil, fmt.Errorf("StepInfo: response has %d samples but time vector has %d: %w", cols, len(resp.T), ErrDimensionMismatch)
+	}
+	if cols < 2 {
+		return nil, fmt.Errorf("StepInfo: need at least 2 response samples: %w", ErrDimensionMismatch)
+	}
+	if err := validateStepInfoTime(resp.T); err != nil {
+		return nil, err
+	}
+
+	cfg := defaultStepInfoOptions(opts)
+	if cfg.SteadyStateValue != nil && len(cfg.SteadyStateValue) != rows {
+		return nil, fmt.Errorf("StepInfo: steady-state values length %d does not match response rows %d: %w", len(cfg.SteadyStateValue), rows, ErrDimensionMismatch)
+	}
+	metrics := make([]StepMetric, rows)
+	for row := 0; row < rows; row++ {
+		metrics[row] = stepMetricForRow(resp, row, cfg)
+	}
+	return &StepInfoResult{Metrics: metrics, OutputName: copyStringSlice(resp.OutputName)}, nil
+}
+
+func StepInfoForSystem(sys *System, tFinal float64, opts *StepInfoOptions) (*StepInfoResult, error) {
+	if sys == nil {
+		return nil, fmt.Errorf("StepInfoForSystem: system must not be nil: %w", ErrDimensionMismatch)
+	}
+	stable, err := sys.IsStable()
+	if err != nil {
+		return nil, fmt.Errorf("StepInfoForSystem: %w", err)
+	}
+	if !stable {
+		return nil, fmt.Errorf("StepInfoForSystem: model is unstable: %w", ErrUnstable)
+	}
+	resp, err := Step(sys, tFinal)
+	if err != nil {
+		return nil, err
+	}
+	return StepInfo(resp, opts)
+}
+
+func defaultStepInfoOptions(opts *StepInfoOptions) StepInfoOptions {
+	cfg := StepInfoOptions{
+		RiseTimeLimits:    [2]float64{0.1, 0.9},
+		SettlingThreshold: 0.02,
+	}
+	if opts != nil {
+		cfg = *opts
+	}
+	if cfg.RiseTimeLimits == [2]float64{} {
+		cfg.RiseTimeLimits = [2]float64{0.1, 0.9}
+	}
+	if cfg.SettlingThreshold == 0 {
+		cfg.SettlingThreshold = 0.02
+	}
+	return cfg
+}
+
+func validateStepInfoTime(t []float64) error {
+	for k := 1; k < len(t); k++ {
+		if t[k] <= t[k-1] {
+			return fmt.Errorf("StepInfo: time vector must be strictly increasing at index %d: %w", k, ErrDimensionMismatch)
+		}
+	}
+	return nil
+}
+
+func stepMetricForRow(resp *TimeResponse, row int, cfg StepInfoOptions) StepMetric {
+	_, cols := resp.Y.Dims()
+	initial := resp.Y.At(row, 0)
+	final := resp.Y.At(row, cols-1)
+	if cfg.SteadyStateValue != nil {
+		final = cfg.SteadyStateValue[row]
+	}
+	delta := final - initial
+	scale := math.Abs(delta)
+	if scale == 0 {
+		scale = math.Max(math.Abs(final), 1)
+	}
+	direction := 1.0
+	if delta < 0 {
+		direction = -1
+	}
+
+	peak, peakTime := directionalPeak(resp, row, direction)
+	rise := math.NaN()
+	if delta != 0 {
+		lo := initial + delta*cfg.RiseTimeLimits[0]
+		hi := initial + delta*cfg.RiseTimeLimits[1]
+		tLo := crossingTime(resp, row, lo, direction)
+		tHi := crossingTime(resp, row, hi, direction)
+		if !math.IsNaN(tLo) && !math.IsNaN(tHi) {
+			rise = tHi - tLo
+		}
+	}
+
+	settling, settled := settlingTime(resp, row, final, cfg.SettlingThreshold*scale)
+	overshoot := 0.0
+	if beyond := direction * (peak - final); beyond > 0 && delta != 0 {
+		overshoot = 100 * beyond / math.Abs(delta)
+	}
+	undershoot := rowUndershoot(resp, row, initial, direction, scale)
+
+	return StepMetric{
+		RiseTime:         rise,
+		SettlingTime:     settling,
+		Overshoot:        overshoot,
+		Undershoot:       undershoot,
+		Peak:             peak,
+		PeakTime:         peakTime,
+		SteadyStateValue: final,
+		Settled:          settled,
+	}
+}
+
+func directionalPeak(resp *TimeResponse, row int, direction float64) (float64, float64) {
+	_, cols := resp.Y.Dims()
+	peak := resp.Y.At(row, 0)
+	peakTime := resp.T[0]
+	best := direction * peak
+	for k := 1; k < cols; k++ {
+		y := resp.Y.At(row, k)
+		score := direction * y
+		if score >= best {
+			best = score
+			peak = y
+			peakTime = resp.T[k]
+		}
+	}
+	return peak, peakTime
+}
+
+func crossingTime(resp *TimeResponse, row int, level, direction float64) float64 {
+	_, cols := resp.Y.Dims()
+	prev := resp.Y.At(row, 0)
+	for k := 1; k < cols; k++ {
+		curr := resp.Y.At(row, k)
+		if direction*(curr-level) >= 0 && direction*(prev-level) < 0 {
+			if curr == prev {
+				return resp.T[k]
+			}
+			alpha := (level - prev) / (curr - prev)
+			return resp.T[k-1] + alpha*(resp.T[k]-resp.T[k-1])
+		}
+		prev = curr
+	}
+	return math.NaN()
+}
+
+func settlingTime(resp *TimeResponse, row int, final, band float64) (float64, bool) {
+	_, cols := resp.Y.Dims()
+	lastOutside := -1
+	for k := 0; k < cols; k++ {
+		if math.Abs(resp.Y.At(row, k)-final) > band {
+			lastOutside = k
+		}
+	}
+	if lastOutside == -1 {
+		return resp.T[0], true
+	}
+	if lastOutside == cols-1 {
+		return math.NaN(), false
+	}
+	return resp.T[lastOutside+1], true
+}
+
+func rowUndershoot(resp *TimeResponse, row int, initial, direction, scale float64) float64 {
+	_, cols := resp.Y.Dims()
+	worst := 0.0
+	for k := 0; k < cols; k++ {
+		opposite := direction * (initial - resp.Y.At(row, k))
+		if opposite > worst {
+			worst = opposite
+		}
+	}
+	if worst == 0 {
+		return 0
+	}
+	return 100 * worst / scale
+}

--- a/response_info_test.go
+++ b/response_info_test.go
@@ -1,0 +1,189 @@
+package controlsys
+
+import (
+	"math"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestStepInfoFirstOrderResponse(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(1, 1, []float64{-1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := Step(sys, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := StepInfo(resp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info.Metrics) != 1 {
+		t.Fatalf("got %d metrics, want 1", len(info.Metrics))
+	}
+
+	got := info.Metrics[0]
+	if math.Abs(got.SteadyStateValue-1) > 1e-3 {
+		t.Fatalf("steady-state value = %g, want near 1", got.SteadyStateValue)
+	}
+	if math.Abs(got.RiseTime-2.2) > 0.08 {
+		t.Errorf("rise time = %g, want near 2.2", got.RiseTime)
+	}
+	if math.Abs(got.SettlingTime-3.9) > 0.15 {
+		t.Errorf("settling time = %g, want near 3.9", got.SettlingTime)
+	}
+	if math.Abs(got.Peak-1) > 1e-3 {
+		t.Errorf("peak = %g, want near 1", got.Peak)
+	}
+	if math.Abs(got.PeakTime-8) > 1e-12 {
+		t.Errorf("peak time = %g, want final sample time 8", got.PeakTime)
+	}
+	if got.Overshoot > 1e-9 {
+		t.Errorf("overshoot = %g, want 0", got.Overshoot)
+	}
+}
+
+func TestStepInfoUnderdampedResponseUsesKnownSteadyState(t *testing.T) {
+	wn := 2.0
+	zeta := 0.25
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{0, 1, -wn * wn, -2 * zeta * wn}),
+		mat.NewDense(2, 1, []float64{0, wn * wn}),
+		mat.NewDense(1, 2, []float64{1, 0}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := Step(sys, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := StepInfo(resp, &StepInfoOptions{SteadyStateValue: []float64{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := info.Metrics[0]
+
+	wantOvershoot := 100 * math.Exp(-zeta*math.Pi/math.Sqrt(1-zeta*zeta))
+	if math.Abs(got.Overshoot-wantOvershoot) > 1.0 {
+		t.Errorf("overshoot = %g, want near %g", got.Overshoot, wantOvershoot)
+	}
+	wantPeakTime := math.Pi / (wn * math.Sqrt(1-zeta*zeta))
+	if math.Abs(got.PeakTime-wantPeakTime) > 0.08 {
+		t.Errorf("peak time = %g, want near %g", got.PeakTime, wantPeakTime)
+	}
+	if got.Peak <= got.SteadyStateValue {
+		t.Errorf("peak = %g, want above steady-state %g", got.Peak, got.SteadyStateValue)
+	}
+}
+
+func TestStepInfoUnsettledResponseWithKnownSteadyState(t *testing.T) {
+	resp := &TimeResponse{
+		T: []float64{0, 1, 2, 3},
+		Y: mat.NewDense(1, 4, []float64{0, 0.8, 1.4, 1.2}),
+	}
+
+	info, err := StepInfo(resp, &StepInfoOptions{SteadyStateValue: []float64{1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := info.Metrics[0]
+	if got.Settled {
+		t.Fatal("response reported settled, want unsettled")
+	}
+	if !math.IsNaN(got.SettlingTime) {
+		t.Errorf("settling time = %g, want NaN", got.SettlingTime)
+	}
+}
+
+func TestStepInfoDiscreteNonzeroFinalValue(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(1, 1, []float64{0.5}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{2}),
+		1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := Step(sys, 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := StepInfo(resp, &StepInfoOptions{SteadyStateValue: []float64{4}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := info.Metrics[0]
+	if math.Abs(got.SteadyStateValue-4) > 1e-12 {
+		t.Fatalf("steady-state value = %g, want 4", got.SteadyStateValue)
+	}
+	if got.RiseTime <= 0 {
+		t.Errorf("rise time = %g, want positive", got.RiseTime)
+	}
+	if !got.Settled {
+		t.Error("discrete response did not settle")
+	}
+}
+
+func TestStepInfoMIMONonSymmetricRows(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{-2, 1, 0, -3}),
+		mat.NewDense(2, 2, []float64{1, 0, 0, 1}),
+		mat.NewDense(2, 2, []float64{1, 0, 0, 1}),
+		mat.NewDense(2, 2, []float64{0, 0, 0, 0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := Step(sys, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := StepInfo(resp, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(info.Metrics) != 4 {
+		t.Fatalf("got %d metrics, want 4", len(info.Metrics))
+	}
+	for i, metric := range info.Metrics {
+		if math.IsNaN(metric.SettlingTime) {
+			t.Fatalf("metric %d settling time is NaN", i)
+		}
+	}
+}
+
+func TestStepInfoForSystemRejectsUnstableModel(t *testing.T) {
+	sys, err := New(
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = StepInfoForSystem(sys, 3, nil)
+	if err == nil {
+		t.Fatal("expected unstable model error")
+	}
+}

--- a/state_space_utils.go
+++ b/state_space_utils.go
@@ -1,0 +1,215 @@
+package controlsys
+
+import (
+	"fmt"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func NewDescriptor(A, B, C, D, E *mat.Dense, dt float64) (*System, error) {
+	sys, err := New(A, B, C, D, dt)
+	if err != nil {
+		return nil, err
+	}
+	n, _, _ := sys.Dims()
+	policy := descriptorPolicy{E: E}
+	if err := policy.validate(n); err != nil {
+		return nil, err
+	}
+	sys.E = copyDescriptorE(E)
+	return sys, nil
+}
+
+func (sys *System) DescriptorE() *mat.Dense {
+	if sys == nil {
+		return nil
+	}
+	return copyDescriptorE(sys.E)
+}
+
+func (sys *System) ToExplicit() (*System, error) {
+	if sys == nil {
+		return nil, fmt.Errorf("ToExplicit: nil system: %w", ErrDimensionMismatch)
+	}
+	if !sys.IsDescriptor() {
+		cp := sys.Copy()
+		cp.E = nil
+		return cp, nil
+	}
+	n, _, _ := sys.Dims()
+	var lu mat.LU
+	lu.Factorize(sys.E)
+	if luNearSingular(&lu) {
+		return nil, fmt.Errorf("ToExplicit: %w", ErrDescriptorSingular)
+	}
+
+	Aexp := mat.NewDense(n, n, nil)
+	if err := lu.SolveTo(Aexp, false, sys.A); err != nil {
+		return nil, fmt.Errorf("ToExplicit: %w", ErrDescriptorSingular)
+	}
+	var Bexp *mat.Dense
+	if _, m, _ := sys.Dims(); m > 0 {
+		Bexp = mat.NewDense(n, m, nil)
+		if err := lu.SolveTo(Bexp, false, sys.B); err != nil {
+			return nil, fmt.Errorf("ToExplicit: %w", ErrDescriptorSingular)
+		}
+	} else {
+		Bexp = &mat.Dense{}
+	}
+
+	result := sys.Copy()
+	result.A = Aexp
+	result.B = Bexp
+	result.E = nil
+	return result, nil
+}
+
+func (sys *System) EliminateStates(elim []int, method BalredMethod) (*System, error) {
+	return Modred(sys, elim, method)
+}
+
+func (sys *System) StateTransform(T *mat.Dense) (*System, error) {
+	return SS2SS(sys, T)
+}
+
+func (sys *System) FixedInputReduction(fixed map[int]float64, offsetName string) (*System, error) {
+	if sys == nil {
+		return nil, fmt.Errorf("FixedInputReduction: nil system: %w", ErrDimensionMismatch)
+	}
+	if len(fixed) == 0 {
+		return sys.Copy(), nil
+	}
+	if err := newDescriptorPolicy(sys).requireStandard("FixedInputReduction"); err != nil {
+		return nil, err
+	}
+	n, m, p := sys.Dims()
+	keep := make([]int, 0, m-len(fixed))
+	fixedSeen := make([]bool, m)
+	for idx := range fixed {
+		if idx < 0 || idx >= m {
+			return nil, fmt.Errorf("FixedInputReduction: input index %d out of range: %w", idx, ErrDimensionMismatch)
+		}
+		fixedSeen[idx] = true
+	}
+	for j := 0; j < m; j++ {
+		if !fixedSeen[j] {
+			keep = append(keep, j)
+		}
+	}
+
+	mNew := len(keep) + 1
+	B := mat.NewDense(n, mNew, nil)
+	D := mat.NewDense(p, mNew, nil)
+	bRaw := B.RawMatrix()
+	dRaw := D.RawMatrix()
+	srcBRaw := sys.B.RawMatrix()
+	srcDRaw := sys.D.RawMatrix()
+	for outCol, inCol := range keep {
+		for i := 0; i < n; i++ {
+			bRaw.Data[i*bRaw.Stride+outCol] = srcBRaw.Data[i*srcBRaw.Stride+inCol]
+		}
+		for i := 0; i < p; i++ {
+			dRaw.Data[i*dRaw.Stride+outCol] = srcDRaw.Data[i*srcDRaw.Stride+inCol]
+		}
+	}
+	offsetCol := len(keep)
+	for inCol, value := range fixed {
+		for i := 0; i < n; i++ {
+			bRaw.Data[i*bRaw.Stride+offsetCol] += srcBRaw.Data[i*srcBRaw.Stride+inCol] * value
+		}
+		for i := 0; i < p; i++ {
+			dRaw.Data[i*dRaw.Stride+offsetCol] += srcDRaw.Data[i*srcDRaw.Stride+inCol] * value
+		}
+	}
+
+	result, err := newNoCopy(denseCopy(sys.A), B, denseCopy(sys.C), D, sys.Dt)
+	if err != nil {
+		return nil, err
+	}
+	result.E = copyDescriptorE(sys.E)
+	result.Delay = selectInputDelayWithOffset(sys.Delay, keep, p, mNew)
+	result.InputDelay = selectDelaySliceWithOffset(sys.InputDelay, keep)
+	result.OutputDelay = copySliceOrNil(sys.OutputDelay)
+	if sys.LFT != nil {
+		result.LFT = &LFTDelay{
+			Tau: append([]float64(nil), sys.LFT.Tau...),
+			B2:  copyDelayOrNil(sys.LFT.B2),
+			C2:  copyDelayOrNil(sys.LFT.C2),
+			D12: selectLFTD12Columns(sys.LFT.D12, keep),
+			D21: copyDelayOrNil(sys.LFT.D21),
+			D22: copyDelayOrNil(sys.LFT.D22),
+		}
+	}
+	result.InputName = append(selectStringSlice(sys.InputName, keep), offsetName)
+	result.OutputName = copyStringSlice(sys.OutputName)
+	result.StateName = copyStringSlice(sys.StateName)
+	return result, nil
+}
+
+func (sys *System) AugmentInternalDelayOutputs(prefix string) (*System, error) {
+	if sys == nil {
+		return nil, fmt.Errorf("AugmentInternalDelayOutputs: nil system: %w", ErrDimensionMismatch)
+	}
+	if !sys.HasInternalDelay() {
+		return sys.Copy(), nil
+	}
+	n, m, p := sys.Dims()
+	N := len(sys.LFT.Tau)
+	C := mat.NewDense(p+N, n, nil)
+	D := mat.NewDense(p+N, m, nil)
+	setBlock(C, 0, 0, sys.C)
+	setBlock(D, 0, 0, sys.D)
+	setBlock(C, p, 0, sys.LFT.C2)
+	setBlock(D, p, 0, sys.LFT.D21)
+
+	result := sys.Copy()
+	result.C = C
+	result.D = D
+	result.OutputName = append(copyStringSlice(sys.OutputName), autoLabel(prefix, N)...)
+	return result, nil
+}
+
+func selectDelaySlice(values []float64, indices []int) []float64 {
+	if values == nil {
+		return nil
+	}
+	out := make([]float64, len(indices))
+	for i, idx := range indices {
+		out[i] = values[idx]
+	}
+	return out
+}
+
+func selectDelaySliceWithOffset(values []float64, indices []int) []float64 {
+	if values == nil {
+		return nil
+	}
+	return append(selectDelaySlice(values, indices), 0)
+}
+
+func selectInputDelayWithOffset(delay *mat.Dense, inputs []int, p, mNew int) *mat.Dense {
+	if delay == nil {
+		return nil
+	}
+	out := mat.NewDense(p, mNew, nil)
+	for i := 0; i < p; i++ {
+		for j, idx := range inputs {
+			out.Set(i, j, delay.At(i, idx))
+		}
+	}
+	return out
+}
+
+func selectLFTD12Columns(D12 *mat.Dense, inputs []int) *mat.Dense {
+	if D12 == nil {
+		return nil
+	}
+	r, _ := D12.Dims()
+	out := mat.NewDense(r, len(inputs)+1, nil)
+	for i := 0; i < r; i++ {
+		for j, idx := range inputs {
+			out.Set(i, j, D12.At(i, idx))
+		}
+	}
+	return out
+}

--- a/state_space_utils_test.go
+++ b/state_space_utils_test.go
@@ -1,0 +1,182 @@
+package controlsys
+
+import (
+	"errors"
+	"math/cmplx"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestDescriptorConstructionAccessAndExplicitConversion(t *testing.T) {
+	A := mat.NewDense(2, 2, []float64{-2, 1, -3, -4})
+	B := mat.NewDense(2, 1, []float64{2, -4})
+	C := mat.NewDense(1, 2, []float64{1, -1})
+	D := mat.NewDense(1, 1, []float64{0.5})
+	E := mat.NewDense(2, 2, []float64{2, 0, 0, 4})
+
+	desc, err := NewDescriptor(A, B, C, D, E, 0)
+	if err != nil {
+		t.Fatalf("NewDescriptor: %v", err)
+	}
+	if !desc.IsDescriptor() {
+		t.Fatal("expected descriptor model")
+	}
+	gotE := desc.DescriptorE()
+	gotE.Set(0, 0, 99)
+	if desc.E.At(0, 0) == 99 {
+		t.Fatal("DescriptorE returned aliased matrix")
+	}
+
+	explicit, err := desc.ToExplicit()
+	if err != nil {
+		t.Fatalf("ToExplicit: %v", err)
+	}
+	wantA := mat.NewDense(2, 2, []float64{-1, 0.5, -0.75, -1})
+	wantB := mat.NewDense(2, 1, []float64{1, -1})
+	if explicit.IsDescriptor() {
+		t.Fatal("explicit model still reports descriptor")
+	}
+	if !matEqual(explicit.A, wantA, 1e-12) || !matEqual(explicit.B, wantB, 1e-12) {
+		t.Fatalf("explicit matrices mismatch\nA=%v\nB=%v", mat.Formatted(explicit.A), mat.Formatted(explicit.B))
+	}
+
+	singular, err := NewDescriptor(A, B, C, D, mat.NewDense(2, 2, []float64{1, 0, 0, 0}), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := singular.ToExplicit(); !errors.Is(err, ErrDescriptorSingular) {
+		t.Fatalf("singular ToExplicit err = %v, want ErrDescriptorSingular", err)
+	}
+}
+
+func TestStateSpaceUtilityWrappersPreserveBehaviorAndMetadata(t *testing.T) {
+	sys := utilityTestSystem(t)
+	sys.InputName = []string{"left", "right"}
+	sys.OutputName = []string{"position"}
+	sys.StateName = []string{"fast", "slow"}
+
+	truncated, err := sys.EliminateStates([]int{1}, Truncate)
+	if err != nil {
+		t.Fatalf("EliminateStates: %v", err)
+	}
+	if n, _, _ := truncated.Dims(); n != 1 {
+		t.Fatalf("truncated order = %d, want 1", n)
+	}
+	if !sameStrings(truncated.InputName, sys.InputName) || !sameStrings(truncated.OutputName, sys.OutputName) {
+		t.Fatalf("metadata lost input=%v output=%v", truncated.InputName, truncated.OutputName)
+	}
+
+	T := mat.NewDense(2, 2, []float64{1, 2, 0, 1})
+	equivalent, err := sys.StateTransform(T)
+	if err != nil {
+		t.Fatalf("StateTransform: %v", err)
+	}
+	omega := []float64{0.1, 1.0, 3.0}
+	baseResp, err := sys.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	equivResp, err := equivalent.FreqResponse(omega)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k := range omega {
+		for i := 0; i < baseResp.P; i++ {
+			for j := 0; j < baseResp.M; j++ {
+				if cmplx.Abs(baseResp.At(k, i, j)-equivResp.At(k, i, j)) > 1e-10 {
+					t.Fatalf("transformed response mismatch at (%d,%d,%d)", k, i, j)
+				}
+			}
+		}
+	}
+}
+
+func TestFixedInputReductionAddsOffsetChannel(t *testing.T) {
+	sys := utilityTestSystem(t)
+	sys.InputName = []string{"free", "bias"}
+	sys.OutputName = []string{"y"}
+
+	reduced, err := sys.FixedInputReduction(map[int]float64{1: 2.5}, "bias_offset")
+	if err != nil {
+		t.Fatalf("FixedInputReduction: %v", err)
+	}
+	if _, m, p := reduced.Dims(); m != 2 || p != 1 {
+		t.Fatalf("reduced dims = (_, %d, %d), want (_, 2, 1)", m, p)
+	}
+	if !sameStrings(reduced.InputName, []string{"free", "bias_offset"}) {
+		t.Fatalf("input names = %v", reduced.InputName)
+	}
+
+	uOriginal := mat.NewDense(4, 2, []float64{
+		1, 2.5,
+		0.5, 2.5,
+		-0.25, 2.5,
+		0, 2.5,
+	})
+	uReduced := mat.NewDense(4, 2, []float64{
+		1, 1,
+		0.5, 1,
+		-0.25, 1,
+		0, 1,
+	})
+	tGrid := []float64{0, 0.1, 0.2, 0.3}
+	origResp, err := Lsim(sys, uOriginal, tGrid, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redResp, err := Lsim(reduced, uReduced, tGrid, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matEqual(origResp.Y, redResp.Y, 1e-12) {
+		t.Fatalf("fixed-input response mismatch\norig=%v\nred=%v", mat.Formatted(origResp.Y), mat.Formatted(redResp.Y))
+	}
+}
+
+func TestAugmentInternalDelayOutputs(t *testing.T) {
+	sys := utilityTestSystem(t)
+	sys.OutputName = []string{"plant_y"}
+	if err := sys.SetInternalDelay(
+		[]float64{0.2},
+		mat.NewDense(2, 1, []float64{0.5, -0.25}),
+		mat.NewDense(1, 2, []float64{0.3, -0.4}),
+		mat.NewDense(1, 1, []float64{0.1}),
+		mat.NewDense(1, 2, []float64{0.2, 0.1}),
+		mat.NewDense(1, 1, []float64{0}),
+	); err != nil {
+		t.Fatalf("SetInternalDelay: %v", err)
+	}
+
+	aug, err := sys.AugmentInternalDelayOutputs("delay")
+	if err != nil {
+		t.Fatalf("AugmentInternalDelayOutputs: %v", err)
+	}
+	if _, _, p := aug.Dims(); p != 2 {
+		t.Fatalf("outputs = %d, want 2", p)
+	}
+	if !sameStrings(aug.OutputName, []string{"plant_y", "delay1"}) {
+		t.Fatalf("output names = %v", aug.OutputName)
+	}
+	if !aug.HasInternalDelay() || aug.LFT.Tau[0] != 0.2 {
+		t.Fatalf("internal delay not preserved: %v", aug.LFT)
+	}
+	if aug.LFT.C2.At(0, 0) != 0.3 || aug.LFT.D21.At(0, 1) != 0.1 {
+		t.Fatal("internal-delay output matrices not preserved")
+	}
+}
+
+func utilityTestSystem(t *testing.T) *System {
+	t.Helper()
+	sys, err := New(
+		mat.NewDense(2, 2, []float64{-1, 0.5, -2, -3}),
+		mat.NewDense(2, 2, []float64{1, -1, 0.5, 2}),
+		mat.NewDense(1, 2, []float64{2, -0.5}),
+		mat.NewDense(1, 2, []float64{0.25, -0.75}),
+		0,
+	)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return sys
+}

--- a/tunable.go
+++ b/tunable.go
@@ -1,0 +1,447 @@
+package controlsys
+
+import (
+	"fmt"
+	"math/rand"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+type TunableBounds struct {
+	Lower float64
+	Upper float64
+}
+
+type TunableReal struct {
+	name   string
+	value  float64
+	bounds TunableBounds
+	fixed  bool
+}
+
+func NewTunableReal(name string, value float64, bounds TunableBounds) (*TunableReal, error) {
+	if name == "" {
+		return nil, fmt.Errorf("NewTunableReal: name is empty: %w", ErrDimensionMismatch)
+	}
+	if bounds.Lower != 0 || bounds.Upper != 0 {
+		if bounds.Lower > bounds.Upper {
+			return nil, fmt.Errorf("NewTunableReal: lower bound %g > upper bound %g: %w", bounds.Lower, bounds.Upper, ErrDimensionMismatch)
+		}
+		if value < bounds.Lower || value > bounds.Upper {
+			return nil, fmt.Errorf("NewTunableReal: value %g outside [%g,%g]: %w", value, bounds.Lower, bounds.Upper, ErrDimensionMismatch)
+		}
+	}
+	return &TunableReal{name: name, value: value, bounds: bounds}, nil
+}
+
+func (p *TunableReal) Name() string {
+	if p == nil {
+		return ""
+	}
+	return p.name
+}
+
+func (p *TunableReal) Value() float64 {
+	if p == nil {
+		return 0
+	}
+	return p.value
+}
+
+func (p *TunableReal) Bounds() TunableBounds {
+	if p == nil {
+		return TunableBounds{}
+	}
+	return p.bounds
+}
+
+func (p *TunableReal) Fixed() bool {
+	return p != nil && p.fixed
+}
+
+func (p *TunableReal) SetFixed(fixed bool) {
+	if p != nil {
+		p.fixed = fixed
+	}
+}
+
+func (p *TunableReal) SetValue(value float64) error {
+	if p == nil {
+		return fmt.Errorf("TunableReal.SetValue: nil parameter: %w", ErrDimensionMismatch)
+	}
+	if err := p.validateValue(value); err != nil {
+		return err
+	}
+	p.value = value
+	return nil
+}
+
+func (p *TunableReal) Sample(values map[string]float64) (*TunableReal, error) {
+	cp := p.copy()
+	if cp == nil {
+		return nil, fmt.Errorf("TunableReal.Sample: nil parameter: %w", ErrDimensionMismatch)
+	}
+	if cp.fixed {
+		return cp, nil
+	}
+	value, ok := values[cp.name]
+	if !ok {
+		return cp, nil
+	}
+	if err := cp.SetValue(value); err != nil {
+		return nil, err
+	}
+	return cp, nil
+}
+
+func (p *TunableReal) RandomSample(rng *rand.Rand) (*TunableReal, error) {
+	cp := p.copy()
+	if cp == nil {
+		return nil, fmt.Errorf("TunableReal.RandomSample: nil parameter: %w", ErrDimensionMismatch)
+	}
+	if cp.fixed || (cp.bounds.Lower == 0 && cp.bounds.Upper == 0) {
+		return cp, nil
+	}
+	if rng == nil {
+		rng = rand.New(rand.NewSource(1))
+	}
+	cp.value = cp.bounds.Lower + rng.Float64()*(cp.bounds.Upper-cp.bounds.Lower)
+	return cp, nil
+}
+
+func (p *TunableReal) validateValue(value float64) error {
+	if p.bounds.Lower == 0 && p.bounds.Upper == 0 {
+		return nil
+	}
+	if value < p.bounds.Lower || value > p.bounds.Upper {
+		return fmt.Errorf("TunableReal.SetValue: value %g outside [%g,%g]: %w", value, p.bounds.Lower, p.bounds.Upper, ErrDimensionMismatch)
+	}
+	return nil
+}
+
+func (p *TunableReal) copy() *TunableReal {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	return &cp
+}
+
+type TunableGain struct {
+	name string
+	dt   float64
+	D    [][]*TunableReal
+}
+
+func NewTunableGain(name string, D [][]*TunableReal, dt float64) *TunableGain {
+	return &TunableGain{name: name, D: copyTunableMatrix(D), dt: dt}
+}
+
+func (b *TunableGain) CurrentSystem() (*System, error) {
+	D, err := tunableMatrixValues(b.D, "TunableGain")
+	if err != nil {
+		return nil, err
+	}
+	return NewGain(D, b.dt)
+}
+
+func (b *TunableGain) Sample(values map[string]float64) (*TunableGain, error) {
+	D, err := sampleTunableMatrix(b.D, values)
+	if err != nil {
+		return nil, err
+	}
+	return &TunableGain{name: b.name, D: D, dt: b.dt}, nil
+}
+
+func (b *TunableGain) RandomSample(rng *rand.Rand) (*TunableGain, error) {
+	D, err := randomSampleTunableMatrix(b.D, rng)
+	if err != nil {
+		return nil, err
+	}
+	return &TunableGain{name: b.name, D: D, dt: b.dt}, nil
+}
+
+type TunablePID struct {
+	name       string
+	Kp, Ki, Kd *TunableReal
+	Tf         float64
+	Dt         float64
+}
+
+func NewTunablePID(name string, kp, ki, kd *TunableReal, tf, dt float64) *TunablePID {
+	return &TunablePID{name: name, Kp: kp.copy(), Ki: ki.copy(), Kd: kd.copy(), Tf: tf, Dt: dt}
+}
+
+func (b *TunablePID) CurrentSystem() (*System, error) {
+	pid := NewPID(b.Kp.Value(), b.Ki.Value(), b.Kd.Value(), WithFilter(b.Tf), WithTs(b.Dt))
+	return pid.System()
+}
+
+func (b *TunablePID) Sample(values map[string]float64) (*TunablePID, error) {
+	kp, err := b.Kp.Sample(values)
+	if err != nil {
+		return nil, err
+	}
+	ki, err := b.Ki.Sample(values)
+	if err != nil {
+		return nil, err
+	}
+	kd, err := b.Kd.Sample(values)
+	if err != nil {
+		return nil, err
+	}
+	return &TunablePID{name: b.name, Kp: kp, Ki: ki, Kd: kd, Tf: b.Tf, Dt: b.Dt}, nil
+}
+
+func (b *TunablePID) RandomSample(rng *rand.Rand) (*TunablePID, error) {
+	kp, err := b.Kp.RandomSample(rng)
+	if err != nil {
+		return nil, err
+	}
+	ki, err := b.Ki.RandomSample(rng)
+	if err != nil {
+		return nil, err
+	}
+	kd, err := b.Kd.RandomSample(rng)
+	if err != nil {
+		return nil, err
+	}
+	return &TunablePID{name: b.name, Kp: kp, Ki: ki, Kd: kd, Tf: b.Tf, Dt: b.Dt}, nil
+}
+
+type TunableTF struct {
+	name string
+	Num  [][][]*TunableReal
+	Den  [][]float64
+	Dt   float64
+}
+
+func NewTunableTF(name string, num [][][]*TunableReal, den [][]float64, dt float64) *TunableTF {
+	return &TunableTF{name: name, Num: copyTunableTensor(num), Den: copyFloatRows(den), Dt: dt}
+}
+
+func (b *TunableTF) CurrentSystem() (*System, error) {
+	p := len(b.Num)
+	num := make([][][]float64, p)
+	for i := range b.Num {
+		num[i] = make([][]float64, len(b.Num[i]))
+		for j := range b.Num[i] {
+			num[i][j] = make([]float64, len(b.Num[i][j]))
+			for k, param := range b.Num[i][j] {
+				if param == nil {
+					return nil, fmt.Errorf("TunableTF: nil numerator parameter: %w", ErrDimensionMismatch)
+				}
+				num[i][j][k] = param.Value()
+			}
+		}
+	}
+	tf := &TransferFunc{Num: num, Den: copyFloatRows(b.Den), Dt: b.Dt}
+	result, err := tf.StateSpace(nil)
+	if err != nil {
+		return nil, err
+	}
+	return result.Sys, nil
+}
+
+func (b *TunableTF) Sample(values map[string]float64) (*TunableTF, error) {
+	num, err := sampleTunableTensor(b.Num, values)
+	if err != nil {
+		return nil, err
+	}
+	return &TunableTF{name: b.name, Num: num, Den: copyFloatRows(b.Den), Dt: b.Dt}, nil
+}
+
+func (b *TunableTF) RandomSample(rng *rand.Rand) (*TunableTF, error) {
+	num, err := randomSampleTunableTensor(b.Num, rng)
+	if err != nil {
+		return nil, err
+	}
+	return &TunableTF{name: b.name, Num: num, Den: copyFloatRows(b.Den), Dt: b.Dt}, nil
+}
+
+type TunableSS struct {
+	name       string
+	A, B, C, D [][]*TunableReal
+	Dt         float64
+}
+
+func NewTunableSS(name string, A, B, C, D [][]*TunableReal, dt float64) *TunableSS {
+	return &TunableSS{
+		name: name,
+		A:    copyTunableMatrix(A),
+		B:    copyTunableMatrix(B),
+		C:    copyTunableMatrix(C),
+		D:    copyTunableMatrix(D),
+		Dt:   dt,
+	}
+}
+
+func (b *TunableSS) CurrentSystem() (*System, error) {
+	A, err := tunableMatrixValues(b.A, "TunableSS.A")
+	if err != nil {
+		return nil, err
+	}
+	B, err := tunableMatrixValues(b.B, "TunableSS.B")
+	if err != nil {
+		return nil, err
+	}
+	C, err := tunableMatrixValues(b.C, "TunableSS.C")
+	if err != nil {
+		return nil, err
+	}
+	D, err := tunableMatrixValues(b.D, "TunableSS.D")
+	if err != nil {
+		return nil, err
+	}
+	return New(A, B, C, D, b.Dt)
+}
+
+func (b *TunableSS) Sample(values map[string]float64) (*TunableSS, error) {
+	A, err := sampleTunableMatrix(b.A, values)
+	if err != nil {
+		return nil, err
+	}
+	B, err := sampleTunableMatrix(b.B, values)
+	if err != nil {
+		return nil, err
+	}
+	C, err := sampleTunableMatrix(b.C, values)
+	if err != nil {
+		return nil, err
+	}
+	D, err := sampleTunableMatrix(b.D, values)
+	if err != nil {
+		return nil, err
+	}
+	return &TunableSS{name: b.name, A: A, B: B, C: C, D: D, Dt: b.Dt}, nil
+}
+
+func (b *TunableSS) RandomSample(rng *rand.Rand) (*TunableSS, error) {
+	A, err := randomSampleTunableMatrix(b.A, rng)
+	if err != nil {
+		return nil, err
+	}
+	B, err := randomSampleTunableMatrix(b.B, rng)
+	if err != nil {
+		return nil, err
+	}
+	C, err := randomSampleTunableMatrix(b.C, rng)
+	if err != nil {
+		return nil, err
+	}
+	D, err := randomSampleTunableMatrix(b.D, rng)
+	if err != nil {
+		return nil, err
+	}
+	return &TunableSS{name: b.name, A: A, B: B, C: C, D: D, Dt: b.Dt}, nil
+}
+
+func tunableMatrixValues(params [][]*TunableReal, context string) (*mat.Dense, error) {
+	if len(params) == 0 {
+		return &mat.Dense{}, nil
+	}
+	cols := len(params[0])
+	data := make([]float64, 0, len(params)*cols)
+	for i, row := range params {
+		if len(row) != cols {
+			return nil, fmt.Errorf("%s: ragged row %d: %w", context, i, ErrDimensionMismatch)
+		}
+		for _, param := range row {
+			if param == nil {
+				return nil, fmt.Errorf("%s: nil parameter: %w", context, ErrDimensionMismatch)
+			}
+			data = append(data, param.Value())
+		}
+	}
+	return mat.NewDense(len(params), cols, data), nil
+}
+
+func copyTunableMatrix(params [][]*TunableReal) [][]*TunableReal {
+	if params == nil {
+		return nil
+	}
+	out := make([][]*TunableReal, len(params))
+	for i := range params {
+		out[i] = make([]*TunableReal, len(params[i]))
+		for j := range params[i] {
+			out[i][j] = params[i][j].copy()
+		}
+	}
+	return out
+}
+
+func sampleTunableMatrix(params [][]*TunableReal, values map[string]float64) ([][]*TunableReal, error) {
+	out := make([][]*TunableReal, len(params))
+	for i := range params {
+		out[i] = make([]*TunableReal, len(params[i]))
+		for j, param := range params[i] {
+			sampled, err := param.Sample(values)
+			if err != nil {
+				return nil, err
+			}
+			out[i][j] = sampled
+		}
+	}
+	return out, nil
+}
+
+func randomSampleTunableMatrix(params [][]*TunableReal, rng *rand.Rand) ([][]*TunableReal, error) {
+	out := make([][]*TunableReal, len(params))
+	for i := range params {
+		out[i] = make([]*TunableReal, len(params[i]))
+		for j, param := range params[i] {
+			sampled, err := param.RandomSample(rng)
+			if err != nil {
+				return nil, err
+			}
+			out[i][j] = sampled
+		}
+	}
+	return out, nil
+}
+
+func copyTunableTensor(params [][][]*TunableReal) [][][]*TunableReal {
+	if params == nil {
+		return nil
+	}
+	out := make([][][]*TunableReal, len(params))
+	for i := range params {
+		out[i] = copyTunableMatrix(params[i])
+	}
+	return out
+}
+
+func sampleTunableTensor(params [][][]*TunableReal, values map[string]float64) ([][][]*TunableReal, error) {
+	out := make([][][]*TunableReal, len(params))
+	for i := range params {
+		sampled, err := sampleTunableMatrix(params[i], values)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = sampled
+	}
+	return out, nil
+}
+
+func randomSampleTunableTensor(params [][][]*TunableReal, rng *rand.Rand) ([][][]*TunableReal, error) {
+	out := make([][][]*TunableReal, len(params))
+	for i := range params {
+		sampled, err := randomSampleTunableMatrix(params[i], rng)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = sampled
+	}
+	return out, nil
+}
+
+func copyFloatRows(rows [][]float64) [][]float64 {
+	if rows == nil {
+		return nil
+	}
+	out := make([][]float64, len(rows))
+	for i := range rows {
+		out[i] = copyFloatSlice(rows[i])
+	}
+	return out
+}

--- a/tunable_test.go
+++ b/tunable_test.go
@@ -1,0 +1,146 @@
+package controlsys
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"testing"
+
+	"gonum.org/v1/gonum/mat"
+)
+
+func TestTunableRealSetSampleAndFixedBehavior(t *testing.T) {
+	k, err := NewTunableReal("K", 2, TunableBounds{Lower: 1, Upper: 4})
+	if err != nil {
+		t.Fatalf("NewTunableReal: %v", err)
+	}
+	if k.Name() != "K" || k.Value() != 2 || k.Bounds().Lower != 1 || k.Bounds().Upper != 4 {
+		t.Fatalf("unexpected parameter state: %#v", k)
+	}
+	if err := k.SetValue(5); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("SetValue outside bounds err = %v, want ErrDimensionMismatch", err)
+	}
+	if err := k.SetValue(3); err != nil {
+		t.Fatalf("SetValue: %v", err)
+	}
+	sample := map[string]float64{"K": 1.5}
+	sampled, err := k.Sample(sample)
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	if sampled.Value() != 1.5 || k.Value() != 3 {
+		t.Fatalf("sampled/current values = %g/%g, want 1.5/3", sampled.Value(), k.Value())
+	}
+	k.SetFixed(true)
+	randomized, err := k.RandomSample(rand.New(rand.NewSource(1)))
+	if err != nil {
+		t.Fatalf("RandomSample fixed: %v", err)
+	}
+	if randomized.Value() != k.Value() {
+		t.Fatalf("fixed random value = %g, want %g", randomized.Value(), k.Value())
+	}
+}
+
+func TestTunableRealRejectsInvalidBounds(t *testing.T) {
+	if _, err := NewTunableReal("bad", 0, TunableBounds{Lower: 2, Upper: 1}); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("invalid bounds err = %v, want ErrDimensionMismatch", err)
+	}
+	if _, err := NewTunableReal("", 0, TunableBounds{}); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("empty name err = %v, want ErrDimensionMismatch", err)
+	}
+}
+
+func TestTunableGainPIDTFAndSSCurrentValues(t *testing.T) {
+	k, _ := NewTunableReal("K", 2, TunableBounds{Lower: 0, Upper: 10})
+	gain := NewTunableGain("gain", [][]*TunableReal{{k}}, 0)
+	gainSys, err := gain.CurrentSystem()
+	if err != nil {
+		t.Fatalf("gain CurrentSystem: %v", err)
+	}
+	if gainSys.D.At(0, 0) != 2 {
+		t.Fatalf("gain D = %g, want 2", gainSys.D.At(0, 0))
+	}
+
+	kp, _ := NewTunableReal("Kp", 1.2, TunableBounds{Lower: 0, Upper: 5})
+	ki, _ := NewTunableReal("Ki", 0.3, TunableBounds{Lower: 0, Upper: 5})
+	kd, _ := NewTunableReal("Kd", 0.4, TunableBounds{Lower: 0, Upper: 5})
+	pid := NewTunablePID("pid", kp, ki, kd, 0.1, 0)
+	pidSys, err := pid.CurrentSystem()
+	if err != nil {
+		t.Fatalf("pid CurrentSystem: %v", err)
+	}
+	if _, m, p := pidSys.Dims(); m != 1 || p != 1 {
+		t.Fatalf("PID dims = (_, %d, %d), want (_, 1, 1)", m, p)
+	}
+
+	numGain, _ := NewTunableReal("num", 3, TunableBounds{Lower: 1, Upper: 5})
+	tf := NewTunableTF("tf", [][][]*TunableReal{{{numGain}}}, [][]float64{{1, 2}}, 0)
+	tfSys, err := tf.CurrentSystem()
+	if err != nil {
+		t.Fatalf("tf CurrentSystem: %v", err)
+	}
+	resp, err := tfSys.EvalFr(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := real(resp[0][0]), 1.5; math.Abs(got-want) > 1e-12 {
+		t.Fatalf("tf dc = %g, want %g", got, want)
+	}
+
+	a11, _ := NewTunableReal("a11", -1, TunableBounds{Lower: -5, Upper: -0.1})
+	ss := NewTunableSS(
+		"ss",
+		[][]*TunableReal{{a11, fixedReal(t, "a12", 0.5)}, {fixedReal(t, "a21", -2), fixedReal(t, "a22", -3)}},
+		[][]*TunableReal{{fixedReal(t, "b11", 1)}, {fixedReal(t, "b21", -1)}},
+		[][]*TunableReal{{fixedReal(t, "c11", 2), fixedReal(t, "c12", -0.5)}},
+		[][]*TunableReal{{fixedReal(t, "d11", 0.25)}},
+		0,
+	)
+	ssSys, err := ss.CurrentSystem()
+	if err != nil {
+		t.Fatalf("ss CurrentSystem: %v", err)
+	}
+	if ssSys.A.At(0, 1) != 0.5 || ssSys.A.At(1, 0) != -2 {
+		t.Fatalf("non-symmetric A not preserved: %v", mat.Formatted(ssSys.A))
+	}
+}
+
+func TestTunableBlockDeterministicAndRandomSampling(t *testing.T) {
+	k, _ := NewTunableReal("K", 2, TunableBounds{Lower: 1, Upper: 4})
+	block := NewTunableGain("gain", [][]*TunableReal{{k}}, 0)
+
+	sampled, err := block.Sample(map[string]float64{"K": 3.5})
+	if err != nil {
+		t.Fatalf("Sample: %v", err)
+	}
+	sys, err := sampled.CurrentSystem()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sys.D.At(0, 0) != 3.5 || k.Value() != 2 {
+		t.Fatalf("sampled/current gain = %g/%g, want 3.5/2", sys.D.At(0, 0), k.Value())
+	}
+
+	randomized, err := block.RandomSample(rand.New(rand.NewSource(4)))
+	if err != nil {
+		t.Fatalf("RandomSample: %v", err)
+	}
+	randSys, err := randomized.CurrentSystem()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := randSys.D.At(0, 0)
+	if got < 1 || got > 4 {
+		t.Fatalf("random gain = %g outside [1,4]", got)
+	}
+}
+
+func fixedReal(t *testing.T, name string, value float64) *TunableReal {
+	t.Helper()
+	p, err := NewTunableReal(name, value, TunableBounds{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.SetFixed(true)
+	return p
+}

--- a/tuning.go
+++ b/tuning.go
@@ -1,0 +1,166 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+)
+
+type SystuneOptions struct {
+	GridPoints int
+}
+
+type SystuneResult struct {
+	Pass       bool
+	Score      float64
+	Iterations int
+	Parameters map[string]float64
+	Controller *System
+	ClosedLoop *System
+	Goals      []TuningGoalResult
+}
+
+func Systune(model *GeneralizedClosedLoop, goals []TuningGoal, opts *SystuneOptions) (*SystuneResult, error) {
+	return tuneFixedStructure(model, goals, opts)
+}
+
+func Looptune(model *GeneralizedClosedLoop, goals []TuningGoal, opts *SystuneOptions) (*SystuneResult, error) {
+	return tuneFixedStructure(model, goals, opts)
+}
+
+func tuneFixedStructure(model *GeneralizedClosedLoop, goals []TuningGoal, opts *SystuneOptions) (*SystuneResult, error) {
+	if model == nil {
+		return nil, fmt.Errorf("Systune: nil model: %w", ErrDimensionMismatch)
+	}
+	gain, ok := model.controllerRaw.(*TunableGain)
+	if !ok {
+		return nil, fmt.Errorf("Systune: only TunableGain controllers are supported by this tracer: %w", ErrDimensionMismatch)
+	}
+	if len(goals) == 0 {
+		return nil, fmt.Errorf("Systune: no goals: %w", ErrDimensionMismatch)
+	}
+	gridPoints := 5
+	if opts != nil && opts.GridPoints > 0 {
+		gridPoints = opts.GridPoints
+	}
+	params := uniqueFreeTunableReals(gain.D)
+	if len(params) == 0 {
+		return nil, fmt.Errorf("Systune: no free tunable parameters: %w", ErrDimensionMismatch)
+	}
+
+	best := &SystuneResult{Score: math.Inf(1)}
+	iterations := 0
+	values := make(map[string]float64, len(params))
+	var search func(int) error
+	search = func(idx int) error {
+		if idx == len(params) {
+			iterations++
+			sampled, err := gain.Sample(values)
+			if err != nil {
+				return err
+			}
+			candidate := *model
+			candidate.controller = sampled
+			candidate.controllerRaw = sampled
+			closed, err := candidate.ClosedLoop(firstAnalysisPointName(candidate.analysisPoints))
+			if err != nil {
+				return err
+			}
+			goalResults, score, pass, err := evaluateTuningGoals(closed, goals)
+			if err != nil {
+				return err
+			}
+			if score < best.Score {
+				ctrl, err := sampled.CurrentSystem()
+				if err != nil {
+					return err
+				}
+				best = &SystuneResult{
+					Pass:       pass,
+					Score:      score,
+					Parameters: copyStringFloatMap(values),
+					Controller: ctrl,
+					ClosedLoop: closed,
+					Goals:      goalResults,
+				}
+			}
+			return nil
+		}
+		param := params[idx]
+		candidates := parameterGrid(param, gridPoints)
+		for _, value := range candidates {
+			values[param.Name()] = value
+			if err := search(idx + 1); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := search(0); err != nil {
+		return nil, err
+	}
+	best.Iterations = iterations
+	return best, nil
+}
+
+func evaluateTuningGoals(sys *System, goals []TuningGoal) ([]TuningGoalResult, float64, bool, error) {
+	results := make([]TuningGoalResult, len(goals))
+	score := 0.0
+	pass := true
+	for i, goal := range goals {
+		result, err := goal.Evaluate(sys)
+		if err != nil {
+			return nil, 0, false, err
+		}
+		results[i] = result
+		if !result.Pass {
+			pass = false
+		}
+		score += goalViolation(result)
+	}
+	return results, score, pass, nil
+}
+
+func goalViolation(result TuningGoalResult) float64 {
+	if result.Pass {
+		return 0
+	}
+	if result.Limit == 0 {
+		return math.Abs(result.Value)
+	}
+	return math.Abs((result.Value - result.Limit) / result.Limit)
+}
+
+func uniqueFreeTunableReals(params [][]*TunableReal) []*TunableReal {
+	seen := make(map[string]bool)
+	var out []*TunableReal
+	for _, row := range params {
+		for _, param := range row {
+			if param == nil || param.Fixed() || seen[param.Name()] {
+				continue
+			}
+			seen[param.Name()] = true
+			out = append(out, param)
+		}
+	}
+	return out
+}
+
+func parameterGrid(param *TunableReal, points int) []float64 {
+	bounds := param.Bounds()
+	if points < 2 || (bounds.Lower == 0 && bounds.Upper == 0) {
+		return []float64{param.Value()}
+	}
+	out := make([]float64, points)
+	for i := range out {
+		out[i] = bounds.Lower + float64(i)*(bounds.Upper-bounds.Lower)/float64(points-1)
+	}
+	return out
+}
+
+func copyStringFloatMap(src map[string]float64) map[string]float64 {
+	out := make(map[string]float64, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}

--- a/tuning_goal.go
+++ b/tuning_goal.go
@@ -1,0 +1,248 @@
+package controlsys
+
+import (
+	"fmt"
+	"math"
+	"math/cmplx"
+)
+
+type TuningGoalType int
+
+const (
+	TuningGoalTracking TuningGoalType = iota
+	TuningGoalRejection
+	TuningGoalSensitivity
+	TuningGoalWeightedGain
+	TuningGoalLoopShape
+	TuningGoalMargin
+	TuningGoalPole
+	TuningGoalOvershoot
+)
+
+type TuningGoalSpec struct {
+	Name string
+	Type TuningGoalType
+	Max  float64
+	Min  float64
+}
+
+type TuningGoal struct {
+	spec TuningGoalSpec
+}
+
+type TuningGoalResult struct {
+	GoalName    string
+	Pass        bool
+	Value       float64
+	Limit       float64
+	Diagnostics map[string]float64
+}
+
+func NewTuningGoal(spec TuningGoalSpec) (TuningGoal, error) {
+	if spec.Name == "" {
+		return TuningGoal{}, fmt.Errorf("NewTuningGoal: name is empty: %w", ErrDimensionMismatch)
+	}
+	if spec.Max < 0 || spec.Min < 0 {
+		return TuningGoal{}, fmt.Errorf("NewTuningGoal: negative bound: %w", ErrDimensionMismatch)
+	}
+	return TuningGoal{spec: spec}, nil
+}
+
+func NewTrackingGoal(name string, maxError float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalTracking, Max: maxError})
+}
+
+func NewRejectionGoal(name string, maxGain float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalRejection, Max: maxGain})
+}
+
+func NewSensitivityGoal(name string, maxGain float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalSensitivity, Max: maxGain})
+}
+
+func NewWeightedGainGoal(name string, maxGain float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalWeightedGain, Max: maxGain})
+}
+
+func NewLoopShapeGoal(name string, minGain, maxGain float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalLoopShape, Min: minGain, Max: maxGain})
+}
+
+func NewMarginGoal(name string, minGainMarginDB, minPhaseMarginDeg float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalMargin, Min: minGainMarginDB, Max: minPhaseMarginDeg})
+}
+
+func NewPoleGoal(name string, maxRealPart float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalPole, Max: maxRealPart})
+}
+
+func NewOvershootGoal(name string, maxPercent float64) TuningGoal {
+	return mustTuningGoal(TuningGoalSpec{Name: name, Type: TuningGoalOvershoot, Max: maxPercent})
+}
+
+func mustTuningGoal(spec TuningGoalSpec) TuningGoal {
+	goal, err := NewTuningGoal(spec)
+	if err != nil {
+		panic(err)
+	}
+	return goal
+}
+
+func (g TuningGoal) Name() string {
+	return g.spec.Name
+}
+
+func (g TuningGoal) Evaluate(model any) (TuningGoalResult, error) {
+	sys, err := tuningGoalSystem(model)
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	switch g.spec.Type {
+	case TuningGoalTracking:
+		return g.evaluateTracking(sys)
+	case TuningGoalRejection, TuningGoalSensitivity, TuningGoalWeightedGain:
+		return g.evaluateMaxGain(sys)
+	case TuningGoalLoopShape:
+		return g.evaluateLoopShape(sys)
+	case TuningGoalMargin:
+		return g.evaluateMargin(sys)
+	case TuningGoalPole:
+		return g.evaluatePole(sys)
+	case TuningGoalOvershoot:
+		return g.evaluateOvershoot(sys)
+	default:
+		return TuningGoalResult{}, fmt.Errorf("TuningGoal.Evaluate: unsupported goal type: %w", ErrDimensionMismatch)
+	}
+}
+
+func tuningGoalSystem(model any) (*System, error) {
+	switch v := model.(type) {
+	case *System:
+		return v.Copy(), nil
+	case *GeneralizedModel:
+		return v.CurrentSystem()
+	case *GeneralizedClosedLoop:
+		return v.ClosedLoop(firstAnalysisPointName(v.analysisPoints))
+	default:
+		return nil, fmt.Errorf("TuningGoal.Evaluate: unsupported model %T: %w", model, ErrDimensionMismatch)
+	}
+}
+
+func firstAnalysisPointName(points map[string]AnalysisPoint) string {
+	for name := range points {
+		return name
+	}
+	return ""
+}
+
+func (g TuningGoal) evaluateTracking(sys *System) (TuningGoalResult, error) {
+	dc, err := sys.DCGain()
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	errVal := maxDCErrorFromOne(dc)
+	return g.scalarResult(errVal, g.spec.Max, errVal <= g.spec.Max, map[string]float64{"dc_error": errVal}), nil
+}
+
+func (g TuningGoal) evaluateMaxGain(sys *System) (TuningGoalResult, error) {
+	value, err := maxFrequencyGain(sys, nil)
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	return g.scalarResult(value, g.spec.Max, value <= g.spec.Max, map[string]float64{"max_gain": value}), nil
+}
+
+func (g TuningGoal) evaluateLoopShape(sys *System) (TuningGoalResult, error) {
+	value, err := maxFrequencyGain(sys, nil)
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	pass := value >= g.spec.Min && value <= g.spec.Max
+	return g.scalarResult(value, g.spec.Max, pass, map[string]float64{"max_gain": value, "min_gain": g.spec.Min}), nil
+}
+
+func (g TuningGoal) evaluateMargin(sys *System) (TuningGoalResult, error) {
+	margin, err := Margin(sys)
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	pass := margin.GainMargin >= g.spec.Min && margin.PhaseMargin >= g.spec.Max
+	diag := map[string]float64{"gain_margin_db": margin.GainMargin, "phase_margin_deg": margin.PhaseMargin}
+	return g.scalarResult(math.Min(margin.GainMargin, margin.PhaseMargin), g.spec.Max, pass, diag), nil
+}
+
+func (g TuningGoal) evaluatePole(sys *System) (TuningGoalResult, error) {
+	poles, err := sys.Poles()
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	maxReal := math.Inf(-1)
+	for _, p := range poles {
+		if real(p) > maxReal {
+			maxReal = real(p)
+		}
+	}
+	if len(poles) == 0 {
+		maxReal = math.Inf(-1)
+	}
+	return g.scalarResult(maxReal, g.spec.Max, maxReal <= g.spec.Max, map[string]float64{"max_real_pole": maxReal}), nil
+}
+
+func (g TuningGoal) evaluateOvershoot(sys *System) (TuningGoalResult, error) {
+	info, err := StepInfoForSystem(sys, 0, nil)
+	if err != nil {
+		return TuningGoalResult{}, err
+	}
+	maxOvershoot := 0.0
+	for _, metric := range info.Metrics {
+		if metric.Overshoot > maxOvershoot {
+			maxOvershoot = metric.Overshoot
+		}
+	}
+	return g.scalarResult(maxOvershoot, g.spec.Max, maxOvershoot <= g.spec.Max, map[string]float64{"overshoot_percent": maxOvershoot}), nil
+}
+
+func (g TuningGoal) scalarResult(value, limit float64, pass bool, diag map[string]float64) TuningGoalResult {
+	return TuningGoalResult{GoalName: g.spec.Name, Pass: pass, Value: value, Limit: limit, Diagnostics: diag}
+}
+
+func maxDCErrorFromOne(dc interface {
+	Dims() (int, int)
+	At(int, int) float64
+}) float64 {
+	r, c := dc.Dims()
+	maxErr := 0.0
+	for i := 0; i < r; i++ {
+		for j := 0; j < c; j++ {
+			want := 0.0
+			if i == j {
+				want = 1
+			}
+			if err := math.Abs(dc.At(i, j) - want); err > maxErr {
+				maxErr = err
+			}
+		}
+	}
+	return maxErr
+}
+
+func maxFrequencyGain(sys *System, omega []float64) (float64, error) {
+	if omega == nil {
+		omega = logspace(-2, 2, 80)
+	}
+	resp, err := sys.FreqResponse(omega)
+	if err != nil {
+		return 0, err
+	}
+	maxGain := 0.0
+	for k := range omega {
+		for i := 0; i < resp.P; i++ {
+			for j := 0; j < resp.M; j++ {
+				if gain := cmplx.Abs(resp.At(k, i, j)); gain > maxGain {
+					maxGain = gain
+				}
+			}
+		}
+	}
+	return maxGain, nil
+}

--- a/tuning_goal_test.go
+++ b/tuning_goal_test.go
@@ -1,0 +1,61 @@
+package controlsys
+
+import "testing"
+
+func TestTuningGoalsEvaluatePassFailFamilies(t *testing.T) {
+	sys := makeSISO(-2, 2, 1, 0)
+	goals := []TuningGoal{
+		NewTrackingGoal("track", 1.2),
+		NewRejectionGoal("reject", 1.2),
+		NewSensitivityGoal("sens", 1.2),
+		NewWeightedGainGoal("gain", 1.2),
+		NewLoopShapeGoal("loop", 0.5, 2.0),
+		NewMarginGoal("margin", 0, 0),
+		NewPoleGoal("poles", 0),
+		NewOvershootGoal("overshoot", 5),
+	}
+	for _, goal := range goals {
+		result, err := goal.Evaluate(sys)
+		if err != nil {
+			t.Fatalf("%s Evaluate: %v", goal.Name(), err)
+		}
+		if result.GoalName != goal.Name() || len(result.Diagnostics) == 0 {
+			t.Fatalf("%s result missing diagnostics: %#v", goal.Name(), result)
+		}
+	}
+}
+
+func TestTuningGoalsKnownFailuresAndGeneralizedCurrentValue(t *testing.T) {
+	sys := makeSISO(-1, 1, 2, 0)
+	failGoal := NewWeightedGainGoal("too_small", 0.5)
+	res, err := failGoal.Evaluate(sys)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if res.Pass {
+		t.Fatalf("expected weighted gain failure, got %#v", res)
+	}
+
+	k, _ := NewTunableReal("K", 0.25, TunableBounds{Lower: 0, Upper: 1})
+	gm, err := NewGeneralizedModel("gain", NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	passGoal := NewWeightedGainGoal("small_gain", 0.5)
+	gres, err := passGoal.Evaluate(gm)
+	if err != nil {
+		t.Fatalf("Evaluate generalized: %v", err)
+	}
+	if !gres.Pass {
+		t.Fatalf("expected generalized gain pass, got %#v", gres)
+	}
+}
+
+func TestTuningGoalValidation(t *testing.T) {
+	if _, err := NewTuningGoal(TuningGoalSpec{Name: "", Type: TuningGoalWeightedGain, Max: 1}); err == nil {
+		t.Fatal("empty goal name should fail")
+	}
+	if _, err := NewTuningGoal(TuningGoalSpec{Name: "bad", Type: TuningGoalWeightedGain, Max: -1}); err == nil {
+		t.Fatal("negative max should fail")
+	}
+}

--- a/tuning_test.go
+++ b/tuning_test.go
@@ -1,0 +1,61 @@
+package controlsys
+
+import "testing"
+
+func TestSystuneTunesSISOTunableGain(t *testing.T) {
+	plant := makeSISO(-2, 1, 1, 0)
+	k, _ := NewTunableReal("K", 0.1, TunableBounds{Lower: 0.1, Upper: 5})
+	controller := NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)
+	closed, err := NewGeneralizedClosedLoop("loop", plant, controller, "u")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Systune(closed, []TuningGoal{NewTrackingGoal("track", 0.4)}, &SystuneOptions{GridPoints: 9})
+	if err != nil {
+		t.Fatalf("Systune: %v", err)
+	}
+	if !result.Pass {
+		t.Fatalf("expected tuned result to pass, got %#v", result)
+	}
+	if result.Parameters["K"] <= 0.1 {
+		t.Fatalf("K was not increased: %#v", result.Parameters)
+	}
+	if len(result.Goals) != 1 || !result.Goals[0].Pass {
+		t.Fatalf("goal diagnostics = %#v", result.Goals)
+	}
+}
+
+func TestSystuneTunesSmallMIMOTunableGain(t *testing.T) {
+	plant := benchSysNonSym(2, 2, 2)
+	k1, _ := NewTunableReal("K1", 0.1, TunableBounds{Lower: 0.1, Upper: 2})
+	k2, _ := NewTunableReal("K2", 0.1, TunableBounds{Lower: 0.1, Upper: 2})
+	controller := NewTunableGain("Kblock", [][]*TunableReal{{k1, fixedReal(t, "z12", 0)}, {fixedReal(t, "z21", 0), k2}}, 0)
+	closed, err := NewGeneralizedClosedLoop("loop", plant, controller, "u")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Looptune(closed, []TuningGoal{NewWeightedGainGoal("bounded", 10)}, &SystuneOptions{GridPoints: 5})
+	if err != nil {
+		t.Fatalf("Looptune: %v", err)
+	}
+	if !result.Pass {
+		t.Fatalf("expected MIMO tuning pass, got %#v", result)
+	}
+	if _, ok := result.Parameters["K1"]; !ok {
+		t.Fatalf("missing K1 in parameters: %#v", result.Parameters)
+	}
+}
+
+func TestSystuneUnsupportedControllerFailsClearly(t *testing.T) {
+	plant := makeSISO(-1, 1, 1, 0)
+	fixed := makeSISO(-2, 1, 1, 0)
+	closed, err := NewGeneralizedClosedLoop("loop", plant, fixed, "u")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Systune(closed, []TuningGoal{NewWeightedGainGoal("gain", 1)}, nil); err == nil {
+		t.Fatal("expected unsupported fixed controller to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- Add tracer APIs for MATLAB Control System Toolbox parity gaps from #136: tunable blocks, generalized models, tuning goals, fixed-structure tuning, state-space utilities, model arrays, physical assembly, passivity/spectral factor analysis, modal reduction, and LPV/LTV/sparse scope documentation.
- Add StepInfo and FRD convenience operations with focused behavior tests.
- Add performance benchmarks for each new tracer path and related existing paths.

## Validation
- go test -v -count=1
- go test -bench=. -benchmem -run '^$' (completed successfully, 316.543s)

Closes #137
Closes #138
Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
Closes #144
Closes #145
Closes #146
Closes #147
Closes #148