### PR TITLE
Deepen generalized tuning seam

### DIFF
--- a/generalized.go
+++ b/generalized.go
@@ -6,6 +6,12 @@ type NumericBlock interface {
 	CurrentSystem() (*System, error)
 }
 
+type TunableBlock interface {
+	NumericBlock
+	FreeParameters() []*TunableReal
+	SampleBlock(map[string]float64) (TunableBlock, error)
+}
+
 type fixedSystemBlock struct {
 	sys *System
 }
@@ -103,11 +109,12 @@ func (g *GeneralizedModel) CurrentSystem() (*System, error) {
 }
 
 type GeneralizedClosedLoop struct {
-	name           string
-	plant          *System
-	controller     NumericBlock
-	controllerRaw  any
-	analysisPoints map[string]AnalysisPoint
+	name                 string
+	plant                *System
+	controller           NumericBlock
+	tunableController    TunableBlock
+	analysisPoints       map[string]AnalysisPoint
+	primaryAnalysisPoint string
 }
 
 func NewGeneralizedClosedLoop(name string, plant *System, controller any, analysisPoint string) (*GeneralizedClosedLoop, error) {
@@ -119,11 +126,14 @@ func NewGeneralizedClosedLoop(name string, plant *System, controller any, analys
 		return nil, fmt.Errorf("NewGeneralizedClosedLoop: nil plant: %w", ErrDimensionMismatch)
 	}
 	g := &GeneralizedClosedLoop{
-		name:           name,
-		plant:          plant.Copy(),
-		controller:     ctrl,
-		controllerRaw:  controller,
-		analysisPoints: make(map[string]AnalysisPoint),
+		name:                 name,
+		plant:                plant.Copy(),
+		controller:           ctrl,
+		analysisPoints:       make(map[string]AnalysisPoint),
+		primaryAnalysisPoint: analysisPoint,
+	}
+	if tunable, ok := controller.(TunableBlock); ok {
+		g.tunableController = tunable
 	}
 	g.analysisPoints[analysisPoint] = AnalysisPoint{Name: analysisPoint}
 	return g, nil
@@ -176,4 +186,14 @@ func (g *GeneralizedClosedLoop) Sensitivity(name string) (*System, error) {
 	negT.C.Scale(-1, negT.C)
 	negT.D.Scale(-1, negT.D)
 	return Parallel(one, negT)
+}
+
+func (g *GeneralizedClosedLoop) primaryAnalysisPointName() string {
+	if g == nil {
+		return ""
+	}
+	if g.primaryAnalysisPoint != "" {
+		return g.primaryAnalysisPoint
+	}
+	return firstAnalysisPointName(g.analysisPoints)
 }

--- a/tunable.go
+++ b/tunable.go
@@ -161,6 +161,17 @@ func (b *TunableGain) RandomSample(rng *rand.Rand) (*TunableGain, error) {
 	return &TunableGain{name: b.name, D: D, dt: b.dt}, nil
 }
 
+func (b *TunableGain) FreeParameters() []*TunableReal {
+	if b == nil {
+		return nil
+	}
+	return uniqueFreeTunableReals(b.D)
+}
+
+func (b *TunableGain) SampleBlock(values map[string]float64) (TunableBlock, error) {
+	return b.Sample(values)
+}
+
 type TunablePID struct {
 	name       string
 	Kp, Ki, Kd *TunableReal
@@ -207,6 +218,17 @@ func (b *TunablePID) RandomSample(rng *rand.Rand) (*TunablePID, error) {
 		return nil, err
 	}
 	return &TunablePID{name: b.name, Kp: kp, Ki: ki, Kd: kd, Tf: b.Tf, Dt: b.Dt}, nil
+}
+
+func (b *TunablePID) FreeParameters() []*TunableReal {
+	if b == nil {
+		return nil
+	}
+	return uniqueFreeTunableReals([][]*TunableReal{{b.Kp, b.Ki, b.Kd}})
+}
+
+func (b *TunablePID) SampleBlock(values map[string]float64) (TunableBlock, error) {
+	return b.Sample(values)
 }
 
 type TunableTF struct {
@@ -257,6 +279,17 @@ func (b *TunableTF) RandomSample(rng *rand.Rand) (*TunableTF, error) {
 		return nil, err
 	}
 	return &TunableTF{name: b.name, Num: num, Den: copyFloatRows(b.Den), Dt: b.Dt}, nil
+}
+
+func (b *TunableTF) FreeParameters() []*TunableReal {
+	if b == nil {
+		return nil
+	}
+	return uniqueFreeTunableTensors(b.Num)
+}
+
+func (b *TunableTF) SampleBlock(values map[string]float64) (TunableBlock, error) {
+	return b.Sample(values)
 }
 
 type TunableSS struct {
@@ -334,6 +367,17 @@ func (b *TunableSS) RandomSample(rng *rand.Rand) (*TunableSS, error) {
 		return nil, err
 	}
 	return &TunableSS{name: b.name, A: A, B: B, C: C, D: D, Dt: b.Dt}, nil
+}
+
+func (b *TunableSS) FreeParameters() []*TunableReal {
+	if b == nil {
+		return nil
+	}
+	return uniqueFreeTunableMatrices(b.A, b.B, b.C, b.D)
+}
+
+func (b *TunableSS) SampleBlock(values map[string]float64) (TunableBlock, error) {
+	return b.Sample(values)
 }
 
 func tunableMatrixValues(params [][]*TunableReal, context string) (*mat.Dense, error) {
@@ -433,6 +477,42 @@ func randomSampleTunableTensor(params [][][]*TunableReal, rng *rand.Rand) ([][][
 		out[i] = sampled
 	}
 	return out, nil
+}
+
+func uniqueFreeTunableMatrices(matrices ...[][]*TunableReal) []*TunableReal {
+	seen := make(map[string]bool)
+	var out []*TunableReal
+	for _, matrix := range matrices {
+		for _, row := range matrix {
+			for _, param := range row {
+				if param == nil || param.Fixed() || seen[param.Name()] {
+					continue
+				}
+				seen[param.Name()] = true
+				out = append(out, param)
+			}
+		}
+	}
+	return out
+}
+
+func uniqueFreeTunableTensors(tensors ...[][][]*TunableReal) []*TunableReal {
+	seen := make(map[string]bool)
+	var out []*TunableReal
+	for _, tensor := range tensors {
+		for _, matrix := range tensor {
+			for _, row := range matrix {
+				for _, param := range row {
+					if param == nil || param.Fixed() || seen[param.Name()] {
+						continue
+					}
+					seen[param.Name()] = true
+					out = append(out, param)
+				}
+			}
+		}
+	}
+	return out
 }
 
 func copyFloatRows(rows [][]float64) [][]float64 {

--- a/tuning.go
+++ b/tuning.go
@@ -31,9 +31,9 @@ func tuneFixedStructure(model *GeneralizedClosedLoop, goals []TuningGoal, opts *
 	if model == nil {
 		return nil, fmt.Errorf("Systune: nil model: %w", ErrDimensionMismatch)
 	}
-	gain, ok := model.controllerRaw.(*TunableGain)
-	if !ok {
-		return nil, fmt.Errorf("Systune: only TunableGain controllers are supported by this tracer: %w", ErrDimensionMismatch)
+	controller := model.tunableController
+	if controller == nil {
+		return nil, fmt.Errorf("Systune: controller is not tunable: %w", ErrDimensionMismatch)
 	}
 	if len(goals) == 0 {
 		return nil, fmt.Errorf("Systune: no goals: %w", ErrDimensionMismatch)
@@ -42,7 +42,7 @@ func tuneFixedStructure(model *GeneralizedClosedLoop, goals []TuningGoal, opts *
 	if opts != nil && opts.GridPoints > 0 {
 		gridPoints = opts.GridPoints
 	}
-	params := uniqueFreeTunableReals(gain.D)
+	params := controller.FreeParameters()
 	if len(params) == 0 {
 		return nil, fmt.Errorf("Systune: no free tunable parameters: %w", ErrDimensionMismatch)
 	}
@@ -54,14 +54,14 @@ func tuneFixedStructure(model *GeneralizedClosedLoop, goals []TuningGoal, opts *
 	search = func(idx int) error {
 		if idx == len(params) {
 			iterations++
-			sampled, err := gain.Sample(values)
+			sampled, err := controller.SampleBlock(values)
 			if err != nil {
 				return err
 			}
 			candidate := *model
 			candidate.controller = sampled
-			candidate.controllerRaw = sampled
-			closed, err := candidate.ClosedLoop(firstAnalysisPointName(candidate.analysisPoints))
+			candidate.tunableController = sampled
+			closed, err := candidate.ClosedLoop(candidate.primaryAnalysisPointName())
 			if err != nil {
 				return err
 			}

--- a/tuning_goal.go
+++ b/tuning_goal.go
@@ -122,7 +122,7 @@ func tuningGoalSystem(model any) (*System, error) {
 	case *GeneralizedModel:
 		return v.CurrentSystem()
 	case *GeneralizedClosedLoop:
-		return v.ClosedLoop(firstAnalysisPointName(v.analysisPoints))
+		return v.ClosedLoop(v.primaryAnalysisPointName())
 	default:
 		return nil, fmt.Errorf("TuningGoal.Evaluate: unsupported model %T: %w", model, ErrDimensionMismatch)
 	}

--- a/tuning_test.go
+++ b/tuning_test.go
@@ -48,6 +48,24 @@ func TestSystuneTunesSmallMIMOTunableGain(t *testing.T) {
 	}
 }
 
+func TestSystuneUsesTunableBlockInterface(t *testing.T) {
+	plant := makeSISO(-2, 1, 1, 0)
+	k, _ := NewTunableReal("K", 0.1, TunableBounds{Lower: 0.1, Upper: 5})
+	controller := wrappedTunableGain{gain: NewTunableGain("Kblock", [][]*TunableReal{{k}}, 0)}
+	closed, err := NewGeneralizedClosedLoop("loop", plant, controller, "u")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Systune(closed, []TuningGoal{NewTrackingGoal("track", 0.4)}, &SystuneOptions{GridPoints: 9})
+	if err != nil {
+		t.Fatalf("Systune: %v", err)
+	}
+	if !result.Pass {
+		t.Fatalf("expected wrapped tunable block to tune, got %#v", result)
+	}
+}
+
 func TestSystuneUnsupportedControllerFailsClearly(t *testing.T) {
 	plant := makeSISO(-1, 1, 1, 0)
 	fixed := makeSISO(-2, 1, 1, 0)
@@ -58,4 +76,24 @@ func TestSystuneUnsupportedControllerFailsClearly(t *testing.T) {
 	if _, err := Systune(closed, []TuningGoal{NewWeightedGainGoal("gain", 1)}, nil); err == nil {
 		t.Fatal("expected unsupported fixed controller to fail")
 	}
+}
+
+type wrappedTunableGain struct {
+	gain *TunableGain
+}
+
+func (w wrappedTunableGain) CurrentSystem() (*System, error) {
+	return w.gain.CurrentSystem()
+}
+
+func (w wrappedTunableGain) FreeParameters() []*TunableReal {
+	return w.gain.FreeParameters()
+}
+
+func (w wrappedTunableGain) SampleBlock(values map[string]float64) (TunableBlock, error) {
+	sampled, err := w.gain.Sample(values)
+	if err != nil {
+		return nil, err
+	}
+	return wrappedTunableGain{gain: sampled}, nil
 }


### PR DESCRIPTION
## Summary
- add a `TunableBlock` seam for generalized closed-loop tuning
- remove `Systune`'s concrete `*TunableGain` dependency and route sampling/parameter discovery through the tunable interface
- keep the primary analysis point explicit instead of relying on map iteration
- add a public-behavior tracer test proving custom tunable block adapters can tune

## Architecture loop
Used the architecture skill deletion test on the post-PR #150 codebase. The only surviving meaningful drift was the generalized tuning seam: `NumericBlock` existed, but tuning bypassed it through `controllerRaw any`. After this refactor, the remaining observed candidates were not implementation-ready: physical assembly needs specified physical connection equations before deepening, and ModelArray has too little repeated batch behavior to justify a new seam.

## Validation
- go test -run 'TestSystuneUsesTunableBlockInterface|TestSystune|TestGeneralized|TestTunable' -count=1\n- go test -v -count=1\n- benchstat against origin/main for `Benchmark(Tunable|Generalized|Systune)` with -count=6\n\n## Performance gate\nbenchstat count=6: sec/op geomean -0.35%; B/op geomean +0.03%; allocs/op geomean +0.07%. `Systune` gains 2 allocs/op through the tunable interface path; timing remains within noise.