### PR TITLE
Add DC gain coupled singular block regression

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -201,6 +201,26 @@ func TestDCGain_DecoupledIntegratorResiduesCancel(t *testing.T) {
 	}
 }
 
+func TestDCGain_CoupledSingularBlockFallsBackToTransferLimit(t *testing.T) {
+	sys, _ := New(
+		mat.NewDense(2, 2, []float64{
+			0, 1,
+			0, 0,
+		}),
+		mat.NewDense(2, 1, []float64{0, 1}),
+		mat.NewDense(1, 2, []float64{1, 0}),
+		mat.NewDense(1, 1, nil),
+		0,
+	)
+	g, err := sys.DCGain()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !math.IsInf(g.At(0, 0), 1) {
+		t.Fatalf("DCGain = %v, want +Inf", g.At(0, 0))
+	}
+}
+
 func TestDamp_ContinuousUnderdamped(t *testing.T) {
 	wn := 10.0
 	zeta := 0.3


### PR DESCRIPTION
## Summary
- add a DCGain regression for a coupled singular Jordan block that must use the transfer-function limit fallback
- assert the double-integrator channel returns +Inf instead of erroring or relying on the decoupled singular-mode fast path

## Verification
- go test -v -count=1 -run 'TestDCGain_CoupledSingularBlockFallsBackToTransferLimit'\n- go test -v -count=1 -run 'TestDCGain'\n- go test -v -count=1\n- git diff --check