### PR TITLE
Address PR 149 review comments

### DIFF
--- a/passivity.go
+++ b/passivity.go
@@ -3,6 +3,9 @@ package controlsys
 import (
 	"fmt"
 	"math"
+	"math/cmplx"
+
+	"gonum.org/v1/gonum/mat"
 )
 
 type PassivityOptions struct {
@@ -114,12 +117,38 @@ func minHermitianPart(h [][]complex128) float64 {
 	if len(h) == 1 && len(h[0]) == 1 {
 		return real(h[0][0])
 	}
-	minDiag := math.Inf(1)
-	for i := range h {
-		v := real(h[i][i])
-		if v < minDiag {
-			minDiag = v
+	n := len(h)
+	if n == 2 {
+		a := real(h[0][0])
+		d := real(h[1][1])
+		off := (h[0][1] + cmplx.Conj(h[1][0])) / 2
+		halfDiff := (a - d) / 2
+		radius := math.Sqrt(halfDiff*halfDiff + real(off)*real(off) + imag(off)*imag(off))
+		return (a+d)/2 - radius
+	}
+	dim := 2 * n
+	sym := mat.NewSymDense(dim, nil)
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			herm := (h[i][j] + cmplx.Conj(h[j][i])) / 2
+			re := real(herm)
+			im := imag(herm)
+			sym.SetSym(i, j, re)
+			sym.SetSym(i, n+j, -im)
+			sym.SetSym(n+i, j, im)
+			sym.SetSym(n+i, n+j, re)
 		}
 	}
-	return minDiag
+	var eig mat.EigenSym
+	if ok := eig.Factorize(sym, false); !ok {
+		return math.Inf(-1)
+	}
+	vals := eig.Values(nil)
+	minPart := vals[0]
+	for _, v := range vals[1:] {
+		if v < minPart {
+			minPart = v
+		}
+	}
+	return minPart
 }

--- a/passivity_test.go
+++ b/passivity_test.go
@@ -39,6 +39,28 @@ func TestPassivityDenseAndFRD(t *testing.T) {
 	}
 }
 
+func TestFRDPassiveUsesMIMOHermitianEigenvalue(t *testing.T) {
+	frd, err := NewFRD([][][]complex128{
+		{
+			{1, 2},
+			{2, 1},
+		},
+	}, []float64{1}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := FRDPassive(frd, nil)
+	if err != nil {
+		t.Fatalf("FRDPassive: %v", err)
+	}
+	if result.Passive {
+		t.Fatalf("expected nonpassive MIMO result, got %#v", result)
+	}
+	if result.MinHermitianPart != -1 {
+		t.Fatalf("min Hermitian part = %g, want -1", result.MinHermitianPart)
+	}
+}
+
 func TestSpectralFactorStaticGainAndUnsupportedCases(t *testing.T) {
 	sys, err := NewGain(mat.NewDense(1, 1, []float64{4}), 0)
 	if err != nil {

--- a/tuning_goal.go
+++ b/tuning_goal.go
@@ -42,7 +42,7 @@ func NewTuningGoal(spec TuningGoalSpec) (TuningGoal, error) {
 	if spec.Name == "" {
 		return TuningGoal{}, fmt.Errorf("NewTuningGoal: name is empty: %w", ErrDimensionMismatch)
 	}
-	if spec.Max < 0 || spec.Min < 0 {
+	if spec.Type != TuningGoalPole && (spec.Max < 0 || spec.Min < 0) {
 		return TuningGoal{}, fmt.Errorf("NewTuningGoal: negative bound: %w", ErrDimensionMismatch)
 	}
 	return TuningGoal{spec: spec}, nil

--- a/tuning_goal_test.go
+++ b/tuning_goal_test.go
@@ -58,4 +58,22 @@ func TestTuningGoalValidation(t *testing.T) {
 	if _, err := NewTuningGoal(TuningGoalSpec{Name: "bad", Type: TuningGoalWeightedGain, Max: -1}); err == nil {
 		t.Fatal("negative max should fail")
 	}
+	if _, err := NewTuningGoal(TuningGoalSpec{Name: "pole_spec", Type: TuningGoalPole, Min: -2, Max: -0.5}); err != nil {
+		t.Fatalf("negative pole bounds should pass: %v", err)
+	}
+	goal := NewPoleGoal("stable_fast", -0.5)
+	pass, err := goal.Evaluate(makeSISO(-1, 1, 1, 0))
+	if err != nil {
+		t.Fatalf("Evaluate stable pole goal: %v", err)
+	}
+	if !pass.Pass {
+		t.Fatalf("expected pole goal pass, got %#v", pass)
+	}
+	fail, err := goal.Evaluate(makeSISO(-0.2, 1, 1, 0))
+	if err != nil {
+		t.Fatalf("Evaluate slow pole goal: %v", err)
+	}
+	if fail.Pass {
+		t.Fatalf("expected pole goal failure, got %#v", fail)
+	}
 }


### PR DESCRIPTION
## Summary
- allow pole tuning goals to use negative real-part bounds
- compute MIMO passivity from the Hermitian-part minimum eigenvalue instead of the minimum diagonal entry
- keep the common 2x2 MIMO passivity path allocation-stable with a closed-form eigenvalue

## Validation
- go test -run 'TestTuningGoal|TestPassivity|TestFRDPassive|TestSpectralFactor' -count=1\n- go test -v -count=1\n- go test -bench='Benchmark.*Passiv|Benchmark.*FRD' -benchmem -run '^$' before/after with benchstat\n\n## Performance gate\nbenchstat before vs after: geomean +0.62% sec/op, -0.01% B/op, -0.04% allocs/op. Existing BenchmarkFRDPassivity_MIMO moved from 3.889µs/op to 4.145µs/op with unchanged 1048 B/op and 2 allocs/op.