### PR TITLE
Update module to Go 1.26.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ For domain terminology, modeling assumptions, and project language, read
 go test -v -count=1
 ```
 
+## Go Modernization
+
+- When updating to a newer Go toolchain, start from a clean git state and run `go fix ./...`; repeat until it reaches a fixed point before reviewing the mechanical diff.
+- Keep generated rewrites only after the normal test and benchmark gates stay clean; roll back hot-path rewrites that regress performance.
+
 ## Key Conventions
 
 - gonum LAPACK uses **row-major** flat arrays (`a[row*n+col]`), not column-major like Fortran

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jamestjsp/controlsys
 
-go 1.25.3
+go 1.26.3
 
 require gonum.org/v1/gonum v0.15.0
 


### PR DESCRIPTION
## Summary
- update the module `go` directive to Go 1.26.3
- document the Go 1.26 `go fix ./...` workflow and performance-gated review process in `AGENTS.md`

## Validation
- `go fix ./...` run to fixed point; generated source rewrites were reviewed and not retained after benchmark gates exposed hot-path regressions
- `go mod tidy`
- `git diff --check`
- `go test -v -count=1`
- `go test -run=^$ -bench=. -benchmem` + `benchstat`
  - sec/op geomean: `40.04µ` -> `40.20µ` (`+0.40%`)
  - B/op geomean: `-0.01%`
  - allocs/op geomean: `-0.00%`

References:
- https://go.dev/dl/
- https://go.dev/blog/gofix