### PR TITLE
Match MATLAB DC gain behavior and optimize integrator path

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -200,6 +200,10 @@ _Avoid_: sample time
 The MIMO input-output response matrix evaluated at one frequency.
 _Avoid_: frequency-response data when referring to one frequency value
 
+**DC gain**:
+The zero-frequency transfer-matrix limit for each input-output channel of a model.
+_Avoid_: steady-state value when model stability or step-response convergence is meant
+
 **Static-gain model**:
 A model with direct input-to-output gain and no dynamic state.
 _Avoid_: gain system unless matching established API names, zero-state system

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -48,6 +48,38 @@ func benchFRDFromSys(sys *System, nw int) *FRD {
 	return f
 }
 
+func benchIntegratorMIMOSystem(n, m, p int) *System {
+	A := mat.NewDense(n, n, nil)
+	for i := 1; i < n; i++ {
+		A.Set(i, i, -float64(i+1)*0.25)
+		if i > 1 {
+			A.Set(i, i-1, 0.2)
+		}
+		if i < n-1 {
+			A.Set(i, i+1, 0.05)
+		}
+	}
+	B := mat.NewDense(n, m, nil)
+	for j := 0; j < m; j++ {
+		B.Set(0, j, float64(j+1))
+	}
+	for i := 1; i < n; i++ {
+		B.Set(i, i%m, 1)
+	}
+	C := mat.NewDense(p, n, nil)
+	for i := 0; i < p; i++ {
+		if i%2 == 0 {
+			C.Set(i, 0, 1)
+		}
+		if n > 1 {
+			C.Set(i, 1+i%(n-1), 1)
+		}
+	}
+	D := mat.NewDense(p, m, nil)
+	sys, _ := New(A, B, C, D, 0)
+	return sys
+}
+
 func benchModelArray(b *testing.B, count, n, m, p int) *ModelArray {
 	b.Helper()
 	models := make([]*System, count)
@@ -64,6 +96,38 @@ func benchModelArray(b *testing.B, count, n, m, p int) *ModelArray {
 		b.Fatal(err)
 	}
 	return arr
+}
+
+// --------------- DC gain ---------------
+
+func BenchmarkDCGain_StableMIMO_N10_M4_P6(b *testing.B) {
+	sys := benchSysNonSym(10, 4, 6)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sys.DCGain(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDCGain_IntegratorMIMO_N10_M4_P6(b *testing.B) {
+	sys := benchIntegratorMIMOSystem(10, 4, 6)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sys.DCGain(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDCGain_IntegratorMIMO_N40_M8_P8(b *testing.B) {
+	sys := benchIntegratorMIMOSystem(40, 8, 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := sys.DCGain(); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 // --------------- FRD stack ---------------

--- a/response.go
+++ b/response.go
@@ -286,11 +286,123 @@ func (sys *System) DCGain() (*mat.Dense, error) {
 }
 
 func (sys *System) dcGainByTransferFunctionLimit() (*mat.Dense, error) {
+	if gain, ok := sys.dcGainByDecoupledSingularModes(); ok {
+		return gain, nil
+	}
 	res, err := sys.TransferFunction(nil)
 	if err != nil {
 		return nil, fmt.Errorf("DCGain: %w", err)
 	}
 	return dcGainFromTransferFunction(res.TF), nil
+}
+
+func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
+	n, m, p := sys.Dims()
+	target := 0.0
+	if sys.IsDiscrete() {
+		target = 1.0
+	}
+	tol := dcGainMatrixTol(sys.A)
+	singular := make([]bool, n)
+	regularCount := 0
+	for k := 0; k < n; k++ {
+		if math.Abs(sys.A.At(k, k)-target) <= tol && rowColDecoupledAt(sys.A, k, tol) {
+			singular[k] = true
+			continue
+		}
+		regularCount++
+	}
+	if regularCount == n {
+		return nil, false
+	}
+
+	regular := make([]int, 0, regularCount)
+	for k := 0; k < n; k++ {
+		if !singular[k] {
+			regular = append(regular, k)
+		}
+	}
+
+	gain := denseCopySafe(sys.D, p, m)
+	if regularCount > 0 {
+		Areg := mat.NewDense(regularCount, regularCount, nil)
+		Breg := mat.NewDense(regularCount, m, nil)
+		Creg := mat.NewDense(p, regularCount, nil)
+		for ri, srcRow := range regular {
+			for ci, srcCol := range regular {
+				Areg.Set(ri, ci, sys.A.At(srcRow, srcCol))
+			}
+			for j := 0; j < m; j++ {
+				Breg.Set(ri, j, sys.B.At(srcRow, j))
+			}
+			for i := 0; i < p; i++ {
+				Creg.Set(i, ri, sys.C.At(i, srcRow))
+			}
+		}
+
+		var X mat.Dense
+		var err error
+		if sys.IsContinuous() {
+			err = X.Solve(Areg, Breg)
+		} else {
+			ImA := mat.NewDense(regularCount, regularCount, nil)
+			for i := 0; i < regularCount; i++ {
+				for j := 0; j < regularCount; j++ {
+					v := -Areg.At(i, j)
+					if i == j {
+						v += 1
+					}
+					ImA.Set(i, j, v)
+				}
+			}
+			err = X.Solve(ImA, Breg)
+		}
+		if err != nil {
+			return nil, false
+		}
+		var finite mat.Dense
+		finite.Mul(Creg, &X)
+		if sys.IsContinuous() {
+			finite.Scale(-1, &finite)
+		}
+		gain.Add(gain, &finite)
+	}
+
+	for k := 0; k < n; k++ {
+		if !singular[k] {
+			continue
+		}
+		for i := 0; i < p; i++ {
+			c := sys.C.At(i, k)
+			if math.Abs(c) <= tol {
+				continue
+			}
+			for j := 0; j < m; j++ {
+				coeff := c * sys.B.At(k, j)
+				if math.Abs(coeff) > tol {
+					gain.Set(i, j, math.Inf(signInt(coeff)))
+				}
+			}
+		}
+	}
+	return gain, true
+}
+
+func rowColDecoupledAt(a *mat.Dense, k int, tol float64) bool {
+	n, _ := a.Dims()
+	for i := 0; i < n; i++ {
+		if i == k {
+			continue
+		}
+		if math.Abs(a.At(k, i)) > tol || math.Abs(a.At(i, k)) > tol {
+			return false
+		}
+	}
+	return true
+}
+
+func dcGainMatrixTol(m *mat.Dense) float64 {
+	return 100 * eps() * math.Max(denseNorm(m), 1)
 }
 
 func dcGainFromTransferFunction(tf *TransferFunc) *mat.Dense {

--- a/response.go
+++ b/response.go
@@ -250,7 +250,7 @@ func (sys *System) DCGain() (*mat.Dense, error) {
 		var X mat.Dense
 		err := X.Solve(sys.A, sys.B)
 		if err != nil {
-			return nil, fmt.Errorf("DCGain: A singular, DC gain undefined: %w", ErrSingularTransform)
+			return sys.dcGainByTransferFunctionLimit()
 		}
 		gain := mat.NewDense(p, m, nil)
 		gain.Mul(sys.C, &X)
@@ -275,7 +275,7 @@ func (sys *System) DCGain() (*mat.Dense, error) {
 	var X mat.Dense
 	err := X.Solve(ImA, sys.B)
 	if err != nil {
-		return nil, fmt.Errorf("DCGain: (I-A) singular, DC gain undefined: %w", ErrSingularTransform)
+		return sys.dcGainByTransferFunctionLimit()
 	}
 	gain := mat.NewDense(p, m, nil)
 	gain.Mul(sys.C, &X)
@@ -283,6 +283,103 @@ func (sys *System) DCGain() (*mat.Dense, error) {
 		gain.Add(gain, sys.D)
 	}
 	return gain, nil
+}
+
+func (sys *System) dcGainByTransferFunctionLimit() (*mat.Dense, error) {
+	res, err := sys.TransferFunction(nil)
+	if err != nil {
+		return nil, fmt.Errorf("DCGain: %w", err)
+	}
+	return dcGainFromTransferFunction(res.TF), nil
+}
+
+func dcGainFromTransferFunction(tf *TransferFunc) *mat.Dense {
+	p, m := tf.Dims()
+	point := 0.0
+	if tf.Dt > 0 {
+		point = 1.0
+	}
+	gain := mat.NewDense(p, m, nil)
+	for i := 0; i < p; i++ {
+		for j := 0; j < m; j++ {
+			gain.Set(i, j, rationalLimitAtReal(tf.Num[i][j], tf.Den[i], point))
+		}
+	}
+	return gain
+}
+
+func rationalLimitAtReal(num, den []float64, point float64) float64 {
+	numMult, numValue, numZero := polynomialRootMultiplicityValue(num, point)
+	if numZero {
+		return 0
+	}
+	denMult, denValue, denZero := polynomialRootMultiplicityValue(den, point)
+	if denZero {
+		return math.NaN()
+	}
+	if denMult > numMult {
+		return math.Inf(signInt(numValue / denValue))
+	}
+	if denMult < numMult {
+		return 0
+	}
+	return numValue / denValue
+}
+
+func polynomialRootMultiplicityValue(poly []float64, root float64) (multiplicity int, value float64, zero bool) {
+	p := trimLeadingNearZero(poly, dcGainPolyTol(poly))
+	if len(p) == 0 {
+		return 0, 0, true
+	}
+	tol := dcGainPolyTol(p)
+	for len(p) > 1 {
+		q, rem := deflateRealRoot(p, root)
+		if math.Abs(rem) > tol {
+			break
+		}
+		multiplicity++
+		p = trimLeadingNearZero(q, tol)
+		if len(p) == 0 {
+			return multiplicity, 0, true
+		}
+		tol = dcGainPolyTol(p)
+	}
+	return multiplicity, real(Poly(p).Eval(complex(root, 0))), false
+}
+
+func deflateRealRoot(poly []float64, root float64) ([]float64, float64) {
+	q := make([]float64, len(poly)-1)
+	q[0] = poly[0]
+	for i := 1; i < len(q); i++ {
+		q[i] = poly[i] + root*q[i-1]
+	}
+	rem := poly[len(poly)-1] + root*q[len(q)-1]
+	return q, rem
+}
+
+func trimLeadingNearZero(poly []float64, tol float64) []float64 {
+	start := 0
+	for start < len(poly) && math.Abs(poly[start]) <= tol {
+		start++
+	}
+	return poly[start:]
+}
+
+func dcGainPolyTol(poly []float64) float64 {
+	scale := 1.0
+	for _, v := range poly {
+		if a := math.Abs(v); a > scale {
+			scale = a
+		}
+	}
+	return 100 * eps() * scale
+}
+
+func signInt(v float64) int {
+	if math.Signbit(v) {
+		return -1
+	}
+	return 1
 }
 
 func Damp(sys *System) ([]DampInfo, error) {

--- a/response.go
+++ b/response.go
@@ -368,6 +368,7 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 		gain.Add(gain, &finite)
 	}
 
+	residue := mat.NewDense(p, m, nil)
 	for k := 0; k < n; k++ {
 		if !singular[k] {
 			continue
@@ -380,8 +381,16 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 			for j := 0; j < m; j++ {
 				coeff := c * sys.B.At(k, j)
 				if math.Abs(coeff) > tol {
-					gain.Set(i, j, math.Inf(signInt(coeff)))
+					residue.Set(i, j, residue.At(i, j)+coeff)
 				}
+			}
+		}
+	}
+	for i := 0; i < p; i++ {
+		for j := 0; j < m; j++ {
+			coeff := residue.At(i, j)
+			if math.Abs(coeff) > tol {
+				gain.Set(i, j, math.Inf(signInt(coeff)))
 			}
 		}
 	}

--- a/response_test.go
+++ b/response_test.go
@@ -178,6 +178,29 @@ func TestDCGain_MIMOIntegratorHiddenFromOutput(t *testing.T) {
 	}
 }
 
+func TestDCGain_DecoupledIntegratorResiduesCancel(t *testing.T) {
+	sys, _ := New(
+		mat.NewDense(2, 2, []float64{
+			0, 0,
+			0, 0,
+		}),
+		mat.NewDense(2, 1, []float64{1, 1}),
+		mat.NewDense(1, 2, []float64{1, -1}),
+		mat.NewDense(1, 1, nil),
+		0,
+	)
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if math.IsInf(g.At(0, 0), 0) || math.IsNaN(g.At(0, 0)) {
+		t.Fatalf("DCGain = %v, want finite cancellation", g.At(0, 0))
+	}
+	if math.Abs(g.At(0, 0)) > 1e-12 {
+		t.Fatalf("DCGain = %v, want 0", g.At(0, 0))
+	}
+}
+
 func TestDamp_ContinuousUnderdamped(t *testing.T) {
 	wn := 10.0
 	zeta := 0.3

--- a/response_test.go
+++ b/response_test.go
@@ -75,7 +75,7 @@ func TestDCGain_PureGain(t *testing.T) {
 	}
 }
 
-func TestDCGain_Integrator_Error(t *testing.T) {
+func TestDCGain_Integrator_Infinite(t *testing.T) {
 	sys, _ := New(
 		mat.NewDense(1, 1, []float64{0}),
 		mat.NewDense(1, 1, []float64{1}),
@@ -83,13 +83,33 @@ func TestDCGain_Integrator_Error(t *testing.T) {
 		mat.NewDense(1, 1, []float64{0}),
 		0,
 	)
-	_, err := sys.DCGain()
-	if err == nil {
-		t.Fatal("expected error for integrator (singular A)")
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsInf(g.At(0, 0), 1) {
+		t.Fatalf("DCGain = %v, want +Inf", g.At(0, 0))
 	}
 }
 
-func TestDCGain_Discrete_PoleAtOne_Error(t *testing.T) {
+func TestDCGain_NegativeIntegrator_NegativeInfinite(t *testing.T) {
+	sys, _ := New(
+		mat.NewDense(1, 1, []float64{0}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(1, 1, []float64{-1}),
+		mat.NewDense(1, 1, []float64{0}),
+		0,
+	)
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsInf(g.At(0, 0), -1) {
+		t.Fatalf("DCGain = %v, want -Inf", g.At(0, 0))
+	}
+}
+
+func TestDCGain_DiscretePoleAtOne_Infinite(t *testing.T) {
 	sys, _ := New(
 		mat.NewDense(1, 1, []float64{1}),
 		mat.NewDense(1, 1, []float64{1}),
@@ -97,9 +117,64 @@ func TestDCGain_Discrete_PoleAtOne_Error(t *testing.T) {
 		mat.NewDense(1, 1, []float64{0}),
 		0.1,
 	)
-	_, err := sys.DCGain()
-	if err == nil {
-		t.Fatal("expected error for discrete pole at z=1")
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsInf(g.At(0, 0), 1) {
+		t.Fatalf("DCGain = %v, want +Inf", g.At(0, 0))
+	}
+}
+
+func TestDCGain_MIMOIntegratorChannelwise(t *testing.T) {
+	sys, _ := New(
+		mat.NewDense(2, 2, []float64{
+			0, 0,
+			0, -2,
+		}),
+		mat.NewDense(2, 2, []float64{
+			1, 0,
+			0, 1,
+		}),
+		mat.NewDense(2, 2, []float64{
+			1, 0,
+			0, 1,
+		}),
+		mat.NewDense(2, 2, nil),
+		0,
+	)
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsInf(g.At(0, 0), 1) {
+		t.Fatalf("DCGain[0,0] = %v, want +Inf", g.At(0, 0))
+	}
+	if g.At(0, 1) != 0 || g.At(1, 0) != 0 {
+		t.Fatalf("off-diagonal DCGain = [%v %v], want zeros", g.At(0, 1), g.At(1, 0))
+	}
+	if math.Abs(g.At(1, 1)-0.5) > 1e-12 {
+		t.Fatalf("DCGain[1,1] = %v, want 0.5", g.At(1, 1))
+	}
+}
+
+func TestDCGain_MIMOIntegratorHiddenFromOutput(t *testing.T) {
+	sys, _ := New(
+		mat.NewDense(1, 1, []float64{0}),
+		mat.NewDense(1, 1, []float64{1}),
+		mat.NewDense(2, 1, []float64{1, 0}),
+		mat.NewDense(2, 1, nil),
+		0,
+	)
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsInf(g.At(0, 0), 1) {
+		t.Fatalf("DCGain[0,0] = %v, want +Inf", g.At(0, 0))
+	}
+	if g.At(1, 0) != 0 {
+		t.Fatalf("DCGain[1,0] = %v, want 0", g.At(1, 0))
 	}
 }
 


### PR DESCRIPTION
## Summary
- match MATLAB dcgain behavior for integrator channels by returning per-channel Inf/-Inf instead of failing the whole MIMO model
- define DC gain in the project glossary as a zero-frequency transfer-matrix limit, distinct from stable step-response final value
- add DCGain benchmarks and optimize the common decoupled integrator/accumulator path while preserving the transfer-function fallback

## Verification
- go test -v -count=1 -run 'TestDCGain'
- go test -v -count=1
- go test -run '^$' -bench 'BenchmarkDCGain' -benchmem -count=5

## Benchmark
- DCGain_StableMIMO_N10_M4_P6: ~3.38us -> ~3.33us, no regression
- DCGain_IntegratorMIMO_N10_M4_P6: 70.79us -> 4.85us, -93.16%
- DCGain_IntegratorMIMO_N40_M8_P8: 1.688ms -> 51.93us, -96.92%
