### PR TITLE
Upgrade to Go 1.26.3 and apply go fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,15 @@
 For domain terminology, modeling assumptions, and project language, read
 `CONTEXT.md` before making design, documentation, or behavior changes.
 
+## Static Checks
+
+Run `go fix` the same way you run `go vet`:
+
+```bash
+go fix ./...
+go vet ./...
+```
+
 ## Build & Test
 
 ```bash

--- a/architecture_backlog_test.go
+++ b/architecture_backlog_test.go
@@ -158,8 +158,8 @@ func TestTransferFunctionPreservesRowRealizationBehavior(t *testing.T) {
 	if !stringSlicesEqual(res.TF.OutputName, sys.OutputName) {
 		t.Fatalf("OutputName = %v, want %v", res.TF.OutputName, sys.OutputName)
 	}
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			if res.TF.Delay[i][j] != sys.Delay.At(i, j) {
 				t.Fatalf("Delay[%d][%d] = %v, want %v", i, j, res.TF.Delay[i][j], sys.Delay.At(i, j))
 			}
@@ -173,8 +173,8 @@ func TestTransferFunctionPreservesRowRealizationBehavior(t *testing.T) {
 	}
 	for k, w := range omega {
 		tfEval := res.TF.Eval(complex(0, w))
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				assertComplexApprox(t, tfEval[i][j], resp.At(k, i, j), 1e-8)
 			}
 		}
@@ -327,8 +327,8 @@ func assertDenseApprox(t *testing.T, got, want *mat.Dense, tol float64) {
 	if gr != wr || gc != wc {
 		t.Fatalf("dims = %dx%d, want %dx%d", gr, gc, wr, wc)
 	}
-	for i := 0; i < gr; i++ {
-		for j := 0; j < gc; j++ {
+	for i := range gr {
+		for j := range gc {
 			if math.Abs(got.At(i, j)-want.At(i, j)) > tol {
 				t.Fatalf("(%d,%d) = %v, want %v", i, j, got.At(i, j), want.At(i, j))
 			}

--- a/architecture_prd125_test.go
+++ b/architecture_prd125_test.go
@@ -97,7 +97,7 @@ func TestPRD125FreqRespEstUsesStridedSampledSignals(t *testing.T) {
 	output := baseOutput.Slice(0, 2, 1, steps+1).(*mat.Dense)
 
 	rng := rand.New(rand.NewSource(125))
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u0 := rng.NormFloat64()
 		u1 := rng.NormFloat64()
 		input.Set(0, k, u0)

--- a/augstate.go
+++ b/augstate.go
@@ -13,17 +13,17 @@ func Augstate(sys *System) (*System, error) {
 	cNew := mat.NewDense(pNew, n, nil)
 	cRaw := cNew.RawMatrix()
 	origC := sys.C.RawMatrix()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(cRaw.Data[i*cRaw.Stride:i*cRaw.Stride+n], origC.Data[i*origC.Stride:i*origC.Stride+n])
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		cRaw.Data[(p+i)*cRaw.Stride+i] = 1
 	}
 
 	dNew := mat.NewDense(pNew, m, nil)
 	dRaw := dNew.RawMatrix()
 	origD := sys.D.RawMatrix()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(dRaw.Data[i*dRaw.Stride:i*dRaw.Stride+m], origD.Data[i*origD.Stride:i*origD.Stride+m])
 	}
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkSimulateWithDelay_SISO(b *testing.B) {
 
 	steps := 100
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 	x0 := mat.NewVecDense(2, []float64{1, -0.5})
@@ -31,7 +31,7 @@ func BenchmarkSimulateWithDelay_SISO(b *testing.B) {
 func BenchmarkSimulateWithDelay_MIMO(b *testing.B) {
 	n, m, p := 10, 4, 6
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, 0.9-float64(i)*0.05)
 		if i > 0 {
 			A.Set(i, i-1, 0.1)
@@ -48,8 +48,8 @@ func BenchmarkSimulateWithDelay_MIMO(b *testing.B) {
 	D := mat.NewDense(p, m, nil)
 
 	delay := mat.NewDense(p, m, nil)
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			delay.Set(i, j, float64(2+i+j))
 		}
 	}
@@ -57,13 +57,13 @@ func BenchmarkSimulateWithDelay_MIMO(b *testing.B) {
 
 	steps := 200
 	u := mat.NewDense(m, steps, nil)
-	for j := 0; j < m; j++ {
-		for k := 0; k < steps; k++ {
+	for j := range m {
+		for k := range steps {
 			u.Set(j, k, math.Sin(float64(k)*0.1+float64(j)))
 		}
 	}
 	x0 := mat.NewVecDense(n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		x0.SetVec(i, float64(i+1)*0.1)
 	}
 
@@ -76,14 +76,14 @@ func BenchmarkSimulateWithDelay_MIMO(b *testing.B) {
 func BenchmarkBilinearDiscretize(b *testing.B) {
 	n := 20
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.5)
 		if i > 0 {
 			A.Set(i, i-1, 1)
 		}
 	}
 	B := mat.NewDense(n, 3, nil)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		B.Set(i, i, 1)
 	}
 	C := mat.NewDense(2, n, nil)
@@ -101,7 +101,7 @@ func BenchmarkBilinearDiscretize(b *testing.B) {
 func BenchmarkTransferFunction_MIMO(b *testing.B) {
 	n := 15
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.3)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -112,11 +112,11 @@ func BenchmarkTransferFunction_MIMO(b *testing.B) {
 	}
 	m, p := 3, 4
 	B := mat.NewDense(n, m, nil)
-	for i := 0; i < m; i++ {
+	for i := range m {
 		B.Set(i, i, 1)
 	}
 	C := mat.NewDense(p, n, nil)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		C.Set(i, i%n, 1)
 	}
 	D := mat.NewDense(p, m, nil)
@@ -131,7 +131,7 @@ func BenchmarkTransferFunction_MIMO(b *testing.B) {
 func BenchmarkReduce(b *testing.B) {
 	n := 20
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.2)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -154,14 +154,14 @@ func BenchmarkReduce(b *testing.B) {
 
 func BenchmarkAbsorbDelay(b *testing.B) {
 	A := mat.NewDense(5, 5, nil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		A.Set(i, i, 0.8-float64(i)*0.05)
 		if i > 0 {
 			A.Set(i, i-1, 0.1)
 		}
 	}
 	B := mat.NewDense(5, 3, nil)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		B.Set(i, i, 1)
 	}
 	C := mat.NewDense(2, 5, nil)
@@ -180,7 +180,7 @@ func BenchmarkAbsorbDelay(b *testing.B) {
 func BenchmarkDiscretizeZOH(b *testing.B) {
 	n := 20
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.5)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -188,7 +188,7 @@ func BenchmarkDiscretizeZOH(b *testing.B) {
 	}
 	m := 5
 	B := mat.NewDense(n, m, nil)
-	for i := 0; i < m; i++ {
+	for i := range m {
 		B.Set(i, i, 1)
 	}
 	C := mat.NewDense(3, n, nil)
@@ -206,8 +206,8 @@ func BenchmarkDiscretizeZOH(b *testing.B) {
 
 func BenchmarkDenseNorm(b *testing.B) {
 	m := mat.NewDense(50, 50, nil)
-	for i := 0; i < 50; i++ {
-		for j := 0; j < 50; j++ {
+	for i := range 50 {
+		for j := range 50 {
 			m.Set(i, j, float64(i*50+j)*0.01)
 		}
 	}
@@ -283,7 +283,7 @@ func BenchmarkBode(b *testing.B) {
 
 func BenchmarkZeros_SISO(b *testing.B) {
 	A := mat.NewDense(5, 5, nil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		A.Set(i, i, -float64(i+1)*0.5)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -310,7 +310,7 @@ func BenchmarkZeros_MIMO(b *testing.B) {
 func BenchmarkZeros_NonSquare(b *testing.B) {
 	n, m, p := 15, 5, 8
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.3)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -320,11 +320,11 @@ func BenchmarkZeros_NonSquare(b *testing.B) {
 		}
 	}
 	B := mat.NewDense(n, m, nil)
-	for i := 0; i < m; i++ {
+	for i := range m {
 		B.Set(i, i, 1)
 	}
 	C := mat.NewDense(p, n, nil)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		C.Set(i, i%n, 1)
 	}
 	D := mat.NewDense(p, m, nil)
@@ -338,7 +338,7 @@ func BenchmarkZeros_NonSquare(b *testing.B) {
 func BenchmarkControllabilityStaircase(b *testing.B) {
 	n := 20
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.2)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -362,13 +362,13 @@ func BenchmarkSimulateNoDelay(b *testing.B) {
 	sys.Dt = 0.01
 	steps := 500
 	u := mat.NewDense(3, steps, nil)
-	for j := 0; j < 3; j++ {
-		for k := 0; k < steps; k++ {
+	for j := range 3 {
+		for k := range steps {
 			u.Set(j, k, math.Sin(float64(k)*0.1+float64(j)))
 		}
 	}
 	x0 := mat.NewVecDense(20, nil)
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		x0.SetVec(i, float64(i)*0.05)
 	}
 	b.ResetTimer()
@@ -437,7 +437,7 @@ func BenchmarkSetDelayModel(b *testing.B) {
 
 func BenchmarkAbsorbInternalDelay(b *testing.B) {
 	A := mat.NewDense(5, 5, nil)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		A.Set(i, i, 0.8-float64(i)*0.05)
 		if i > 0 {
 			A.Set(i, i-1, 0.1)
@@ -519,7 +519,7 @@ func BenchmarkSimulateInternalDelay(b *testing.B) {
 
 	steps := 200
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.1))
 	}
 	x0 := mat.NewVecDense(3, []float64{1, 0, 0})
@@ -569,7 +569,7 @@ func BenchmarkZeroDelayApprox(b *testing.B) {
 func BenchmarkIsStrictlyUpperTriangular(b *testing.B) {
 	n := 20
 	m := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		for j := i + 1; j < n; j++ {
 			m.Set(i, j, float64(i*n+j)*0.01)
 		}
@@ -609,7 +609,7 @@ func BenchmarkSimulate_DCMotor(b *testing.B) {
 	disc, _ := sys.DiscretizeZOH(0.001)
 	steps := 1000
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 	b.ResetTimer()
@@ -668,7 +668,7 @@ func BenchmarkSimulate_MassSpringDamper(b *testing.B) {
 	disc, _ := sys.DiscretizeZOH(0.01)
 	steps := 500
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.05))
 	}
 	b.ResetTimer()
@@ -700,7 +700,7 @@ func BenchmarkDiscretizeAndSimulate_B747Longitudinal(b *testing.B) {
 	disc, _ := sys.DiscretizeZOH(0.05)
 	steps := 200
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		if k < 50 {
 			u.Set(0, k, -0.01)
 		}
@@ -719,8 +719,8 @@ func BenchmarkSimulate_Large(b *testing.B) {
 	sys.Dt = 0.01
 	steps := 1000
 	u := mat.NewDense(m, steps, nil)
-	for j := 0; j < m; j++ {
-		for k := 0; k < steps; k++ {
+	for j := range m {
+		for k := range steps {
 			u.Set(j, k, math.Sin(float64(k)*0.02+float64(j)))
 		}
 	}
@@ -762,7 +762,7 @@ func BenchmarkFeedbackAndSimulate(b *testing.B) {
 	disc, _ := cl.DiscretizeZOH(0.05)
 	steps := 200
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < 50; k++ {
+	for k := range 50 {
 		u.Set(0, k, 1)
 	}
 	b.ResetTimer()
@@ -1273,7 +1273,7 @@ func BenchmarkFreqRespEst_MIMO(b *testing.B) {
 
 func benchSys(n, m, p int) *System {
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.3)
 		if i > 0 {
 			A.Set(i, i-1, 1)
@@ -1342,7 +1342,7 @@ func BenchmarkLFT_Large(b *testing.B) {
 
 func benchD2CSystem(n, m int, dt float64) *System {
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.5)
 		if i > 0 {
 			A.Set(i, i-1, 0.3)

--- a/benchmark_hotspots_test.go
+++ b/benchmark_hotspots_test.go
@@ -12,7 +12,7 @@ import (
 // A has sub/superdiagonal coupling so transposition bugs surface.
 func benchSysNonSym(n, m, p int) *System {
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		A.Set(i, i, -float64(i+1)*0.3)
 		if i > 0 {
 			A.Set(i, i-1, 1.0)
@@ -60,14 +60,14 @@ func benchIntegratorMIMOSystem(n, m, p int) *System {
 		}
 	}
 	B := mat.NewDense(n, m, nil)
-	for j := 0; j < m; j++ {
+	for j := range m {
 		B.Set(0, j, float64(j+1))
 	}
 	for i := 1; i < n; i++ {
 		B.Set(i, i%m, 1)
 	}
 	C := mat.NewDense(p, n, nil)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		if i%2 == 0 {
 			C.Set(i, 0, 1)
 		}
@@ -404,8 +404,8 @@ func benchLsimB(b *testing.B, n, m, p, steps int) {
 		t[k] = float64(k) * dt
 	}
 	u := mat.NewDense(steps, m, nil)
-	for k := 0; k < steps; k++ {
-		for j := 0; j < m; j++ {
+	for k := range steps {
+		for j := range m {
 			u.Set(k, j, math.Sin(float64(k)*dt*float64(j+1)))
 		}
 	}
@@ -653,7 +653,7 @@ func benchDescriptorSystem(b *testing.B, n, m, p int) *System {
 	b.Helper()
 	sys := benchSysNonSym(n, m, p)
 	E := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		E.Set(i, i, 1+0.1*float64(i+1))
 	}
 	sys.E = E
@@ -693,7 +693,7 @@ func BenchmarkStabsep_N100(b *testing.B) { benchStabsep(b, 100) }
 
 func benchStabsep(b *testing.B, n int) {
 	A := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i%2 == 0 {
 			A.Set(i, i, -float64(i+1)*0.3)
 		} else {
@@ -796,7 +796,7 @@ func BenchmarkCovar_MIMO_N10(b *testing.B)  { benchCovarB(b, 10, 3, 4) }
 func benchCovarB(b *testing.B, n, m, p int) {
 	sys := benchSysNonSym(n, m, p)
 	W := mat.NewDense(m, m, nil)
-	for i := 0; i < m; i++ {
+	for i := range m {
 		W.Set(i, i, 1)
 	}
 	b.ResetTimer()

--- a/canon.go
+++ b/canon.go
@@ -79,7 +79,7 @@ func canonModalEig(sys *System, policy realizationTransformPolicy) (*CanonResult
 
 	blocks := make([]eigBlock, 0, n)
 	used := make([]bool, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if used[i] {
 			continue
 		}
@@ -124,12 +124,12 @@ func canonModalEig(sys *System, policy realizationTransformPolicy) (*CanonResult
 	col := 0
 	for _, blk := range blocks {
 		if blk.imag1 == 0 {
-			for row := 0; row < n; row++ {
+			for row := range n {
 				tData[row*n+col] = real(vecs.At(row, blk.idx))
 			}
 			col++
 		} else {
-			for row := 0; row < n; row++ {
+			for row := range n {
 				v := vecs.At(row, blk.idx)
 				tData[row*n+col] = real(v)
 				tData[row*n+col+1] = imag(v)
@@ -296,7 +296,7 @@ func canonCompanion(sys *System) (*CanonResult, error) {
 	for i := 0; i < n-1; i++ {
 		Ac.Set(i, i+1, 1)
 	}
-	for j := 0; j < n; j++ {
+	for j := range n {
 		Ac.Set(n-1, j, -charPoly[j])
 	}
 

--- a/canon_test.go
+++ b/canon_test.go
@@ -32,8 +32,8 @@ func TestCanonModal_RealEigenvalues(t *testing.T) {
 		t.Errorf("poles = %v, want [-3, -2]", poles)
 	}
 
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			if i != j && math.Abs(Amod.At(i, j)) > 1e-8 {
 				t.Errorf("A_modal[%d,%d] = %g, want 0 (should be diagonal)", i, j, Amod.At(i, j))
 			}

--- a/connect.go
+++ b/connect.go
@@ -21,7 +21,7 @@ func setBlock(dst *mat.Dense, r0, c0 int, src *mat.Dense) {
 	}
 	dRaw := dst.RawMatrix()
 	sRaw := src.RawMatrix()
-	for i := 0; i < sr; i++ {
+	for i := range sr {
 		copy(dRaw.Data[(r0+i)*dRaw.Stride+c0:], sRaw.Data[i*sRaw.Stride:i*sRaw.Stride+sc])
 	}
 }
@@ -136,8 +136,8 @@ func seriesDelay(sys1, sys2 *System) *mat.Dense {
 	d2 := ioDelayOrZero(sys2.Delay, p2, p1)
 
 	result := mat.NewDense(p2, m1, nil)
-	for i := 0; i < p2; i++ {
-		for j := 0; j < m1; j++ {
+	for i := range p2 {
+		for j := range m1 {
 			ref := d1.At(0, j) + d2.At(i, 0)
 			for k := 1; k < p1; k++ {
 				if math.Abs(d1.At(k, j)+d2.At(i, k)-ref) > 1e-12 {
@@ -158,7 +158,7 @@ func seriesInputOutputDelay(sys1, sys2 *System, p, m int, ioDelay *mat.Dense) (i
 
 	intermediate := make([]float64, p1)
 	hasIntermediate := false
-	for k := 0; k < p1; k++ {
+	for k := range p1 {
 		var od, id float64
 		if sys1.OutputDelay != nil {
 			od = sys1.OutputDelay[k]
@@ -188,8 +188,8 @@ func seriesInputOutputDelay(sys1, sys2 *System, p, m int, ioDelay *mat.Dense) (i
 	}
 
 	raw := ioDelay.RawMatrix()
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			raw.Data[i*raw.Stride+j] += minIntermediate
 		}
 	}
@@ -328,8 +328,8 @@ func parallelInputOutputDelay(sys1, sys2 *System, m, p int, ioDelay *mat.Dense) 
 	residual2 := mat.NewDense(p, m, nil)
 	r1Raw := residual1.RawMatrix()
 	r2Raw := residual2.RawMatrix()
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			v1 := (in1[j] - commonIn[j]) + (out1[i] - commonOut[i])
 			v2 := (in2[j] - commonIn[j]) + (out2[i] - commonOut[i])
 			r1Raw.Data[i*r1Raw.Stride+j] = v1
@@ -363,7 +363,7 @@ func mergeParallelDelay(d1, d2 []float64, n int) []float64 {
 	s2 := sliceOrZeros(d2, n)
 	out := make([]float64, n)
 	allZero := true
-	for i := 0; i < n; i++ {
+	for i := range n {
 		out[i] = math.Min(s1[i], s2[i])
 		if out[i] != 0 {
 			allZero = false
@@ -392,7 +392,7 @@ func Feedback(plant, controller *System, sign float64) (*System, error) {
 			return nil, fmt.Errorf("feedback: plant must be square (m=p) when controller is nil, got %dx%d", m, p)
 		}
 		eyeData := make([]float64, m*m)
-		for i := 0; i < m; i++ {
+		for i := range m {
 			eyeData[i*(m+1)] = 1
 		}
 		var err error
@@ -431,7 +431,7 @@ func Feedback(plant, controller *System, sign float64) (*System, error) {
 	}
 
 	e12Data := make([]float64, m1*m1)
-	for i := 0; i < m1; i++ {
+	for i := range m1 {
 		e12Data[i*(m1+1)] = 1
 	}
 	E12 := mat.NewDense(m1, m1, e12Data)
@@ -538,10 +538,10 @@ func subBlock(dst *mat.Dense, r0, c0 int, src *mat.Dense) {
 	}
 	dRaw := dst.RawMatrix()
 	sRaw := src.RawMatrix()
-	for i := 0; i < sr; i++ {
+	for i := range sr {
 		dRow := dRaw.Data[(r0+i)*dRaw.Stride+c0:]
 		sRow := sRaw.Data[i*sRaw.Stride:]
-		for j := 0; j < sc; j++ {
+		for j := range sc {
 			dRow[j] -= sRow[j]
 		}
 	}
@@ -661,7 +661,7 @@ func resizeDense(src *mat.Dense, r, c int) *mat.Dense {
 	minC := min(sc, c)
 	sRaw := src.RawMatrix()
 	dRaw := dst.RawMatrix()
-	for i := 0; i < minR; i++ {
+	for i := range minR {
 		copy(dRaw.Data[i*dRaw.Stride:i*dRaw.Stride+minC], sRaw.Data[i*sRaw.Stride:i*sRaw.Stride+minC])
 	}
 	return dst
@@ -820,8 +820,8 @@ func seriesLFT(sys1, sys2 *System) (*System, error) {
 		if n2 > 0 {
 			c2sub := mulDense(s2.LFT.D21, s1.C)
 			r, c := c2sub.Dims()
-			for i := 0; i < r; i++ {
-				for j := 0; j < c; j++ {
+			for i := range r {
+				for j := range c {
 					c2.Set(N1+i, j, c2.At(N1+i, j)+c2sub.At(i, j))
 				}
 			}
@@ -874,7 +874,7 @@ func parallelLFT(sys1, sys2 *System) (*System, error) {
 		if s2Stripped.InputDelay == nil {
 			s2Stripped.InputDelay = make([]float64, m1)
 		}
-		for j := 0; j < m1; j++ {
+		for j := range m1 {
 			s1Stripped.InputDelay[j] -= commonIn[j]
 			s2Stripped.InputDelay[j] -= commonIn[j]
 		}
@@ -886,7 +886,7 @@ func parallelLFT(sys1, sys2 *System) (*System, error) {
 		if s2Stripped.OutputDelay == nil {
 			s2Stripped.OutputDelay = make([]float64, p1)
 		}
-		for i := 0; i < p1; i++ {
+		for i := range p1 {
 			s1Stripped.OutputDelay[i] -= commonOut[i]
 			s2Stripped.OutputDelay[i] -= commonOut[i]
 		}
@@ -1413,7 +1413,7 @@ func connectWithDelay(sys *System, Q *mat.Dense, inputs, outputs []int) (*System
 		Bfull.Mul(Bcore, E)
 		bfRaw := Bfull.RawMatrix()
 		for k, j := range inputs {
-			for i := 0; i < nH; i++ {
+			for i := range nH {
 				Bcl.Set(i, k, bfRaw.Data[i*bfRaw.Stride+j])
 			}
 		}
@@ -1464,7 +1464,7 @@ func connectWithDelay(sys *System, Q *mat.Dense, inputs, outputs []int) (*System
 		ErDout.Mul(Er, Dout)
 		erRaw := ErDout.RawMatrix()
 		for ki, oi := range outputs {
-			for j := 0; j < N; j++ {
+			for j := range N {
 				Dcl.Set(ki, mExt+j, erRaw.Data[oi*erRaw.Stride+j])
 			}
 		}
@@ -1472,7 +1472,7 @@ func connectWithDelay(sys *System, Q *mat.Dense, inputs, outputs []int) (*System
 		DinE := mat.NewDense(N, m, nil)
 		DinE.Mul(Din, E)
 		deRaw := DinE.RawMatrix()
-		for i := 0; i < N; i++ {
+		for i := range N {
 			for kj, ij := range inputs {
 				Dcl.Set(pExt+i, kj, deRaw.Data[i*deRaw.Stride+ij])
 			}
@@ -1576,7 +1576,7 @@ func connectSimple(sys *System, Q *mat.Dense, inputs, outputs []int, n, m, p int
 	bfRaw := Bfull.RawMatrix()
 	bcRaw := Bcl.RawMatrix()
 	for k, j := range inputs {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			bcRaw.Data[i*bcRaw.Stride+k] = bfRaw.Data[i*bfRaw.Stride+j]
 		}
 	}

--- a/connect_test.go
+++ b/connect_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"math/cmplx"
+	"slices"
 	"testing"
 
 	"gonum.org/v1/gonum/mat"
@@ -85,8 +86,8 @@ func TestSeries_MIMO(t *testing.T) {
 	h2 := evalTF(sys2, s)
 	hc := evalTF(result, s)
 
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			want := h2[i][0]*h1[0][j] + h2[i][1]*h1[1][j]
 			if cmplx.Abs(hc[i][j]-want) > 1e-8 {
 				t.Errorf("H[%d][%d] at s=j: got %v, want %v", i, j, hc[i][j], want)
@@ -666,7 +667,7 @@ func TestSeries_IntermediateDelayUniform(t *testing.T) {
 	if td == nil {
 		t.Fatal("TotalDelay should not be nil")
 	}
-	for j := 0; j < 2; j++ {
+	for j := range 2 {
 		if td.At(0, j) != 4 {
 			t.Errorf("TotalDelay[0][%d] = %v, want 4", j, td.At(0, j))
 		}
@@ -876,7 +877,7 @@ func TestSafeFeedback_DiscreteInputDelay(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 	clResp, _ := cl.Simulate(u, nil, nil)
@@ -1881,13 +1882,7 @@ func TestFeedbackKeepsInputDelay(t *testing.T) {
 	if !cl.HasInternalDelay() {
 		t.Fatal("plant OutputDelay should become internal delay")
 	}
-	found := false
-	for _, tau := range cl.LFT.Tau {
-		if tau == 2 {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(cl.LFT.Tau, 2)
 	if !found {
 		t.Errorf("InternalDelay should contain 2 (from OutputDelay), got %v", cl.LFT.Tau)
 	}

--- a/convert.go
+++ b/convert.go
@@ -80,7 +80,7 @@ func bilinear(sys *System, palpha, pbeta, alpha, beta float64) (*System, error) 
 	C := denseCopy(sys.C)
 
 	aRaw := A.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		aRaw.Data[i*aRaw.Stride+i] += palpha
 	}
 
@@ -119,7 +119,7 @@ func bilinear(sys *System, palpha, pbeta, alpha, beta float64) (*System, error) 
 	Ainv := mat.NewDense(n, n, nil)
 	eye := mat.NewDense(n, n, nil)
 	eyeRaw := eye.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		eyeRaw.Data[i*eyeRaw.Stride+i] = 1
 	}
 	err := lu.SolveTo(Ainv, false, eye)
@@ -133,7 +133,7 @@ func bilinear(sys *System, palpha, pbeta, alpha, beta float64) (*System, error) 
 	}
 	Ainv.Scale(-twoAB, Ainv)
 	ainvRaw := Ainv.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ainvRaw.Data[i*ainvRaw.Stride+i] += pbeta
 	}
 
@@ -224,15 +224,15 @@ func discretizeDelaysAsInternal(disc *System, contInputDelay, contOutputDelay []
 	dRaw := disc.D.RawMatrix()
 
 	newBData := make([]float64, n*m)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(newBData[i*m:i*m+m], bRaw.Data[i*bRaw.Stride:i*bRaw.Stride+m])
 	}
 	newCData := make([]float64, p*n)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(newCData[i*n:i*n+n], cRaw.Data[i*cRaw.Stride:i*cRaw.Stride+n])
 	}
 	newDData := make([]float64, p*m)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(newDData[i*m:i*m+m], dRaw.Data[i*dRaw.Stride:i*dRaw.Stride+m])
 	}
 
@@ -241,21 +241,21 @@ func discretizeDelaysAsInternal(disc *System, contInputDelay, contOutputDelay []
 		if f.isInput {
 			j := f.idx
 			d21Data[k*m+j] = 1
-			for i := 0; i < n; i++ {
+			for i := range n {
 				b2Data[i*N+k] = newBData[i*m+j]
 				newBData[i*m+j] = 0
 			}
-			for i := 0; i < p; i++ {
+			for i := range p {
 				d12Data[i*N+k] = newDData[i*m+j]
 				newDData[i*m+j] = 0
 			}
 		} else {
 			i := f.idx
-			for col := 0; col < n; col++ {
+			for col := range n {
 				c2Data[k*n+col] = newCData[i*n+col]
 				newCData[i*n+col] = 0
 			}
-			for col := 0; col < m; col++ {
+			for col := range m {
 				d21Data[k*m+col] = newDData[i*m+col]
 				newDData[i*m+col] = 0
 			}
@@ -424,7 +424,7 @@ func (sys *System) DiscretizeZOH(dt float64) (*System, error) {
 	mRaw := M.RawMatrix()
 	aRaw := sys.A.RawMatrix()
 	bRaw := sys.B.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		mRow := mRaw.Data[i*mRaw.Stride:]
 		aRow := aRaw.Data[i*aRaw.Stride : i*aRaw.Stride+n]
 		for j, v := range aRow {
@@ -442,7 +442,7 @@ func (sys *System) DiscretizeZOH(dt float64) (*System, error) {
 	emRaw := eM.RawMatrix()
 	adData := make([]float64, n*n)
 	bdData := make([]float64, n*m)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(adData[i*n:], emRaw.Data[i*emRaw.Stride:i*emRaw.Stride+n])
 		copy(bdData[i*m:], emRaw.Data[i*emRaw.Stride+n:i*emRaw.Stride+n+m])
 	}
@@ -554,18 +554,18 @@ func discretizeZOHAugmented(sys *System, dt float64) (*System, *mat.Dense, error
 		b2RawZ = sys.LFT.B2.RawMatrix()
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		row := mRaw.Data[i*mRaw.Stride:]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			row[j] = aRaw.Data[i*aRaw.Stride+j] * dt
 		}
 		if m > 0 {
-			for j := 0; j < m; j++ {
+			for j := range m {
 				row[n+j] = bRawZ.Data[i*bRawZ.Stride+j] * dt
 			}
 		}
 		if N > 0 {
-			for j := 0; j < N; j++ {
+			for j := range N {
 				row[n+m+j] = b2RawZ.Data[i*b2RawZ.Stride+j] * dt
 			}
 		}
@@ -578,7 +578,7 @@ func discretizeZOHAugmented(sys *System, dt float64) (*System, *mat.Dense, error
 	adData := make([]float64, n*n)
 	bdData := make([]float64, n*m)
 	bd2Data := make([]float64, n*N)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(adData[i*n:i*n+n], emRaw.Data[i*emRaw.Stride:i*emRaw.Stride+n])
 		if m > 0 {
 			copy(bdData[i*m:i*m+m], emRaw.Data[i*emRaw.Stride+n:i*emRaw.Stride+n+m])
@@ -630,7 +630,7 @@ func discretizeTustinAugmented(sys *System, dt float64) (*System, *mat.Dense, er
 	A := mat.NewDense(n, n, nil)
 	A.Copy(sys.A)
 	aRaw := A.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		aRaw.Data[i*aRaw.Stride+i] += palpha
 	}
 
@@ -658,10 +658,7 @@ func isStrictlyUpperTriangular(m *mat.Dense) bool {
 	}
 	raw := m.RawMatrix()
 	for i := 0; i < raw.Rows; i++ {
-		bound := i
-		if raw.Cols-1 < bound {
-			bound = raw.Cols - 1
-		}
+		bound := min(raw.Cols-1, i)
 		row := raw.Data[i*raw.Stride:]
 		for j := 0; j <= bound; j++ {
 			if row[j] != 0 {
@@ -799,16 +796,16 @@ func (sys *System) DiscretizeFOH(dt float64) (*System, error) {
 	aRaw := sys.A.RawMatrix()
 	bRaw := sys.B.RawMatrix()
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		row := mRaw.Data[i*mRaw.Stride:]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			row[j] = aRaw.Data[i*aRaw.Stride+j] * dt
 		}
-		for j := 0; j < m; j++ {
+		for j := range m {
 			row[n+j] = bRaw.Data[i*bRaw.Stride+j] * dt
 		}
 	}
-	for i := 0; i < m; i++ {
+	for i := range m {
 		mRaw.Data[(n+i)*mRaw.Stride+n+m+i] = 1
 	}
 
@@ -819,7 +816,7 @@ func (sys *System) DiscretizeFOH(dt float64) (*System, error) {
 	adData := make([]float64, n*n)
 	g0Data := make([]float64, n*m)
 	g1Data := make([]float64, n*m)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(adData[i*n:i*n+n], emRaw.Data[i*emRaw.Stride:i*emRaw.Stride+n])
 		copy(g0Data[i*m:i*m+m], emRaw.Data[i*emRaw.Stride+n:i*emRaw.Stride+n+m])
 		copy(g1Data[i*m:i*m+m], emRaw.Data[i*emRaw.Stride+n+m:i*emRaw.Stride+n+2*m])
@@ -832,13 +829,13 @@ func fohPureGain(sys *System, m, p int, dt float64) (*System, error) {
 	nNew := m
 	aData := make([]float64, nNew*nNew)
 	bData := make([]float64, nNew*m)
-	for j := 0; j < m; j++ {
+	for j := range m {
 		bData[j*m+j] = 1
 	}
 	cData := make([]float64, p*nNew)
 	if sys.D != nil {
 		dRaw := sys.D.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(cData[i*nNew:i*nNew+m], dRaw.Data[i*dRaw.Stride:i*dRaw.Stride+m])
 		}
 	}
@@ -869,29 +866,29 @@ func buildFOHSystem(sys *System, n, m, p int, dt float64, adData, g0Data, g1Data
 
 	nNew := n + m
 	aFoh := make([]float64, nNew*nNew)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(aFoh[i*nNew:i*nNew+n], adData[i*n:i*n+n])
 		copy(aFoh[i*nNew+n:i*nNew+n+m], b0Data[i*m:i*m+m])
 	}
 
 	bFoh := make([]float64, nNew*m)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(bFoh[i*m:i*m+m], g1Data[i*m:i*m+m])
 	}
-	for j := 0; j < m; j++ {
+	for j := range m {
 		bFoh[(n+j)*m+j] = 1
 	}
 
 	cFoh := make([]float64, p*nNew)
 	if sys.C != nil {
 		cRaw := sys.C.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(cFoh[i*nNew:i*nNew+n], cRaw.Data[i*cRaw.Stride:i*cRaw.Stride+n])
 		}
 	}
 	if sys.D != nil {
 		dRaw := sys.D.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(cFoh[i*nNew+n:i*nNew+n+m], dRaw.Data[i*dRaw.Stride:i*dRaw.Stride+m])
 		}
 	}
@@ -957,23 +954,23 @@ func discretizeFOHAugmented(sys *System, dt float64) (*System, *mat.Dense, error
 		b2Raw = sys.LFT.B2.RawMatrix()
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		row := mRaw.Data[i*mRaw.Stride:]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			row[j] = aRaw.Data[i*aRaw.Stride+j] * dt
 		}
 		if m > 0 {
-			for j := 0; j < m; j++ {
+			for j := range m {
 				row[n+j] = bRaw.Data[i*bRaw.Stride+j] * dt
 			}
 		}
 		if N > 0 {
-			for j := 0; j < N; j++ {
+			for j := range N {
 				row[n+m+j] = b2Raw.Data[i*b2Raw.Stride+j] * dt
 			}
 		}
 	}
-	for i := 0; i < mTotal; i++ {
+	for i := range mTotal {
 		mRaw.Data[(n+i)*mRaw.Stride+n+mTotal+i] = 1
 	}
 
@@ -985,7 +982,7 @@ func discretizeFOHAugmented(sys *System, dt float64) (*System, *mat.Dense, error
 	g0BData := make([]float64, n*m)
 	g1BData := make([]float64, n*m)
 	g0B2Data := make([]float64, n*N)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(adData[i*n:i*n+n], emRaw.Data[i*emRaw.Stride:i*emRaw.Stride+n])
 		if m > 0 {
 			copy(g0BData[i*m:i*m+m], emRaw.Data[i*emRaw.Stride+n:i*emRaw.Stride+n+m])
@@ -1058,7 +1055,7 @@ func (sys *System) DiscretizeMatched(dt float64) (*System, error) {
 		discZeros[i] = cmplx.Exp(z * complex(dt, 0))
 	}
 	excess := len(contPoles) - len(contZeros)
-	for i := 0; i < excess; i++ {
+	for range excess {
 		discZeros = append(discZeros, complex(-1, 0))
 	}
 
@@ -1180,7 +1177,7 @@ func (sys *System) d2cZOH() (*System, error) {
 		AminusI := mat.NewDense(n, n, nil)
 		AminusI.Copy(sys.A)
 		raw := AminusI.RawMatrix()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			raw.Data[i*raw.Stride+i] -= 1
 		}
 		var lu mat.LU

--- a/convert_test.go
+++ b/convert_test.go
@@ -1266,12 +1266,12 @@ func TestImpulse_ImpulseResponseMatch(t *testing.T) {
 	eA.Exp(Adt)
 
 	AkT := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		AkT.Set(i, i, 1)
 	}
 
 	AdPow := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		AdPow.Set(i, i, 1)
 	}
 
@@ -1384,21 +1384,21 @@ func TestFOH_PureGain(t *testing.T) {
 	if n != 3 || m != 3 || p != 2 {
 		t.Fatalf("dims = %d,%d,%d, want 3,3,2", n, m, p)
 	}
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			if disc.A.At(i, j) != 0 {
 				t.Errorf("A[%d,%d] = %v, want 0", i, j, disc.A.At(i, j))
 			}
 		}
 	}
-	for j := 0; j < m; j++ {
+	for j := range m {
 		if disc.B.At(j, j) != 1 {
 			t.Errorf("B[%d,%d] = %v, want 1", j, j, disc.B.At(j, j))
 		}
 	}
 	assertMatClose(t, "C", disc.C, D, 1e-14)
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			if disc.D.At(i, j) != 0 {
 				t.Errorf("D[%d,%d] = %v, want 0", i, j, disc.D.At(i, j))
 			}

--- a/covar.go
+++ b/covar.go
@@ -24,7 +24,7 @@ func Covar(sys *System, W *mat.Dense) (*mat.Dense, error) {
 
 	// symmetrize Q for Lyapunov solver
 	qRaw := Q.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		for j := i + 1; j < n; j++ {
 			avg := (qRaw.Data[i*qRaw.Stride+j] + qRaw.Data[j*qRaw.Stride+i]) / 2
 			qRaw.Data[i*qRaw.Stride+j] = avg

--- a/crossval_test.go
+++ b/crossval_test.go
@@ -79,8 +79,8 @@ func assertMatNear(t *testing.T, label string, got, want *mat.Dense, tol float64
 	if gr != wr || gc != wc {
 		t.Fatalf("%s: dims (%d,%d), want (%d,%d)", label, gr, gc, wr, wc)
 	}
-	for i := 0; i < gr; i++ {
-		for j := 0; j < gc; j++ {
+	for i := range gr {
+		for j := range gc {
 			if math.Abs(got.At(i, j)-want.At(i, j)) > tol {
 				t.Errorf("%s: [%d,%d] = %g, want %g", label, i, j, got.At(i, j), want.At(i, j))
 			}
@@ -242,8 +242,8 @@ func TestCrossval_Tustin_Reference(t *testing.T) {
 	}
 
 	adTruth := 5.0 / 3.0
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			want := 0.0
 			if i == j {
 				want = adTruth
@@ -256,7 +256,7 @@ func TestCrossval_Tustin_Reference(t *testing.T) {
 
 	sinPi4 := math.Sin(math.Pi / 4)
 	bdTruth := (1.0 / 3.0) / sinPi4
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if math.Abs(hd.B.At(i, 0)-bdTruth) > 1e-10 {
 			t.Errorf("Bd[%d,0] = %g, want %g", i, hd.B.At(i, 0), bdTruth)
 		}
@@ -268,8 +268,8 @@ func TestCrossval_Tustin_Reference(t *testing.T) {
 		{4.0 / 3.0, 1.0 / 3.0},
 	})
 	cr, cc := cdTruth.Dims()
-	for i := 0; i < cr; i++ {
-		for j := 0; j < cc; j++ {
+	for i := range cr {
+		for j := range cc {
 			cdTruth.Set(i, j, cdTruth.At(i, j)*sinPi4)
 		}
 	}
@@ -747,8 +747,8 @@ func TestCrossval_FreqResp_PythonControl(t *testing.T) {
 	}
 
 	for k, w := range trueOmega {
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				h := resp.At(k, i, j)
 				gotMag := cmplx.Abs(h)
 				gotPhase := cmplx.Phase(h)
@@ -793,8 +793,8 @@ func TestCrossval_EvalFr_PythonControl(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			if cmplx.Abs(resp[i][j]-wantResp[i][j]) > 1e-3 {
 				t.Errorf("[%d][%d] = %v, want %v", i, j, resp[i][j], wantResp[i][j])
 			}
@@ -885,8 +885,8 @@ func TestCrossval_DCGain_MIMO(t *testing.T) {
 		{21, 14},
 		{33, 22},
 	}
-	for i := 0; i < 3; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 3 {
+		for j := range 2 {
 			got := real(resp[i][j])
 			if math.Abs(got-expected[i][j]) > 1e-10 {
 				t.Errorf("[%d][%d] DC gain = %g, want %g", i, j, got, expected[i][j])
@@ -1145,8 +1145,8 @@ func TestCrossval_Bilinear_FreqResponseMatch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				if cmplx.Abs(hc[i][j]-hd[i][j]) > 1e-8 {
 					t.Errorf("w=%g [%d][%d]: cont=%v, disc=%v", w, i, j, hc[i][j], hd[i][j])
 				}
@@ -1375,7 +1375,7 @@ func TestCrossval_ZOH_StepResponse(t *testing.T) {
 
 	steps := 100
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1.0) // unit step
 	}
 
@@ -1387,7 +1387,7 @@ func TestCrossval_ZOH_StepResponse(t *testing.T) {
 	// Position at time T = n*dt with unit acceleration: y = 0.5*t²
 	// Last sample: t = (steps-1)*dt, but simulation output at step k
 	// corresponds to after k inputs. y[k] ≈ 0.5*(k*dt)²
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		tK := float64(k) * dt
 		expected := 0.5 * tK * tK
 		got := resp.Y.At(0, k)
@@ -1568,8 +1568,8 @@ func TestCrossval_MinReal_MIMO(t *testing.T) {
 		s := complex(0, w)
 		h1, _ := sys.EvalFr(s)
 		h2, _ := reduced.Sys.EvalFr(s)
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				if cmplx.Abs(h1[i][j]-h2[i][j]) > 1e-4 {
 					t.Errorf("w=%g [%d][%d]: orig=%v, reduced=%v", w, i, j, h1[i][j], h2[i][j])
 				}

--- a/delay.go
+++ b/delay.go
@@ -3,6 +3,7 @@ package controlsys
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"gonum.org/v1/gonum/blas/blas64"
 	"gonum.org/v1/gonum/mat"
@@ -68,10 +69,8 @@ func (sys *System) SetInternalDelay(tau []float64, B2, C2, D12, D21, D22 *mat.De
 	if err := validateSliceDelay(tau, N, sys.Dt); err != nil {
 		return err
 	}
-	for _, v := range tau {
-		if v == 0 {
-			return ErrZeroInternalDelay
-		}
+	if slices.Contains(tau, 0) {
+		return ErrZeroInternalDelay
 	}
 	if err := validateLFTDims(n, m, p, N, B2, C2, D12, D21, D22); err != nil {
 		return err
@@ -149,20 +148,20 @@ func effectiveIODelayData(sys *System, p, m int, includeDelayMatrix bool) []floa
 	data := make([]float64, p*m)
 	if includeDelayMatrix && sys.Delay != nil {
 		raw := sys.Delay.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(data[i*m:i*m+m], raw.Data[i*raw.Stride:i*raw.Stride+m])
 		}
 	}
 	if sys.InputDelay != nil {
-		for j := 0; j < m; j++ {
-			for i := 0; i < p; i++ {
+		for j := range m {
+			for i := range p {
 				data[i*m+j] += sys.InputDelay[j]
 			}
 		}
 	}
 	if sys.OutputDelay != nil {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				data[i*m+j] += sys.OutputDelay[i]
 			}
 		}
@@ -333,7 +332,7 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 
 	delays := make([]int, N)
 	totalShift := 0
-	for j := 0; j < N; j++ {
+	for j := range N {
 		delays[j] = int(math.Round(tau[j] / sys.Dt))
 		totalShift += delays[j]
 	}
@@ -361,18 +360,18 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 
 	if n > 0 {
 		hA := H.A.RawMatrix()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			copy(aAug[i*nAug:i*nAug+n], hA.Data[i*hA.Stride:i*hA.Stride+n])
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			copy(bAug[i*m:i*m+m], hB.Data[i*hB.Stride:i*hB.Stride+m])
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(cAug[i*nAug:i*nAug+n], hC.Data[i*hC.Stride:i*hC.Stride+n])
 		}
 	}
 
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(dAug[i*m:i*m+m], hD.Data[i*hD.Stride:i*hD.Stride+m])
 	}
 
@@ -391,7 +390,7 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 	// So the loop w -> D22*w is resolved by the shift registers, no algebraic loop.
 
 	offset := n
-	for j := 0; j < N; j++ {
+	for j := range N {
 		dj := delays[j]
 		if dj == 0 {
 			continue
@@ -400,11 +399,11 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 		// s_1[k+1] = C2[j,:]*x[k] + D21[j,:]*u[k]
 		// (D22 contribution is handled after all shift chains are placed)
 		if n > 0 {
-			for col := 0; col < n; col++ {
+			for col := range n {
 				aAug[offset*nAug+col] = hC.Data[(p+j)*hC.Stride+col]
 			}
 		}
-		for col := 0; col < m; col++ {
+		for col := range m {
 			bAug[offset*m+col] = hD.Data[(p+j)*hD.Stride+col]
 		}
 
@@ -420,18 +419,18 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 	// Build a map from delay index to its last shift state column.
 	lastState := make([]int, N)
 	off := n
-	for j := 0; j < N; j++ {
+	for j := range N {
 		lastState[j] = off + delays[j] - 1
 		off += delays[j]
 	}
 
 	off = n
-	for j := 0; j < N; j++ {
+	for j := range N {
 		dj := delays[j]
 		if dj == 0 {
 			continue
 		}
-		for k := 0; k < N; k++ {
+		for k := range N {
 			dk := delays[k]
 			if dk == 0 {
 				continue
@@ -448,8 +447,8 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 	// through the shift chain last states.
 	// Original A_aug[i, lastState[j]] += B2[i,j] for the original state rows.
 	if n > 0 {
-		for i := 0; i < n; i++ {
-			for j := 0; j < N; j++ {
+		for i := range n {
+			for j := range N {
 				if delays[j] == 0 {
 					continue
 				}
@@ -462,8 +461,8 @@ func absorbInternalDiscreteDelay(sys *System) (*System, error) {
 	}
 
 	// D12 columns: C_aug[i, lastState[j]] += D12[i,j]
-	for i := 0; i < p; i++ {
-		for j := 0; j < N; j++ {
+	for i := range p {
+		for j := range N {
 			if delays[j] == 0 {
 				continue
 			}
@@ -507,7 +506,7 @@ func absorbInternalContinuousDelay(sys *System) (*System, error) {
 	// Build a block-diagonal Padé delay bank for all internal delays.
 	// delayBank is N-input, N-output.
 	var delayBank *System
-	for j := 0; j < N; j++ {
+	for j := range N {
 		pade, err := PadeDelay(tau[j], 5)
 		if err != nil {
 			return nil, fmt.Errorf("absorbInternalDelay: Padé for delay %d: %w", j, err)
@@ -609,19 +608,19 @@ func absorbInternalContinuousDelay(sys *System) (*System, error) {
 			copy(B2.RawMatrix().Data[i*N:i*N+N], hbRaw.Data[i*hbRaw.Stride+m:i*hbRaw.Stride+mN])
 		}
 		hcRaw := H.C.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(C1.RawMatrix().Data[i*nh:i*nh+nh], hcRaw.Data[i*hcRaw.Stride:i*hcRaw.Stride+nh])
 		}
-		for i := 0; i < N; i++ {
+		for i := range N {
 			copy(C2.RawMatrix().Data[i*nh:i*nh+nh], hcRaw.Data[(p+i)*hcRaw.Stride:(p+i)*hcRaw.Stride+nh])
 		}
 	}
 	hdRaw := H.D.RawMatrix()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(D11.RawMatrix().Data[i*m:i*m+m], hdRaw.Data[i*hdRaw.Stride:i*hdRaw.Stride+m])
 		copy(D12.RawMatrix().Data[i*N:i*N+N], hdRaw.Data[i*hdRaw.Stride+m:i*hdRaw.Stride+mN])
 	}
-	for i := 0; i < N; i++ {
+	for i := range N {
 		copy(D21.RawMatrix().Data[i*m:i*m+m], hdRaw.Data[(p+i)*hdRaw.Stride:(p+i)*hdRaw.Stride+m])
 		copy(D22.RawMatrix().Data[i*N:i*N+N], hdRaw.Data[(p+i)*hdRaw.Stride+m:(p+i)*hdRaw.Stride+mN])
 	}
@@ -632,7 +631,7 @@ func absorbInternalContinuousDelay(sys *System) (*System, error) {
 	D22Dd.Mul(D22, Dd)
 	E := mat.NewDense(N, N, nil)
 	eRaw := E.RawMatrix()
-	for i := 0; i < N; i++ {
+	for i := range N {
 		eRaw.Data[i*eRaw.Stride+i] = 1
 	}
 	E.Sub(E, D22Dd)
@@ -640,7 +639,7 @@ func absorbInternalContinuousDelay(sys *System) (*System, error) {
 	lu.Factorize(E)
 	D22Dd.Zero()
 	idRaw := D22Dd.RawMatrix()
-	for i := 0; i < N; i++ {
+	for i := range N {
 		idRaw.Data[i*idRaw.Stride+i] = 1
 	}
 	Einv := mat.NewDense(N, N, nil)
@@ -771,10 +770,10 @@ func addBlock(dst *mat.Dense, r0, c0 int, src *mat.Dense) {
 	}
 	dRaw := dst.RawMatrix()
 	sRaw := src.RawMatrix()
-	for i := 0; i < sr; i++ {
+	for i := range sr {
 		dRow := dRaw.Data[(r0+i)*dRaw.Stride+c0:]
 		sRow := sRaw.Data[i*sRaw.Stride:]
-		for j := 0; j < sc; j++ {
+		for j := range sc {
 			dRow[j] += sRow[j]
 		}
 	}
@@ -790,8 +789,8 @@ func absorbIODelay(sys *System) (*System, error) {
 
 	hasNonzero := false
 	raw := sys.Delay.RawMatrix()
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			if raw.Data[i*raw.Stride+j] != 0 {
 				hasNonzero = true
 				break
@@ -814,14 +813,14 @@ func absorbIODelay(sys *System) (*System, error) {
 	if cp.InputDelay == nil {
 		cp.InputDelay = make([]float64, m)
 	}
-	for j := 0; j < m; j++ {
+	for j := range m {
 		cp.InputDelay[j] += inDel[j]
 	}
 
 	if cp.OutputDelay == nil {
 		cp.OutputDelay = make([]float64, p)
 	}
-	for i := 0; i < p; i++ {
+	for i := range p {
 		cp.OutputDelay[i] += outDel[i]
 	}
 
@@ -905,14 +904,14 @@ func absorbInputDelay(sys *System) (*System, error) {
 
 	if n > 0 {
 		aRaw := sys.A.RawMatrix()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			copy(aAug[i*nAug:i*nAug+n], aRaw.Data[i*aRaw.Stride:i*aRaw.Stride+n])
 		}
 	}
 
 	if n > 0 {
 		cRaw := sys.C.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(cAug[i*nAug:i*nAug+n], cRaw.Data[i*cRaw.Stride:i*cRaw.Stride+n])
 		}
 	}
@@ -921,15 +920,15 @@ func absorbInputDelay(sys *System) (*System, error) {
 	dRaw := sys.D.RawMatrix()
 
 	offset := n
-	for j := 0; j < m; j++ {
+	for j := range m {
 		dj := delays[j]
 		if dj == 0 {
 			if n > 0 {
-				for i := 0; i < n; i++ {
+				for i := range n {
 					bAug[i*m+j] = bRaw.Data[i*bRaw.Stride+j]
 				}
 			}
-			for i := 0; i < p; i++ {
+			for i := range p {
 				dAug[i*m+j] = dRaw.Data[i*dRaw.Stride+j]
 			}
 			continue
@@ -943,11 +942,11 @@ func absorbInputDelay(sys *System) (*System, error) {
 
 		lastShift := offset + dj - 1
 		if n > 0 {
-			for i := 0; i < n; i++ {
+			for i := range n {
 				aAug[i*nAug+lastShift] = bRaw.Data[i*bRaw.Stride+j]
 			}
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			cAug[i*nAug+lastShift] += dRaw.Data[i*dRaw.Stride+j]
 		}
 
@@ -1003,12 +1002,12 @@ func absorbOutputDelay(sys *System) (*System, error) {
 
 	if n > 0 {
 		aRaw := sys.A.RawMatrix()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			copy(aAug[i*nAug:i*nAug+n], aRaw.Data[i*aRaw.Stride:i*aRaw.Stride+n])
 		}
 
 		bRaw := sys.B.RawMatrix()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			copy(bAug[i*m:i*m+m], bRaw.Data[i*bRaw.Stride:i*bRaw.Stride+m])
 		}
 	}
@@ -1017,7 +1016,7 @@ func absorbOutputDelay(sys *System) (*System, error) {
 	dRaw := sys.D.RawMatrix()
 
 	offset := n
-	for i := 0; i < p; i++ {
+	for i := range p {
 		di := delays[i]
 		if di == 0 {
 			if n > 0 {
@@ -1140,8 +1139,8 @@ func absorbIODelayContinuous(sys *System, order int) (*System, error) {
 
 	hasNonzero := false
 	raw := sys.Delay.RawMatrix()
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			if raw.Data[i*raw.Stride+j] != 0 {
 				hasNonzero = true
 				break
@@ -1164,14 +1163,14 @@ func absorbIODelayContinuous(sys *System, order int) (*System, error) {
 	if cp.InputDelay == nil {
 		cp.InputDelay = make([]float64, m)
 	}
-	for j := 0; j < m; j++ {
+	for j := range m {
 		cp.InputDelay[j] += inDel[j]
 	}
 
 	if cp.OutputDelay == nil {
 		cp.OutputDelay = make([]float64, p)
 	}
-	for i := 0; i < p; i++ {
+	for i := range p {
 		cp.OutputDelay[i] += outDel[i]
 	}
 
@@ -1250,9 +1249,9 @@ func decomposeInputFirst(data []float64, stride, p, m int) (inputDelay, outputDe
 	outputDelay = make([]float64, p)
 	residual = make([]float64, p*m)
 
-	for j := 0; j < m; j++ {
+	for j := range m {
 		mn := math.Inf(1)
-		for i := 0; i < p; i++ {
+		for i := range p {
 			if v := data[i*stride+j]; v < mn {
 				mn = v
 			}
@@ -1260,15 +1259,15 @@ func decomposeInputFirst(data []float64, stride, p, m int) (inputDelay, outputDe
 		inputDelay[j] = mn
 	}
 
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			residual[i*m+j] = data[i*stride+j] - inputDelay[j]
 		}
 	}
 
-	for i := 0; i < p; i++ {
+	for i := range p {
 		mn := math.Inf(1)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			if v := residual[i*m+j]; v < mn {
 				mn = v
 			}
@@ -1276,8 +1275,8 @@ func decomposeInputFirst(data []float64, stride, p, m int) (inputDelay, outputDe
 		outputDelay[i] = mn
 	}
 
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			residual[i*m+j] -= outputDelay[i]
 		}
 	}
@@ -1290,9 +1289,9 @@ func decomposeOutputFirst(data []float64, stride, p, m int) (inputDelay, outputD
 	outputDelay = make([]float64, p)
 	residual = make([]float64, p*m)
 
-	for i := 0; i < p; i++ {
+	for i := range p {
 		mn := math.Inf(1)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			if v := data[i*stride+j]; v < mn {
 				mn = v
 			}
@@ -1300,15 +1299,15 @@ func decomposeOutputFirst(data []float64, stride, p, m int) (inputDelay, outputD
 		outputDelay[i] = mn
 	}
 
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			residual[i*m+j] = data[i*stride+j] - outputDelay[i]
 		}
 	}
 
-	for j := 0; j < m; j++ {
+	for j := range m {
 		mn := math.Inf(1)
-		for i := 0; i < p; i++ {
+		for i := range p {
 			if v := residual[i*m+j]; v < mn {
 				mn = v
 			}
@@ -1316,8 +1315,8 @@ func decomposeOutputFirst(data []float64, stride, p, m int) (inputDelay, outputD
 		inputDelay[j] = mn
 	}
 
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			residual[i*m+j] -= inputDelay[j]
 		}
 	}
@@ -1351,13 +1350,13 @@ func (sys *System) PullDelaysToLFT() (*System, error) {
 		if cur.InputDelay == nil {
 			cur.InputDelay = make([]float64, m)
 		}
-		for j := 0; j < m; j++ {
+		for j := range m {
 			cur.InputDelay[j] += inDel[j]
 		}
 		if cur.OutputDelay == nil {
 			cur.OutputDelay = make([]float64, p)
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			cur.OutputDelay[i] += outDel[i]
 		}
 
@@ -1384,19 +1383,19 @@ func (sys *System) PullDelaysToLFT() (*System, error) {
 			// handler below to avoid double-counting feedthrough.
 			resRaw := residual.RawMatrix()
 			if n == 0 && cur.InputDelay != nil {
-				for j := 0; j < m; j++ {
+				for j := range m {
 					if cur.InputDelay[j] == 0 {
 						continue
 					}
 					colHasRes := false
-					for i := 0; i < p; i++ {
+					for i := range p {
 						if resRaw.Data[i*resRaw.Stride+j] > 0 {
 							colHasRes = true
 							break
 						}
 					}
 					if colHasRes {
-						for i := 0; i < p; i++ {
+						for i := range p {
 							resRaw.Data[i*resRaw.Stride+j] += cur.InputDelay[j]
 						}
 						cur.InputDelay[j] = 0
@@ -1404,7 +1403,7 @@ func (sys *System) PullDelaysToLFT() (*System, error) {
 				}
 			}
 			if n == 0 && cur.OutputDelay != nil {
-				for i := 0; i < p; i++ {
+				for i := range p {
 					if cur.OutputDelay[i] == 0 {
 						continue
 					}
@@ -1447,8 +1446,8 @@ func (sys *System) PullDelaysToLFT() (*System, error) {
 	}
 	if cur.Delay != nil {
 		raw := cur.Delay.RawMatrix()
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				v := raw.Data[i*raw.Stride+j]
 				if v > 0 {
 					entries = append(entries, delayEntry{i, j, v, 'd'})
@@ -1523,12 +1522,12 @@ func (sys *System) PullDelaysToLFT() (*System, error) {
 		case 'i':
 			j := e.col
 			if n > 0 {
-				for i := 0; i < n; i++ {
+				for i := range n {
 					b2Raw.Data[i*b2Raw.Stride+idx] = curBRaw.Data[i*curBRaw.Stride+j]
 					newBRaw.Data[i*newBRaw.Stride+j] = 0
 				}
 			}
-			for i := 0; i < p; i++ {
+			for i := range p {
 				dVal := curDRaw.Data[i*curDRaw.Stride+j]
 				if !outputDelayRows[i] {
 					d12Raw.Data[i*d12Raw.Stride+idx] = dVal
@@ -1540,12 +1539,12 @@ func (sys *System) PullDelaysToLFT() (*System, error) {
 		case 'o':
 			i := e.row
 			if n > 0 {
-				for j := 0; j < n; j++ {
+				for j := range n {
 					c2Raw.Data[idx*c2Raw.Stride+j] = curCRaw.Data[i*curCRaw.Stride+j]
 					newCRaw.Data[i*newCRaw.Stride+j] = 0
 				}
 			}
-			for j := 0; j < m; j++ {
+			for j := range m {
 				dVal := curDRaw.Data[i*curDRaw.Stride+j]
 				if inIdx, ok := inputDelayIdx[j]; ok {
 					d22Raw.Data[idx*d22Raw.Stride+inIdx] = dVal
@@ -1701,26 +1700,26 @@ func SetDelayModel(H *System, tau []float64) (*System, error) {
 
 	if n > 0 {
 		hbRaw := H.B.RawMatrix()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			copy(bData[i*m:i*m+m], hbRaw.Data[i*hbRaw.Stride:i*hbRaw.Stride+m])
 			copy(b2Data[i*N:i*N+N], hbRaw.Data[i*hbRaw.Stride+m:i*hbRaw.Stride+mN])
 		}
 
 		hcRaw := H.C.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(cData[i*n:i*n+n], hcRaw.Data[i*hcRaw.Stride:i*hcRaw.Stride+n])
 		}
-		for i := 0; i < N; i++ {
+		for i := range N {
 			copy(c2Data[i*n:i*n+n], hcRaw.Data[(p+i)*hcRaw.Stride:(p+i)*hcRaw.Stride+n])
 		}
 	}
 
 	hdRaw := H.D.RawMatrix()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(dData[i*m:i*m+m], hdRaw.Data[i*hdRaw.Stride:i*hdRaw.Stride+m])
 		copy(d12Data[i*N:i*N+N], hdRaw.Data[i*hdRaw.Stride+m:i*hdRaw.Stride+mN])
 	}
-	for i := 0; i < N; i++ {
+	for i := range N {
 		copy(d21Data[i*m:i*m+m], hdRaw.Data[(p+i)*hdRaw.Stride:(p+i)*hdRaw.Stride+m])
 		copy(d22Data[i*N:i*N+N], hdRaw.Data[(p+i)*hdRaw.Stride+m:(p+i)*hdRaw.Stride+mN])
 	}
@@ -1788,8 +1787,8 @@ func validateDelay(delay *mat.Dense, p, m int, dt float64) error {
 		return fmt.Errorf("delay %d×%d != p×m %d×%d: %w", dr, dc, p, m, ErrDimensionMismatch)
 	}
 	raw := delay.RawMatrix()
-	for i := 0; i < dr; i++ {
-		for j := 0; j < dc; j++ {
+	for i := range dr {
+		for j := range dc {
 			v := raw.Data[i*raw.Stride+j]
 			if v < 0 {
 				return ErrNegativeDelay
@@ -1819,7 +1818,7 @@ func denseToSlice2D(m *mat.Dense) [][]float64 {
 	raw := m.RawMatrix()
 	r, c := raw.Rows, raw.Cols
 	out := make([][]float64, r)
-	for i := 0; i < r; i++ {
+	for i := range r {
 		out[i] = make([]float64, c)
 		copy(out[i], raw.Data[i*raw.Stride:i*raw.Stride+c])
 	}
@@ -1836,7 +1835,7 @@ func slice2DToDense(s [][]float64) *mat.Dense {
 	}
 	m := len(s[0])
 	data := make([]float64, p*m)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		copy(data[i*m:], s[i][:m])
 	}
 	return mat.NewDense(p, m, data)
@@ -1851,7 +1850,7 @@ func (sys *System) MinimalLFT() (*System, error) {
 	n, m, p := sys.Dims()
 
 	keep := make([]int, 0, N)
-	for j := 0; j < N; j++ {
+	for j := range N {
 		if !isZeroGainChannel(sys, j, n, m, p, N) {
 			keep = append(keep, j)
 		}
@@ -1901,16 +1900,16 @@ func lftSelectChannels(sys *System, keep []int, n, m, p int) *System {
 
 	for ki, j := range keep {
 		newTau[ki] = sys.LFT.Tau[j]
-		for i := 0; i < n; i++ {
+		for i := range n {
 			nb2.Data[i*nb2.Stride+ki] = b2Raw.Data[i*b2Raw.Stride+j]
 		}
-		for i := 0; i < n; i++ {
+		for i := range n {
 			nc2.Data[ki*nc2.Stride+i] = c2Raw.Data[j*c2Raw.Stride+i]
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			nd12.Data[i*nd12.Stride+ki] = d12Raw.Data[i*d12Raw.Stride+j]
 		}
-		for i := 0; i < m; i++ {
+		for i := range m {
 			nd21.Data[ki*nd21.Stride+i] = d21Raw.Data[j*d21Raw.Stride+i]
 		}
 		for kj, jj := range keep {
@@ -1943,7 +1942,7 @@ func lftMergeProportional(sys *System, n, m, p int) *System {
 		alpha[i] = 1
 	}
 
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if merged[i] != i {
 			continue
 		}
@@ -1967,7 +1966,7 @@ func lftMergeProportional(sys *System, n, m, p int) *System {
 	}
 
 	changed := false
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if merged[i] != i {
 			changed = true
 			break
@@ -1978,7 +1977,7 @@ func lftMergeProportional(sys *System, n, m, p int) *System {
 	}
 
 	reps := make([]int, 0, N)
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if merged[i] == i {
 			reps = append(reps, i)
 		}
@@ -2007,22 +2006,22 @@ func lftMergeProportional(sys *System, n, m, p int) *System {
 
 	for ki, r := range reps {
 		newTau[ki] = sys.LFT.Tau[r]
-		for i := 0; i < n; i++ {
+		for i := range n {
 			nc2.Data[ki*nc2.Stride+i] = c2Raw.Data[r*c2Raw.Stride+i]
 		}
-		for i := 0; i < m; i++ {
+		for i := range m {
 			nd21.Data[ki*nd21.Stride+i] = d21Raw.Data[r*d21Raw.Stride+i]
 		}
 	}
 
-	for j := 0; j < N; j++ {
+	for j := range N {
 		r := merged[j]
 		ki := repIdx[r]
 		a := alpha[j]
-		for i := 0; i < n; i++ {
+		for i := range n {
 			nb2.Data[i*nb2.Stride+ki] += a * b2Raw.Data[i*b2Raw.Stride+j]
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			nd12.Data[i*nd12.Stride+ki] += a * d12Raw.Data[i*d12Raw.Stride+j]
 		}
 	}
@@ -2052,7 +2051,7 @@ func proportionalRows(c2Raw, d21Raw blas64.General, i, j, n, m int, tol float64)
 	var a float64
 	found := false
 
-	for k := 0; k < n; k++ {
+	for k := range n {
 		vi := c2Raw.Data[i*c2Raw.Stride+k]
 		vj := c2Raw.Data[j*c2Raw.Stride+k]
 		if math.Abs(vi) <= tol && math.Abs(vj) <= tol {
@@ -2070,7 +2069,7 @@ func proportionalRows(c2Raw, d21Raw blas64.General, i, j, n, m int, tol float64)
 		}
 	}
 
-	for k := 0; k < m; k++ {
+	for k := range m {
 		vi := d21Raw.Data[i*d21Raw.Stride+k]
 		vj := d21Raw.Data[j*d21Raw.Stride+k]
 		if math.Abs(vi) <= tol && math.Abs(vj) <= tol {
@@ -2097,31 +2096,31 @@ func proportionalRows(c2Raw, d21Raw blas64.General, i, j, n, m int, tol float64)
 func isZeroGainChannel(sys *System, j, n, m, p, N int) bool {
 	const tol = 1e-15
 	b2Raw := sys.LFT.B2.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if math.Abs(b2Raw.Data[i*b2Raw.Stride+j]) > tol {
 			return false
 		}
 	}
 	d12Raw := sys.LFT.D12.RawMatrix()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		if math.Abs(d12Raw.Data[i*d12Raw.Stride+j]) > tol {
 			return false
 		}
 	}
 	c2Raw := sys.LFT.C2.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if math.Abs(c2Raw.Data[j*c2Raw.Stride+i]) > tol {
 			return false
 		}
 	}
 	d21Raw := sys.LFT.D21.RawMatrix()
-	for i := 0; i < m; i++ {
+	for i := range m {
 		if math.Abs(d21Raw.Data[j*d21Raw.Stride+i]) > tol {
 			return false
 		}
 	}
 	d22Raw := sys.LFT.D22.RawMatrix()
-	for i := 0; i < N; i++ {
+	for i := range N {
 		if math.Abs(d22Raw.Data[j*d22Raw.Stride+i]) > tol {
 			return false
 		}
@@ -2143,8 +2142,8 @@ func (sys *System) ZeroDelayApprox() (*System, error) {
 	ImD22 := mat.NewDense(N, N, nil)
 	d22Raw := sys.LFT.D22.RawMatrix()
 	imRaw := ImD22.RawMatrix()
-	for i := 0; i < N; i++ {
-		for j := 0; j < N; j++ {
+	for i := range N {
+		for j := range N {
 			imRaw.Data[i*imRaw.Stride+j] = -d22Raw.Data[i*d22Raw.Stride+j]
 		}
 		imRaw.Data[i*imRaw.Stride+i] += 1
@@ -2158,7 +2157,7 @@ func (sys *System) ZeroDelayApprox() (*System, error) {
 
 	eye := mat.NewDense(N, N, nil)
 	eyeRaw := eye.RawMatrix()
-	for i := 0; i < N; i++ {
+	for i := range N {
 		eyeRaw.Data[i*eyeRaw.Stride+i] = 1
 	}
 	E := mat.NewDense(N, N, nil)

--- a/delay_bank.go
+++ b/delay_bank.go
@@ -27,7 +27,7 @@ type delayBankSpec struct {
 
 func buildContinuousDelayBank(contDelay []float64, channels int, dt float64, thiranOrder int) (*System, error) {
 	sampleDelay := make([]float64, channels)
-	for i := 0; i < channels; i++ {
+	for i := range channels {
 		sampleDelay[i] = contDelay[i] / dt
 	}
 	return buildDelayBank(delayBankSpec{

--- a/delay_test.go
+++ b/delay_test.go
@@ -166,7 +166,7 @@ func TestSimulateSISOWithDelay(t *testing.T) {
 
 	steps := 10
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -179,7 +179,7 @@ func TestSimulateSISOWithDelay(t *testing.T) {
 	noDelayResp, _ := noDelaySys.Simulate(u, nil, nil)
 
 	// First 3 steps: output = autonomous only (x0=0 → all zero)
-	for k := 0; k < 3; k++ {
+	for k := range 3 {
 		if math.Abs(resp.Y.At(0, k)) > 1e-12 {
 			t.Errorf("step %d: expected 0 (delayed), got %v", k, resp.Y.At(0, k))
 		}
@@ -209,7 +209,7 @@ func TestSimulateMIMOWithDelay(t *testing.T) {
 
 	steps := 8
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 		u.Set(1, k, 1)
 	}
@@ -239,7 +239,7 @@ func TestSimulateDelayMatchesAbsorb(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, float64(k+1))
 	}
 
@@ -289,7 +289,7 @@ func TestSimulateDelayMatchesAbsorbNonSymA(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3))
 		u.Set(1, k, math.Cos(float64(k)*0.5))
 	}
@@ -425,7 +425,7 @@ func TestAbsorbDelayNonUniform(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 	origResp, _ := sys.Simulate(u, nil, nil)
@@ -736,7 +736,7 @@ func TestSimulateNoDelayBackwardCompat(t *testing.T) {
 	x := []float64{0.5, -0.3}
 	uu := []float64{1, 2, 3}
 	wantY := make([]float64, 3)
-	for k := 0; k < 3; k++ {
+	for k := range 3 {
 		wantY[k] = 1*x[0] + 0*x[1] + 0.5*uu[k]
 		nx0 := 0.9*x[0] + 0.1*x[1] + 1*uu[k]
 		nx1 := 0.0*x[0] + 0.8*x[1] + 0*uu[k]
@@ -765,7 +765,7 @@ func TestSimulatePureFeedthroughWithDelay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for k := 0; k < 3; k++ {
+	for k := range 3 {
 		if math.Abs(resp.Y.At(0, k)) > 1e-12 {
 			t.Errorf("step %d: expected 0, got %v", k, resp.Y.At(0, k))
 		}
@@ -789,7 +789,7 @@ func TestSimulateWithDelayAndX0(t *testing.T) {
 
 	steps := 6
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -803,12 +803,12 @@ func TestSimulateWithDelayAndX0(t *testing.T) {
 	// No-delay SIMO response with x0=0, u=1: y_nd[k]
 	noDelaySys, _ := New(A, B, C, D, 1.0)
 	uForced := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		uForced.Set(0, k, 1)
 	}
 	ndResp, _ := noDelaySys.Simulate(uForced, nil, nil)
 
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		autoY := 5 * math.Pow(0.9, float64(k))
 		forcedY := 0.0
 		if k >= 2 {
@@ -835,13 +835,13 @@ func TestMATLABSISOInputDelay(t *testing.T) {
 
 	steps := 12
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
 	resp, _ := sys.Simulate(u, nil, nil)
 
-	for k := 0; k < 5; k++ {
+	for k := range 5 {
 		if math.Abs(resp.Y.At(0, k)) > 1e-12 {
 			t.Errorf("step %d: expected 0 during delay, got %v", k, resp.Y.At(0, k))
 		}
@@ -880,7 +880,7 @@ func TestMATLABMIMOIODelay(t *testing.T) {
 	}
 
 	// Channel (0,0) has delay=2: D feedthrough appears at k=2
-	for k := 0; k < 2; k++ {
+	for k := range 2 {
 		if math.Abs(resp.Y.At(0, k)) > 1e-12 {
 			t.Errorf("y(0,%d): expected 0, got %v", k, resp.Y.At(0, k))
 		}
@@ -890,7 +890,7 @@ func TestMATLABMIMOIODelay(t *testing.T) {
 	}
 
 	// Channel (1,0) has delay=1, D[1,0]=0: first nonzero at k=2
-	for k := 0; k < 2; k++ {
+	for k := range 2 {
 		if math.Abs(resp.Y.At(1, k)) > 1e-12 {
 			t.Errorf("y(1,%d): expected 0, got %v", k, resp.Y.At(1, k))
 		}
@@ -976,7 +976,7 @@ func TestMATLABAbsorbDelayStepResponse(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -991,7 +991,7 @@ func TestMATLABAbsorbDelayStepResponse(t *testing.T) {
 
 	if !matEqual(delayResp.Y, augResp.Y, 1e-12) {
 		t.Error("absorbDelay step response mismatch")
-		for k := 0; k < steps; k++ {
+		for k := range steps {
 			t.Logf("  k=%d: delay=%v aug=%v", k, delayResp.Y.At(0, k), augResp.Y.At(0, k))
 		}
 	}
@@ -1010,7 +1010,7 @@ func TestMATLABMultiInputDelay(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 		u.Set(1, k, 1)
 	}
@@ -1047,7 +1047,7 @@ func TestSimulateSIMOWithDelay(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, float64(k+1)*0.5)
 	}
 
@@ -1059,9 +1059,9 @@ func TestSimulateSIMOWithDelay(t *testing.T) {
 	noDelaySys, _ := New(A, B, C, D, 1.0)
 	ndResp, _ := noDelaySys.Simulate(u, nil, nil)
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		d := int(delay.At(i, 0))
-		for k := 0; k < d; k++ {
+		for k := range d {
 			if math.Abs(resp.Y.At(i, k)) > 1e-12 {
 				t.Errorf("output %d step %d: expected 0 during delay, got %v", i, k, resp.Y.At(i, k))
 			}
@@ -1092,9 +1092,9 @@ func TestSimulateSIMOWithDelay(t *testing.T) {
 		simoSys, _ := New(A, B, C, D, 1.0)
 		forcedResp, _ := simoSys.Simulate(u, nil, nil)
 
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			d := int(delay.At(i, 0))
-			for k := 0; k < steps; k++ {
+			for k := range steps {
 				want := autoResp.Y.At(i, k)
 				if k >= d {
 					want += forcedResp.Y.At(i, k-d)
@@ -1122,7 +1122,7 @@ func TestSimulateMISOWithDelay(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.4)+1)
 		u.Set(1, k, math.Cos(float64(k)*0.3))
 	}
@@ -1134,7 +1134,7 @@ func TestSimulateMISOWithDelay(t *testing.T) {
 
 	u0 := mat.NewDense(1, steps, nil)
 	u1 := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u0.Set(0, k, u.At(0, k))
 		u1.Set(0, k, u.At(1, k))
 	}
@@ -1149,7 +1149,7 @@ func TestSimulateMISOWithDelay(t *testing.T) {
 	sys1, _ := New(A, B1, C, D1, 1.0)
 	resp1, _ := sys1.Simulate(u1, nil, nil)
 
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		want := 0.0
 		if k >= 2 {
 			want += resp0.Y.At(0, k-2)
@@ -1384,8 +1384,8 @@ func TestTotalDelay(t *testing.T) {
 		if r != 2 || c != 3 {
 			t.Fatalf("dims = %d×%d, want 2×3", r, c)
 		}
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 3; j++ {
+		for i := range 2 {
+			for j := range 3 {
 				want := s.InputDelay[j]
 				if td.At(i, j) != want {
 					t.Errorf("td[%d,%d] = %v, want %v", i, j, td.At(i, j), want)
@@ -1401,8 +1401,8 @@ func TestTotalDelay(t *testing.T) {
 		if td == nil {
 			t.Fatal("expected non-nil")
 		}
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 3; j++ {
+		for i := range 2 {
+			for j := range 3 {
 				want := s.OutputDelay[i]
 				if td.At(i, j) != want {
 					t.Errorf("td[%d,%d] = %v, want %v", i, j, td.At(i, j), want)
@@ -1419,8 +1419,8 @@ func TestTotalDelay(t *testing.T) {
 		if td == nil {
 			t.Fatal("expected non-nil")
 		}
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 3; j++ {
+		for i := range 2 {
+			for j := range 3 {
 				if td.At(i, j) != ioDelay.At(i, j) {
 					t.Errorf("td[%d,%d] = %v, want %v", i, j, td.At(i, j), ioDelay.At(i, j))
 				}
@@ -1439,8 +1439,8 @@ func TestTotalDelay(t *testing.T) {
 			t.Fatal("expected non-nil")
 		}
 		want := mat.NewDense(2, 3, []float64{1, 1, 2, 6, 3, 6})
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 3; j++ {
+		for i := range 2 {
+			for j := range 3 {
 				if td.At(i, j) != want.At(i, j) {
 					t.Errorf("td[%d,%d] = %v, want %v", i, j, td.At(i, j), want.At(i, j))
 				}
@@ -1520,25 +1520,25 @@ func TestDecomposeIODelay(t *testing.T) {
 
 			gotInput, gotOutput, gotResid := DecomposeIODelay(ioMat)
 
-			for j := 0; j < m; j++ {
+			for j := range m {
 				if math.Abs(gotInput[j]-tt.wantInput[j]) > 1e-14 {
 					t.Errorf("inputDelay[%d] = %g, want %g", j, gotInput[j], tt.wantInput[j])
 				}
 			}
-			for i := 0; i < p; i++ {
+			for i := range p {
 				if math.Abs(gotOutput[i]-tt.wantOutput[i]) > 1e-14 {
 					t.Errorf("outputDelay[%d] = %g, want %g", i, gotOutput[i], tt.wantOutput[i])
 				}
 			}
-			for i := 0; i < p; i++ {
-				for j := 0; j < m; j++ {
+			for i := range p {
+				for j := range m {
 					if math.Abs(gotResid.At(i, j)-tt.wantResid[i][j]) > 1e-14 {
 						t.Errorf("residual[%d,%d] = %g, want %g", i, j, gotResid.At(i, j), tt.wantResid[i][j])
 					}
 				}
 			}
-			for i := 0; i < p; i++ {
-				for j := 0; j < m; j++ {
+			for i := range p {
+				for j := range m {
 					got := gotInput[j] + gotOutput[i] + gotResid.At(i, j)
 					want := tt.ioDelay[i][j]
 					if math.Abs(got-want) > 1e-14 {
@@ -1558,7 +1558,7 @@ func simulateWithOutputDelay(sys *System, u *mat.Dense, x0 *mat.VecDense) *mat.D
 	ndResp, _ := noDelaySys.Simulate(u, x0, nil)
 
 	Y := mat.NewDense(p, steps, nil)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		d := 0
 		if sys.OutputDelay != nil && i < len(sys.OutputDelay) {
 			d = int(sys.OutputDelay[i])
@@ -1596,7 +1596,7 @@ func TestAbsorbOutputDelay_SISO(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -1631,7 +1631,7 @@ func TestAbsorbOutputDelay_MIMO(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3)+1)
 	}
 
@@ -1639,7 +1639,7 @@ func TestAbsorbOutputDelay_MIMO(t *testing.T) {
 	augResp, _ := aug.Simulate(u, nil, nil)
 	if !matEqual(wantY, augResp.Y, 1e-10) {
 		t.Error("MIMO simulation mismatch")
-		for k := 0; k < steps; k++ {
+		for k := range steps {
 			t.Logf("  k=%d: want=[%v,%v] got=[%v,%v]", k,
 				wantY.At(0, k), wantY.At(1, k),
 				augResp.Y.At(0, k), augResp.Y.At(1, k))
@@ -1708,7 +1708,7 @@ func TestAbsorbOutputDelay_MixedDelays(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, float64(k+1)*0.5)
 	}
 	wantY := simulateWithOutputDelay(sys, u, nil)
@@ -1734,7 +1734,7 @@ func TestAbsorbOutputDelay_GainSystem(t *testing.T) {
 
 	steps := 8
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 	wantY := simulateWithOutputDelay(sys, u, nil)
@@ -1798,7 +1798,7 @@ func TestAbsorbOutputDelay_NonSymA(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3))
 		u.Set(1, k, math.Cos(float64(k)*0.5))
 	}
@@ -1883,8 +1883,8 @@ func TestAbsorbScope_IODecompose(t *testing.T) {
 	if aug.Delay != nil {
 		hasNonzero := false
 		r, c := aug.Delay.Dims()
-		for i := 0; i < r; i++ {
-			for j := 0; j < c; j++ {
+		for i := range r {
+			for j := range c {
 				if aug.Delay.At(i, j) != 0 {
 					hasNonzero = true
 				}
@@ -1923,7 +1923,7 @@ func TestAbsorbScope_All_Default(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3)+1)
 		u.Set(1, k, math.Cos(float64(k)*0.5))
 	}
@@ -1976,7 +1976,7 @@ func TestAbsorbScope_InputOnly_Simulation(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -2003,7 +2003,7 @@ func TestAbsorbScope_OutputOnly_Simulation(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -2075,7 +2075,7 @@ func TestAbsorbScope_BackwardCompat(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, float64(k+1))
 	}
 
@@ -2110,8 +2110,8 @@ func TestAbsorbScope_IOWithResidual(t *testing.T) {
 	hasResidual := false
 	if aug.Delay != nil {
 		r, c := aug.Delay.Dims()
-		for i := 0; i < r; i++ {
-			for j := 0; j < c; j++ {
+		for i := range r {
+			for j := range c {
 				if aug.Delay.At(i, j) != 0 {
 					hasResidual = true
 				}
@@ -2124,7 +2124,7 @@ func TestAbsorbScope_IOWithResidual(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3)+1)
 		u.Set(1, k, math.Cos(float64(k)*0.5))
 	}
@@ -2711,7 +2711,7 @@ func TestAbsorbInternalDelay_FrequencyResponse(t *testing.T) {
 	// DC gain of absorbed system: C*(I-A)^{-1}*B + D
 	n, _, _ := absorbed.Dims()
 	ImA := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ImA.Set(i, i, 1)
 	}
 	ImA.Sub(ImA, absorbed.A)
@@ -2719,7 +2719,7 @@ func TestAbsorbInternalDelay_FrequencyResponse(t *testing.T) {
 	luDC.Factorize(ImA)
 	invImA := mat.NewDense(n, n, nil)
 	eyeN := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		eyeN.Set(i, i, 1)
 	}
 	_ = luDC.SolveTo(invImA, false, eyeN)
@@ -2825,7 +2825,7 @@ func TestSimulateMIMOWithDelayValues(t *testing.T) {
 
 	steps := 15
 
-	for jin := 0; jin < 2; jin++ {
+	for jin := range 2 {
 		t.Run(fmt.Sprintf("impulse_input_%d", jin), func(t *testing.T) {
 			u := mat.NewDense(2, steps, nil)
 			u.Set(jin, 0, 1)
@@ -2836,11 +2836,11 @@ func TestSimulateMIMOWithDelayValues(t *testing.T) {
 			}
 
 			Bj := mat.NewDense(3, 1, nil)
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				Bj.Set(i, 0, B.At(i, jin))
 			}
 			Dj := mat.NewDense(2, 1, nil)
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				Dj.Set(i, 0, D.At(i, jin))
 			}
 			uj := mat.NewDense(1, steps, nil)
@@ -2848,9 +2848,9 @@ func TestSimulateMIMOWithDelayValues(t *testing.T) {
 			ndSys, _ := New(A, Bj, C, Dj, 1.0)
 			ndResp, _ := ndSys.Simulate(uj, nil, nil)
 
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				d := int(delay.At(i, jin))
-				for k := 0; k < d; k++ {
+				for k := range d {
 					if math.Abs(resp.Y.At(i, k)) > 1e-12 {
 						t.Errorf("output %d step %d: expected 0 during delay %d, got %v", i, k, d, resp.Y.At(i, k))
 					}
@@ -2987,7 +2987,7 @@ func TestPullDelaysToLFT_D22Simulation(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -3000,7 +3000,7 @@ func TestPullDelaysToLFT_D22Simulation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		got := respSys.Y.At(0, k)
 		want := respRef.Y.At(0, k)
 		if math.Abs(got-want) > 1e-10 {
@@ -3095,7 +3095,7 @@ func TestPullDelaysToLFT_D22Absorption(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -3108,7 +3108,7 @@ func TestPullDelaysToLFT_D22Absorption(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		got := respAbs.Y.At(0, k)
 		want := respRef.Y.At(0, k)
 		if math.Abs(got-want) > 1e-10 {
@@ -3551,7 +3551,7 @@ func TestMixedDelaySimulate(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 
@@ -3593,7 +3593,7 @@ func TestMixedDelaySimulate_WithX0(t *testing.T) {
 
 	steps := 15
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3))
 	}
 	x0 := mat.NewVecDense(2, []float64{1, -0.5})
@@ -3631,7 +3631,7 @@ func TestMixedDelaySimulate_MIMO(t *testing.T) {
 
 	steps := 20
 	u := mat.NewDense(2, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(float64(k)*0.3))
 		u.Set(1, k, math.Cos(float64(k)*0.5))
 	}
@@ -3685,7 +3685,7 @@ func TestSimulateWithDelay_MIMOManualReference(t *testing.T) {
 
 	steps := 18
 	u := mat.NewDense(3, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, math.Sin(0.2*float64(k))+0.1)
 		u.Set(1, k, math.Cos(0.15*float64(k))-0.2)
 		u.Set(2, k, 0.05*float64(k)-0.3)
@@ -3710,17 +3710,17 @@ func TestSimulateWithDelay_MIMOManualReference(t *testing.T) {
 	wantX := mat.NewVecDense(4, nil)
 	wantX.CopyVec(autoResp.XFinal)
 
-	for j := 0; j < 3; j++ {
+	for j := range 3 {
 		Bj := mat.NewDense(4, 1, nil)
 		Dj := mat.NewDense(3, 1, nil)
 		uj := mat.NewDense(1, steps, nil)
-		for i := 0; i < 4; i++ {
+		for i := range 4 {
 			Bj.Set(i, 0, B.At(i, j))
 		}
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			Dj.Set(i, 0, D.At(i, j))
 		}
-		for k := 0; k < steps; k++ {
+		for k := range steps {
 			uj.Set(0, k, u.At(j, k))
 		}
 
@@ -3733,7 +3733,7 @@ func TestSimulateWithDelay_MIMOManualReference(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			d := int(delay.At(i, j))
 			for k := d; k < steps; k++ {
 				wantY.Set(i, k, wantY.At(i, k)+simoResp.Y.At(i, k-d))
@@ -4023,7 +4023,7 @@ func TestSimulateDelay_AllDelaysExceedSteps(t *testing.T) {
 
 	steps := 5
 	u := mat.NewDense(1, steps, nil)
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		u.Set(0, k, 1)
 	}
 	x0 := mat.NewVecDense(2, []float64{3, 1})

--- a/delay_visibility.go
+++ b/delay_visibility.go
@@ -46,7 +46,7 @@ func clearLeadingDelays(delay []float64, n int) []float64 {
 	if delay == nil {
 		return nil
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		delay[i] = 0
 	}
 	if delaySliceHasNonzero(delay) {

--- a/descriptor.go
+++ b/descriptor.go
@@ -75,8 +75,8 @@ func isIdentityDescriptor(E *mat.Dense) bool {
 		return false
 	}
 	raw := E.RawMatrix()
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			want := 0.0
 			if i == j {
 				want = 1

--- a/example_test.go
+++ b/example_test.go
@@ -142,7 +142,7 @@ func ExampleSystem_Simulate() {
 	resp, _ := sys.Simulate(u, nil, nil)
 
 	_, cols := resp.Y.Dims()
-	for i := 0; i < cols; i++ {
+	for i := range cols {
 		fmt.Printf("y[%d] = %.0f\n", i, resp.Y.At(0, i))
 	}
 

--- a/feedback_lft.go
+++ b/feedback_lft.go
@@ -322,7 +322,7 @@ func feedbackWithLFT(plant, controller *System, sign float64) (*System, error) {
 
 func eyeDense(n int) *mat.Dense {
 	data := make([]float64, n*n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		data[i*(n+1)] = 1
 	}
 	return mat.NewDense(n, n, data)

--- a/frd.go
+++ b/frd.go
@@ -136,10 +136,10 @@ func newFRDResponseStorage(nw, p, m int) ([][][]complex128, []complex128) {
 	}
 	rows := make([][]complex128, nw*p)
 	data := make([]complex128, nw*p*m)
-	for k := 0; k < nw; k++ {
+	for k := range nw {
 		response[k] = rows[k*p : (k+1)*p]
 		block := data[k*p*m : (k+1)*p*m]
-		for i := 0; i < p; i++ {
+		for i := range p {
 			start := i * m
 			response[k][i] = block[start : start+m : start+m]
 		}
@@ -151,24 +151,24 @@ func copyComplexGridInto(dst []complex128, src [][][]complex128, p, m int) {
 	pm := p * m
 	for k := range src {
 		base := k * pm
-		for i := 0; i < p; i++ {
+		for i := range p {
 			copy(dst[base+i*m:base+(i+1)*m], src[k][i])
 		}
 	}
 }
 
 func copyComplexMatrixInto(dst []complex128, src [][]complex128, rows, cols int) {
-	for i := 0; i < rows; i++ {
+	for i := range rows {
 		copy(dst[i*cols:(i+1)*cols], src[i])
 	}
 }
 
 func cMulNestedInto(dst []complex128, a, b [][]complex128, ra, ca, cb int) {
-	for i := 0; i < ra; i++ {
+	for i := range ra {
 		row := dst[i*cb : (i+1)*cb]
-		for j := 0; j < cb; j++ {
+		for j := range cb {
 			var sum complex128
-			for k := 0; k < ca; k++ {
+			for k := range ca {
 				sum += a[i][k] * b[k][j]
 			}
 			row[j] = sum
@@ -177,9 +177,9 @@ func cMulNestedInto(dst []complex128, a, b [][]complex128, ra, ca, cb int) {
 }
 
 func cAddNestedInto(dst []complex128, a, b [][]complex128, rows, cols int) {
-	for i := 0; i < rows; i++ {
+	for i := range rows {
 		row := dst[i*cols : (i+1)*cols]
-		for j := 0; j < cols; j++ {
+		for j := range cols {
 			row[j] = a[i][j] + b[i][j]
 		}
 	}
@@ -221,10 +221,10 @@ func (f *FRD) Abs() *FRD {
 	nw := len(f.Omega)
 	response, data := newFRDResponseStorage(nw, p, m)
 	pm := p * m
-	for k := 0; k < nw; k++ {
+	for k := range nw {
 		base := k * pm
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				data[base+i*m+j] = complex(cmplx.Abs(f.Response[k][i][j]), 0)
 			}
 		}
@@ -298,7 +298,7 @@ func (f *FRD) PeakGain() (*FRDPeakGainResult, error) {
 	}
 	result := &FRDPeakGainResult{Gain: math.Inf(-1), Index: -1}
 	if p == 1 && m == 1 {
-		for k := 0; k < nw; k++ {
+		for k := range nw {
 			gain := cmplx.Abs(f.Response[k][0][0])
 			if gain > result.Gain {
 				result.Gain = gain
@@ -310,7 +310,7 @@ func (f *FRD) PeakGain() (*FRDPeakGainResult, error) {
 	}
 	ws := newComplexSVDWorkspace(p, m)
 	sv := make([]float64, min(p, m))
-	for k := 0; k < nw; k++ {
+	for k := range nw {
 		ws.singularValuesFromNested(sv, f.Response[k], p, m)
 		if sv[0] > result.Gain {
 			result.Gain = sv[0]
@@ -386,7 +386,7 @@ func (f *FRD) withResponseAndOmega(response [][][]complex128, omega []float64) *
 func (f *FRD) EvalFr(freqIdx int) [][]complex128 {
 	p, m := f.Dims()
 	result := make([][]complex128, p)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		result[i] = make([]complex128, m)
 		copy(result[i], f.Response[freqIdx][i])
 	}
@@ -413,8 +413,8 @@ func (f *FRD) Bode() *BodeResult {
 	mag := newSampledScalarResponse(magDB, omega, p, m)
 	phaseResp := newSampledScalarResponse(phase, omega, p, m)
 	for k := range omega {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				h := f.Response[k][i][j]
 				mag.set(k, i, j, 20*math.Log10(cmplx.Abs(h)))
 				phaseResp.set(k, i, j, cmplx.Phase(h)*180/math.Pi)
@@ -441,7 +441,7 @@ func (f *FRD) Nyquist() (*NyquistResult, error) {
 	nw := len(f.Omega)
 	contour := make([]complex128, nw)
 	contourN := make([]complex128, nw)
-	for k := 0; k < nw; k++ {
+	for k := range nw {
 		contour[k] = f.Response[k][0][0]
 		contourN[k] = cmplx.Conj(contour[k])
 	}
@@ -476,7 +476,7 @@ func (f *FRD) Sigma() (*SigmaResult, error) {
 	}
 	sv := make([]float64, nw*nsv)
 	if p == 1 && m == 1 {
-		for k := 0; k < nw; k++ {
+		for k := range nw {
 			sv[k] = cmplx.Abs(f.Response[k][0][0])
 		}
 		omega := make([]float64, nw)
@@ -486,7 +486,7 @@ func (f *FRD) Sigma() (*SigmaResult, error) {
 	response := newSampledComplexGridResponse(f.Response, f.Omega, p, m)
 	var ws *complexSVDWorkspace
 	ws = newComplexSVDWorkspace(p, m)
-	for k := 0; k < nw; k++ {
+	for k := range nw {
 		response.singularValues(sv[k*nsv:(k+1)*nsv], ws, k)
 	}
 	omega := make([]float64, nw)

--- a/frd_test.go
+++ b/frd_test.go
@@ -93,14 +93,14 @@ func TestFRD_MIMOFromSystem(t *testing.T) {
 		{complex(0, 1) + 3, 1},
 		{-2, complex(0, 1)},
 	}
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			want[i][j] /= det
 		}
 	}
 
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			got := frd.At(0, i, j)
 			if cmplx.Abs(got-want[i][j]) > 1e-10 {
 				t.Errorf("H[%d][%d] = %v, want %v", i, j, got, want[i][j])
@@ -385,8 +385,8 @@ func TestFRD_CrossValidateWithFreqResponse(t *testing.T) {
 
 	_, m, p := sys.Dims()
 	for k := range omega {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				got := frd.At(k, i, j)
 				want := resp.At(k, i, j)
 				if cmplx.Abs(got-want) > 1e-10 {
@@ -461,8 +461,8 @@ func TestFRD_CrossValidateMIMO(t *testing.T) {
 
 	_, m, p := sys.Dims()
 	for k := range omega {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				got := frd.At(k, i, j)
 				want := resp.At(k, i, j)
 				if cmplx.Abs(got-want) > 1e-10 {
@@ -563,8 +563,8 @@ func TestFRDSeries_MIMO(t *testing.T) {
 			f2.At(0, 1, 0)*f1.At(0, 0, 1) + f2.At(0, 1, 1)*f1.At(0, 1, 1),
 		},
 	}
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			if cmplx.Abs(got.At(0, i, j)-want[i][j]) > 1e-12 {
 				t.Fatalf("series[%d,%d] = %v, want %v", i, j, got.At(0, i, j), want[i][j])
 			}
@@ -646,8 +646,8 @@ func TestFRDParallel_MIMO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			want := f1.At(0, i, j) + f2.At(0, i, j)
 			if cmplx.Abs(got.At(0, i, j)-want) > 1e-12 {
 				t.Fatalf("parallel[%d,%d] = %v, want %v", i, j, got.At(0, i, j), want)
@@ -677,8 +677,8 @@ func TestFRDFeedback_MIMO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for k := 0; k < 2; k++ {
-		for i := 0; i < 2; i++ {
+	for k := range 2 {
+		for i := range 2 {
 			g := plant.At(k, i, i)
 			c := controller.At(k, i, i)
 			want := g / (1 + c*g)

--- a/freqrestest.go
+++ b/freqrestest.go
@@ -176,20 +176,20 @@ func welchSISO(fft *fourier.FFT, seg []float64, _ []complex128, win []float64,
 	uCoeff := make([]complex128, nFreq)
 	yCoeff := make([]complex128, nFreq)
 
-	for s := 0; s < nSeg; s++ {
+	for s := range nSeg {
 		start := s * hop
 
-		for k := 0; k < nfft; k++ {
+		for k := range nfft {
 			seg[k] = uData[start+k] * win[k]
 		}
 		fft.Coefficients(uCoeff, seg)
 
-		for k := 0; k < nfft; k++ {
+		for k := range nfft {
 			seg[k] = yData[start+k] * win[k]
 		}
 		fft.Coefficients(yCoeff, seg)
 
-		for f := 0; f < nFreq; f++ {
+		for f := range nFreq {
 			Suu[f] += real(uCoeff[f])*real(uCoeff[f]) + imag(uCoeff[f])*imag(uCoeff[f])
 			Syy[f] += real(yCoeff[f])*real(yCoeff[f]) + imag(yCoeff[f])*imag(yCoeff[f])
 			Syu[f] += cmplx.Conj(uCoeff[f]) * yCoeff[f]

--- a/freqrestest_test.go
+++ b/freqrestest_test.go
@@ -304,8 +304,8 @@ func TestFreqRespEstResultFRD(t *testing.T) {
 		t.Fatalf("FRD dims = (%d,%d), want (%d,%d)", p, m, est.H.P, est.H.M)
 	}
 	for k := range est.Omega {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				if frd.At(k, i, j) != est.H.At(k, i, j) {
 					t.Fatalf("FRD[%d,%d,%d] = %v, want %v", k, i, j, frd.At(k, i, j), est.H.At(k, i, j))
 				}

--- a/frequency.go
+++ b/frequency.go
@@ -68,8 +68,8 @@ func bodeResultFromAccessor(omega []float64, p, m int, inputName, outputName []s
 	phaseResp := newSampledScalarResponse(phase, omega, p, m)
 
 	for k := range omega {
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				h := at(k, i, j)
 				mag.set(k, i, j, 20*math.Log10(cmplx.Abs(h)))
 				phaseResp.set(k, i, j, cmplx.Phase(h)*180/math.Pi)
@@ -92,8 +92,8 @@ func bodeResultFromAccessor(omega []float64, p, m int, inputName, outputName []s
 
 func unwrapBodePhase(phase []float64, p, m, nw int) {
 	response := newSampledScalarResponse(phase, nil, p, m)
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			for k := 1; k < nw; k++ {
 				cur := response.layout.offset(k, i, j)
 				prev := response.layout.offset(k-1, i, j)
@@ -323,8 +323,8 @@ func applyIODelayAtS(sys *System, s complex128, data []complex128, p, m int, inc
 
 func applyIODelayMatrixAtS(sys *System, s complex128, data []complex128, p, m int, delay *mat.Dense) {
 	dRaw := delay.RawMatrix()
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			tau := dRaw.Data[i*dRaw.Stride+j]
 			if tau == 0 {
 				continue
@@ -335,7 +335,7 @@ func applyIODelayMatrixAtS(sys *System, s complex128, data []complex128, p, m in
 				continue
 			}
 			d := int(math.Round(tau))
-			for q := 0; q < d; q++ {
+			for range d {
 				data[off] /= s
 			}
 		}
@@ -384,7 +384,7 @@ func evalFrSSInto(ws *ssEvalWorkspace, sys *System, s complex128, n, p, m int) e
 
 func complexFlatToGrid(data []complex128, p, m int) [][]complex128 {
 	result := make([][]complex128, p)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		result[i] = make([]complex128, m)
 		copy(result[i], data[i*m:(i+1)*m])
 	}
@@ -485,14 +485,14 @@ func evalFrLFTInto(ws *lftWorkspace, sys *System, s complex128, n, N, p, m int) 
 	cComputeHInto(ws.H22, ws.hTemp, ws.resolvent, c2Raw.Data, c2Raw.Stride, b2Raw.Data, b2Raw.Stride, d22Data, d22Stride, n, N, N)
 
 	cont := sys.IsContinuous()
-	for j := 0; j < N; j++ {
+	for j := range N {
 		tau := sys.LFT.Tau[j]
 		if cont {
 			ws.delta[j] = cmplx.Exp(-s * complex(tau, 0))
 		} else {
 			d := int(math.Round(tau))
 			ws.delta[j] = 1
-			for q := 0; q < d; q++ {
+			for range d {
 				ws.delta[j] /= s
 			}
 		}
@@ -503,7 +503,7 @@ func evalFrLFTInto(ws *lftWorkspace, sys *System, s complex128, n, N, p, m int) 
 	for i := 0; i < N*N; i++ {
 		ws.ImH22D[i] = -ws.H22D[i]
 	}
-	for i := 0; i < N; i++ {
+	for i := range N {
 		ws.ImH22D[i*N+i] += 1
 	}
 
@@ -538,10 +538,10 @@ func cResolventInto(dst, sIA, invBuf []complex128, aData []float64, aStride int,
 	if n == 0 {
 		return nil
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		row := i * n
 		aRow := i * aStride
-		for j := 0; j < n; j++ {
+		for j := range n {
 			sIA[row+j] = -complex(aData[aRow+j], 0)
 		}
 		sIA[row+i] += s
@@ -554,19 +554,19 @@ func cComputeHInto(dst, temp, resolvent []complex128, cData []float64, cStride i
 		dst[i] = 0
 	}
 	if n > 0 {
-		for i := 0; i < n; i++ {
-			for j := 0; j < cols; j++ {
+		for i := range n {
+			for j := range cols {
 				var sum complex128
-				for k := 0; k < n; k++ {
+				for k := range n {
 					sum += resolvent[i*n+k] * complex(bData[k*bStride+j], 0)
 				}
 				temp[i*cols+j] = sum
 			}
 		}
-		for i := 0; i < rows; i++ {
-			for j := 0; j < cols; j++ {
+		for i := range rows {
+			for j := range cols {
 				var sum complex128
-				for k := 0; k < n; k++ {
+				for k := range n {
 					sum += complex(cData[i*cStride+k], 0) * temp[k*cols+j]
 				}
 				dst[i*cols+j] = sum
@@ -574,8 +574,8 @@ func cComputeHInto(dst, temp, resolvent []complex128, cData []float64, cStride i
 		}
 	}
 	if dData != nil {
-		for i := 0; i < rows; i++ {
-			for j := 0; j < cols; j++ {
+		for i := range rows {
+			for j := range cols {
 				dst[i*cols+j] += complex(dData[i*dStride+j], 0)
 			}
 		}
@@ -583,10 +583,10 @@ func cComputeHInto(dst, temp, resolvent []complex128, cData []float64, cStride i
 }
 
 func cMulInto(dst, a, b []complex128, ar, ac, bc int) {
-	for i := 0; i < ar; i++ {
-		for j := 0; j < bc; j++ {
+	for i := range ar {
+		for j := range bc {
 			var sum complex128
-			for k := 0; k < ac; k++ {
+			for k := range ac {
 				sum += a[i*ac+k] * b[k*bc+j]
 			}
 			dst[i*bc+j] = sum
@@ -595,10 +595,10 @@ func cMulInto(dst, a, b []complex128, ar, ac, bc int) {
 }
 
 func cAddMul(dst, a, b []complex128, ar, ac, bc int) {
-	for i := 0; i < ar; i++ {
-		for j := 0; j < bc; j++ {
+	for i := range ar {
+		for j := range bc {
 			var sum complex128
-			for k := 0; k < ac; k++ {
+			for k := range ac {
 				sum += a[i*ac+k] * b[k*bc+j]
 			}
 			dst[i*bc+j] += sum
@@ -607,16 +607,16 @@ func cAddMul(dst, a, b []complex128, ar, ac, bc int) {
 }
 
 func cMulDiagRightInto(dst, a, diag []complex128, rows, cols int) {
-	for i := 0; i < rows; i++ {
-		for j := 0; j < cols; j++ {
+	for i := range rows {
+		for j := range cols {
 			dst[i*cols+j] = a[i*cols+j] * diag[j]
 		}
 	}
 }
 
 func cMulDiagLeftInto(dst, diag, a []complex128, rows, cols int) {
-	for i := 0; i < rows; i++ {
-		for j := 0; j < cols; j++ {
+	for i := range rows {
+		for j := range cols {
 			dst[i*cols+j] = diag[i] * a[i*cols+j]
 		}
 	}
@@ -654,11 +654,11 @@ func (sys *System) Nichols(omega []float64, nPoints int) (*NicholsResult, error)
 	nw := len(bode.Omega)
 	phaseResp := newSampledScalarResponse(phase, bode.Omega, p, m)
 
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			base := phaseResp.at(0, i, j)
 			shift := math.Ceil(base/360) * 360
-			for k := 0; k < nw; k++ {
+			for k := range nw {
 				phaseResp.set(k, i, j, phaseResp.at(k, i, j)-shift)
 			}
 		}
@@ -745,7 +745,7 @@ func cInvertInto(dst, aug, src []complex128, n int) error {
 	}
 
 	w := 2 * n
-	for i := 0; i < n; i++ {
+	for i := range n {
 		row := i * w
 		copy(aug[row:row+n], src[i*n:(i+1)*n])
 		for j := n; j < w; j++ {
@@ -765,7 +765,7 @@ func cInvertInto(dst, aug, src []complex128, n int) error {
 		tol = 1e-15
 	}
 
-	for col := 0; col < n; col++ {
+	for col := range n {
 		pivot := -1
 		best := 0.0
 		for row := col; row < n; row++ {
@@ -779,7 +779,7 @@ func cInvertInto(dst, aug, src []complex128, n int) error {
 			return fmt.Errorf("controlsys: singular complex matrix: %w", ErrSingularTransform)
 		}
 		if pivot != col {
-			for j := 0; j < w; j++ {
+			for j := range w {
 				aug[col*w+j], aug[pivot*w+j] = aug[pivot*w+j], aug[col*w+j]
 			}
 		}
@@ -787,7 +787,7 @@ func cInvertInto(dst, aug, src []complex128, n int) error {
 		for j := col; j < w; j++ {
 			aug[col*w+j] *= inv
 		}
-		for row := 0; row < n; row++ {
+		for row := range n {
 			if row == col {
 				continue
 			}
@@ -801,7 +801,7 @@ func cInvertInto(dst, aug, src []complex128, n int) error {
 		}
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(dst[i*n:(i+1)*n], aug[i*w+n:i*w+w])
 	}
 	return nil

--- a/frequency_svd.go
+++ b/frequency_svd.go
@@ -58,15 +58,15 @@ func (ws *complexSVDWorkspace) fillBlock(at func(i, j int) complex128, p, m int)
 		ws.block[i] = 0
 	}
 
-	for a := 0; a < n; a++ {
-		for b := 0; b < n; b++ {
+	for a := range n {
+		for b := range n {
 			var g complex128
 			if ws.useCol {
-				for row := 0; row < p; row++ {
+				for row := range p {
 					g += cmplx.Conj(at(row, a)) * at(row, b)
 				}
 			} else {
-				for col := 0; col < m; col++ {
+				for col := range m {
 					g += at(a, col) * cmplx.Conj(at(b, col))
 				}
 			}

--- a/frequency_test.go
+++ b/frequency_test.go
@@ -430,8 +430,8 @@ func TestFreqResponse_InternalDelay_MIMO(t *testing.T) {
 	}
 
 	for k, w := range freqs {
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				magLFT := cmplx.Abs(respLFT.At(k, i, j))
 				magAbs := cmplx.Abs(respAbs.At(k, i, j))
 				absErr := math.Abs(magLFT - magAbs)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jamestjsp/controlsys
 
-go 1.25.3
+go 1.26.3
 
 require gonum.org/v1/gonum v0.15.0
 

--- a/hardening_feedback_test.go
+++ b/hardening_feedback_test.go
@@ -121,7 +121,7 @@ func TestFeedback_HighGain_Bounded(t *testing.T) {
 	}
 
 	_, cols := resp.Y.Dims()
-	for k := 0; k < cols; k++ {
+	for k := range cols {
 		if math.Abs(resp.Y.At(0, k)) > 100 {
 			t.Fatalf("step response unbounded at t=%v: y=%v", resp.T[k], resp.Y.At(0, k))
 		}

--- a/hardening_lyapcanon_test.go
+++ b/hardening_lyapcanon_test.go
@@ -115,8 +115,8 @@ func TestCanon_Modal_DistinctReal(t *testing.T) {
 	}
 
 	Amod := res.Sys.A
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			if i != j && math.Abs(Amod.At(i, j)) > 1e-8 {
 				t.Errorf("A_modal[%d,%d] = %g, want 0", i, j, Amod.At(i, j))
 			}

--- a/hardening_response_test.go
+++ b/hardening_response_test.go
@@ -24,7 +24,7 @@ func TestStep_Integrator(t *testing.T) {
 	}
 
 	_, steps := resp.Y.Dims()
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		tk := resp.T[k]
 		got := resp.Y.At(0, k)
 		if math.Abs(got-tk) > 0.05 {
@@ -288,7 +288,7 @@ func TestStep_NonMinimumPhase(t *testing.T) {
 	_, steps := resp.Y.Dims()
 
 	foundUndershoot := false
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		if resp.Y.At(0, k) < -0.01 {
 			foundUndershoot = true
 			break

--- a/hinfsyn.go
+++ b/hinfsyn.go
@@ -326,10 +326,7 @@ func maxSVD(M *mat.Dense) float64 {
 	mCopy := make([]float64, r*c)
 	copyStrided(mCopy, c, raw.Data, raw.Stride, r, c)
 
-	minDim := r
-	if c < minDim {
-		minDim = c
-	}
+	minDim := min(c, r)
 	s := make([]float64, minDim)
 	ldu := max(1, r)
 	ldvt := max(1, c)

--- a/integration_test.go
+++ b/integration_test.go
@@ -53,8 +53,8 @@ func TestSSToTFToSSRoundtrip(t *testing.T) {
 	for _, s := range freqs {
 		m1 := tfRes.TF.Eval(s)
 		m2 := tfRes2.TF.Eval(s)
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				if cmplx.Abs(m1[i][j]-m2[i][j]) > 1e-6 {
 					t.Errorf("at s=%v [%d][%d]: first=%v roundtrip=%v", s, i, j, m1[i][j], m2[i][j])
 				}
@@ -92,7 +92,7 @@ func TestDiscretizeAndSimulate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < nSteps; i++ {
+	for i := range nSteps {
 		tVal := float64(i) * dt
 		analytical := 1.0 - math.Exp(-tVal)
 		got := resp.Y.At(0, i)
@@ -198,8 +198,8 @@ func TestMIMOTransferFunctionFreqResponse(t *testing.T) {
 
 	for _, s := range freqs {
 		tfMat := tfRes.TF.Eval(s)
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				ssVal := evalSSij(sys, s, i, j)
 				if cmplx.Abs(tfMat[i][j]-ssVal) > 1e-8 {
 					t.Errorf("at s=%v [%d][%d]: TF=%v SS=%v", s, i, j, tfMat[i][j], ssVal)

--- a/lft.go
+++ b/lft.go
@@ -95,7 +95,7 @@ func lftSimple(M, Delta *System, nu, ny int) (*System, error) {
 	gRaw := make([]float64, z*z)
 	G := mat.NewDense(z, z, gRaw)
 	G.Mul(Phi, D22)
-	for i := 0; i < z; i++ {
+	for i := range z {
 		gRaw[i*z+i] += 1
 	}
 
@@ -215,7 +215,7 @@ func lftWithDelay(M, Delta *System, nu, ny int) (*System, error) {
 	gRaw := make([]float64, z*z)
 	G := mat.NewDense(z, z, gRaw)
 	G.Mul(Phi, D22p)
-	for i := 0; i < z; i++ {
+	for i := range z {
 		gRaw[i*z+i] += 1
 	}
 

--- a/lft_test.go
+++ b/lft_test.go
@@ -205,7 +205,7 @@ func TestLFT_DeltaNil(t *testing.T) {
 		s := complex(0, omega)
 		hM := evalMIMOTF(M, s)
 		hR := evalMIMOTF(result, s)
-		for j := 0; j < 2; j++ {
+		for j := range 2 {
 			if cmplx.Abs(hR[0][j]-hM[0][j]) > 1e-10 {
 				t.Errorf("s=%v col %d: got %v, want %v", s, j, hR[0][j], hM[0][j])
 			}
@@ -442,8 +442,8 @@ func TestLFT_MIMO_2x2(t *testing.T) {
 		// M11 = hM[:2][:2], M12 = hM[:2][2:], M21 = hM[2:][:2], M22 = hM[2:][2:]
 		// F_l = M11 + M12*Delta*(I - M22*Delta)^-1*M21  (all 2x2)
 		var m11, m12, m21, m22 [2][2]complex128
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				m11[i][j] = hM[i][j]
 				m12[i][j] = hM[i][j+2]
 				m21[i][j] = hM[i+2][j]
@@ -453,16 +453,16 @@ func TestLFT_MIMO_2x2(t *testing.T) {
 
 		// I - M22*Delta
 		var m22d [2][2]complex128
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
-				for k := 0; k < 2; k++ {
+		for i := range 2 {
+			for j := range 2 {
+				for k := range 2 {
 					m22d[i][j] += m22[i][k] * hD[k][j]
 				}
 			}
 		}
 		var imd [2][2]complex128
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				imd[i][j] = -m22d[i][j]
 			}
 			imd[i][i] += 1
@@ -478,17 +478,17 @@ func TestLFT_MIMO_2x2(t *testing.T) {
 
 		// Delta * inv * M21
 		var di [2][2]complex128
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
-				for k := 0; k < 2; k++ {
+		for i := range 2 {
+			for j := range 2 {
+				for k := range 2 {
 					di[i][j] += hD[i][k] * inv[k][j]
 				}
 			}
 		}
 		var dim21 [2][2]complex128
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
-				for k := 0; k < 2; k++ {
+		for i := range 2 {
+			for j := range 2 {
+				for k := range 2 {
 					dim21[i][j] += di[i][k] * m21[k][j]
 				}
 			}
@@ -496,17 +496,17 @@ func TestLFT_MIMO_2x2(t *testing.T) {
 
 		// M12 * dim21
 		var m12dim21 [2][2]complex128
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
-				for k := 0; k < 2; k++ {
+		for i := range 2 {
+			for j := range 2 {
+				for k := range 2 {
 					m12dim21[i][j] += m12[i][k] * dim21[k][j]
 				}
 			}
 		}
 
 		got := evalMIMOTF(result, s)
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				want := m11[i][j] + m12dim21[i][j]
 				if cmplx.Abs(got[i][j]-want) > 1e-10 {
 					t.Errorf("s=%v [%d][%d]: got %v, want %v (diff=%v)", s, i, j, got[i][j], want, cmplx.Abs(got[i][j]-want))
@@ -532,8 +532,8 @@ func TestLFT_DeltaNil_GainOnly(t *testing.T) {
 	if n != 0 || m != 2 || p != 2 {
 		t.Fatalf("dims = (%d,%d,%d), want (0,2,2)", n, m, p)
 	}
-	for i := 0; i < 2; i++ {
-		for j := 0; j < 2; j++ {
+	for i := range 2 {
+		for j := range 2 {
 			got := result.D.At(i, j)
 			want := M.D.At(i, j)
 			if got != want {

--- a/linearize_test.go
+++ b/linearize_test.go
@@ -221,8 +221,8 @@ func checkDense(t *testing.T, name string, got, want *mat.Dense, tol float64) {
 		t.Errorf("%s dims = (%d,%d), want (%d,%d)", name, gr, gc, r, c)
 		return
 	}
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			if math.Abs(got.At(i, j)-want.At(i, j)) > tol {
 				t.Errorf("%s(%d,%d) = %v, want %v", name, i, j, got.At(i, j), want.At(i, j))
 			}

--- a/loopsens.go
+++ b/loopsens.go
@@ -66,7 +66,7 @@ func Loopsens(P, C *System) (*LoopsensResult, error) {
 
 func makeIdentityGain(n int, dt float64) *System {
 	data := make([]float64, n*n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		data[i*(n+1)] = 1
 	}
 	sys, _ := NewGain(mat.NewDense(n, n, data), dt)

--- a/loopsens_test.go
+++ b/loopsens_test.go
@@ -113,8 +113,8 @@ func TestLoopsens_MIMO_SiNotEqualSo(t *testing.T) {
 	toResp, _ := res.To.EvalFr(s)
 	tiResp, _ := res.Ti.EvalFr(s)
 	n := len(soResp)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			eye := complex(0, 0)
 			if i == j {
 				eye = 1

--- a/lyapunov.go
+++ b/lyapunov.go
@@ -292,7 +292,7 @@ func solveDiscreteSchurLyap(n int, t []float64, ldt int, c []float64, ldc int, w
 					buf[i*dl+jj] = sum
 				}
 			}
-			for i := 0; i < j2; i++ {
+			for i := range j2 {
 				for jj := range dl {
 					sum := 0.0
 					for p := range n {
@@ -307,7 +307,7 @@ func solveDiscreteSchurLyap(n int, t []float64, ldt int, c []float64, ldc int, w
 		// These are Y[p, j1:j2] = Y[j1:j2, p]' for p >= j2, known from symmetry.
 		// C[:j2, j1:j2] -= T[:j2, j2:n] * Y[j2:n, j1:j2] * T_ll'
 		if j2 < n {
-			for i := 0; i < j2; i++ {
+			for i := range j2 {
 				for jj := range dl {
 					sum := 0.0
 					for p := j2; p < n; p++ {
@@ -316,7 +316,7 @@ func solveDiscreteSchurLyap(n int, t []float64, ldt int, c []float64, ldc int, w
 					buf[i*dl+jj] = sum
 				}
 			}
-			for i := 0; i < j2; i++ {
+			for i := range j2 {
 				for jj := range dl {
 					val := 0.0
 					for pp := range dl {

--- a/margin.go
+++ b/margin.go
@@ -92,7 +92,7 @@ func (e *sisoEval) at(w float64) complex128 {
 			h *= cmplx.Exp(-s * complex(e.tau, 0))
 		} else {
 			d := int(math.Round(e.tau))
-			for k := 0; k < d; k++ {
+			for range d {
 				h /= s
 			}
 		}

--- a/matlog.go
+++ b/matlog.go
@@ -55,9 +55,9 @@ func matLog(A *mat.Dense) (*mat.Dense, error) {
 	yTaug := mat.NewDense(2*n, n, nil)
 	vaRaw := vTaug.RawMatrix()
 	yaRaw := yTaug.RawMatrix()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		vRow := vRaw.Data[i*vRaw.Stride : i*vRaw.Stride+n]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			v := vRow[j]
 			a := real(v)
 			b := imag(v)
@@ -69,12 +69,12 @@ func matLog(A *mat.Dense) (*mat.Dense, error) {
 		}
 	}
 	// Y^T_aug: for row i of Y^T (complex), value at col j is d_i · V_{j,i}.
-	for i := 0; i < n; i++ {
+	for i := range n {
 		d := logVals[i]
 		dr, di := real(d), imag(d)
 		reRow := yaRaw.Data[i*yaRaw.Stride : i*yaRaw.Stride+n]
 		imRow := yaRaw.Data[(i+n)*yaRaw.Stride : (i+n)*yaRaw.Stride+n]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			v := vRaw.Data[j*vRaw.Stride+i]
 			a := real(v)
 			b := imag(v)
@@ -100,10 +100,10 @@ func matLog(A *mat.Dense) (*mat.Dense, error) {
 	result := mat.NewDense(n, n, nil)
 	resRaw := result.RawMatrix()
 	maxIm, maxRe := 0.0, 0.0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		reRow := xRaw.Data[i*xRaw.Stride : i*xRaw.Stride+n]
 		imRow := xRaw.Data[(i+n)*xRaw.Stride : (i+n)*xRaw.Stride+n]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			re := reRow[j]
 			im := imRow[j]
 			// (L^T)_{i,j} = X_{i,j}  ⇒  L_{j,i} = X_{i,j}; set result[j,i].

--- a/matutil.go
+++ b/matutil.go
@@ -89,7 +89,7 @@ func isSymmetric(m *mat.Dense, tol float64) bool {
 		return false
 	}
 	raw := m.RawMatrix()
-	for i := 0; i < r; i++ {
+	for i := range r {
 		for j := i + 1; j < c; j++ {
 			if math.Abs(raw.Data[i*raw.Stride+j]-raw.Data[j*raw.Stride+i]) > tol {
 				return false
@@ -112,14 +112,14 @@ func isPSD(m *mat.Dense) bool {
 	copyStrided(tmp, n, raw.Data, raw.Stride, n, n)
 	symmetrize(tmp, n, n)
 	tol := eps() * denseNorm(m) * float64(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		tmp[i*n+i] += tol
 	}
 	return impl.Dpotrf(blas.Lower, n, tmp, n)
 }
 
 func symmetrize(data []float64, n, stride int) {
-	for i := 0; i < n; i++ {
+	for i := range n {
 		for j := i + 1; j < n; j++ {
 			avg := 0.5 * (data[i*stride+j] + data[j*stride+i])
 			data[i*stride+j] = avg
@@ -129,7 +129,7 @@ func symmetrize(data []float64, n, stride int) {
 }
 
 func copyStrided(dst []float64, dstStride int, src []float64, srcStride int, rows, cols int) {
-	for i := 0; i < rows; i++ {
+	for i := range rows {
 		copy(dst[i*dstStride:i*dstStride+cols], src[i*srcStride:i*srcStride+cols])
 	}
 }

--- a/matutil_test.go
+++ b/matutil_test.go
@@ -14,8 +14,8 @@ func assertMatClose(t *testing.T, name string, got, want *mat.Dense, tol float64
 	if r1 != r2 || c1 != c2 {
 		t.Fatalf("%s: dim mismatch got %dx%d want %dx%d", name, r1, c1, r2, c2)
 	}
-	for i := 0; i < r1; i++ {
-		for j := 0; j < c1; j++ {
+	for i := range r1 {
+		for j := range c1 {
 			if diff := math.Abs(got.At(i, j) - want.At(i, j)); diff > tol {
 				t.Errorf("%s[%d,%d] = %v, want %v (diff %v)", name, i, j, got.At(i, j), want.At(i, j), diff)
 			}
@@ -51,8 +51,8 @@ func matEqual(a, b *mat.Dense, tol float64) bool {
 	if ra != rb || ca != cb {
 		return false
 	}
-	for i := 0; i < ra; i++ {
-		for j := 0; j < ca; j++ {
+	for i := range ra {
+		for j := range ca {
 			if math.Abs(a.At(i, j)-b.At(i, j)) > tol {
 				return false
 			}

--- a/minimal.go
+++ b/minimal.go
@@ -169,11 +169,11 @@ func pertransposeSquare(a *mat.Dense, n int) {
 		j := n - 1 - i
 		ri := raw.Data[i*raw.Stride:]
 		rj := raw.Data[j*raw.Stride:]
-		for k := 0; k < n; k++ {
+		for k := range n {
 			ri[k], rj[k] = rj[k], ri[k]
 		}
 	}
-	for k := 0; k < n; k++ {
+	for k := range n {
 		rk := raw.Data[k*raw.Stride:]
 		for i := 0; i < n/2; i++ {
 			j := n - 1 - i
@@ -234,14 +234,14 @@ func equalize(A, B, C *mat.Dense, n, m, p int) {
 
 	for {
 		noconv := false
-		for i := 0; i < n; i++ {
+		for i := range n {
 			c := 0.0
 			r := 0.0
 			ca := 0.0
 			ra := 0.0
 
 			aRow := aRaw.Data[i*aRaw.Stride:]
-			for j := 0; j < n; j++ {
+			for j := range n {
 				if j == i {
 					continue
 				}
@@ -257,14 +257,14 @@ func equalize(A, B, C *mat.Dense, n, m, p int) {
 				}
 			}
 			bRow := bRaw.Data[i*bRaw.Stride:]
-			for j := 0; j < m; j++ {
+			for j := range m {
 				v := math.Abs(bRow[j])
 				r += v
 				if v > ra {
 					ra = v
 				}
 			}
-			for j := 0; j < p; j++ {
+			for j := range p {
 				v := math.Abs(cRaw.Data[j*cRaw.Stride+i])
 				c += v
 				if v > ca {
@@ -313,16 +313,16 @@ func equalize(A, B, C *mat.Dense, n, m, p int) {
 			noconv = true
 
 			fi := 1.0 / f
-			for j := 0; j < n; j++ {
+			for j := range n {
 				aRow[j] *= fi
 			}
-			for j := 0; j < m; j++ {
+			for j := range m {
 				bRow[j] *= fi
 			}
-			for j := 0; j < n; j++ {
+			for j := range n {
 				aRaw.Data[j*aRaw.Stride+i] *= f
 			}
-			for j := 0; j < p; j++ {
+			for j := range p {
 				cRaw.Data[j*cRaw.Stride+i] *= f
 			}
 		}

--- a/minimal_test.go
+++ b/minimal_test.go
@@ -16,8 +16,8 @@ func markovParams(sys *System, k int) []float64 {
 			return nil
 		}
 		data := make([]float64, p*m)
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				data[i*m+j] = sys.D.At(i, j)
 			}
 		}
@@ -28,7 +28,7 @@ func markovParams(sys *System, k int) []float64 {
 	}
 	// C * A^(k-1) * B
 	pow := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		pow.Set(i, i, 1)
 	}
 	for i := 0; i < k-1; i++ {
@@ -42,8 +42,8 @@ func markovParams(sys *System, k int) []float64 {
 	cab.Mul(&tmp2, sys.B)
 	r, c := cab.Dims()
 	data := make([]float64, r*c)
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			data[i*c+j] = cab.At(i, j)
 		}
 	}
@@ -493,8 +493,8 @@ func TestEqualizeIssue26SystemFinite(t *testing.T) {
 func assertAllFinite(t *testing.T, name string, m *mat.Dense) {
 	t.Helper()
 	r, c := m.Dims()
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			v := m.At(i, j)
 			if math.IsNaN(v) || math.IsInf(v, 0) {
 				t.Errorf("%s[%d,%d] = %v (non-finite)", name, i, j, v)
@@ -525,19 +525,19 @@ func normRatio(A, B, C *mat.Dense) float64 {
 	p, _ := C.Dims()
 	maxNorm := 0.0
 	minNorm := math.Inf(1)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		r, c := 0.0, 0.0
-		for j := 0; j < n; j++ {
+		for j := range n {
 			if j == i {
 				continue
 			}
 			r += math.Abs(A.At(i, j))
 			c += math.Abs(A.At(j, i))
 		}
-		for j := 0; j < m; j++ {
+		for j := range m {
 			r += math.Abs(B.At(i, j))
 		}
-		for j := 0; j < p; j++ {
+		for j := range p {
 			c += math.Abs(C.At(j, i))
 		}
 		if r > maxNorm {

--- a/names.go
+++ b/names.go
@@ -218,9 +218,9 @@ func (sys *System) String() string {
 		}
 		b.WriteString("\n")
 		raw := mat.RawMatrix()
-		for i := 0; i < r; i++ {
+		for i := range r {
 			fmt.Fprintf(&b, "  %*s", rowW, rowLabels[i])
-			for j := 0; j < c; j++ {
+			for j := range c {
 				fmt.Fprintf(&b, "%*g", colW+1, raw.Data[i*raw.Stride+j])
 			}
 			b.WriteString("\n")
@@ -264,7 +264,7 @@ func (sys *System) SelectByIndex(inputs, outputs []int) (*System, error) {
 		bRaw := sys.B.RawMatrix()
 		bsRaw := Bsel.RawMatrix()
 		for k, j := range inputs {
-			for i := 0; i < n; i++ {
+			for i := range n {
 				bsRaw.Data[i*bsRaw.Stride+k] = bRaw.Data[i*bRaw.Stride+j]
 			}
 		}

--- a/norm_covar_test.go
+++ b/norm_covar_test.go
@@ -197,7 +197,7 @@ func TestLsim_Step_Continuous(t *testing.T) {
 	steps := 501
 	tVec := make([]float64, steps)
 	uMat := mat.NewDense(steps, 1, nil)
-	for i := 0; i < steps; i++ {
+	for i := range steps {
 		tVec[i] = float64(i) * 0.01
 		uMat.Set(i, 0, 1.0)
 	}
@@ -225,7 +225,7 @@ func TestLsim_InitialCondition_Continuous(t *testing.T) {
 	steps := 201
 	tVec := make([]float64, steps)
 	uMat := mat.NewDense(steps, 1, nil)
-	for i := 0; i < steps; i++ {
+	for i := range steps {
 		tVec[i] = float64(i) * 0.01
 	}
 	x0 := mat.NewVecDense(1, []float64{5})
@@ -253,7 +253,7 @@ func TestLsim_Discrete(t *testing.T) {
 	steps := 10
 	tVec := make([]float64, steps)
 	uMat := mat.NewDense(steps, 1, nil)
-	for i := 0; i < steps; i++ {
+	for i := range steps {
 		tVec[i] = float64(i) * 0.1
 		uMat.Set(i, 0, 1.0)
 	}

--- a/nyquist.go
+++ b/nyquist.go
@@ -199,10 +199,7 @@ func autoNyquistFreqs(sys *System, poles []complex128, imagPoles []imagAxisPole,
 		}
 	}
 
-	baseN := nPoints * 7 / 10
-	if baseN < 50 {
-		baseN = 50
-	}
+	baseN := max(nPoints*7/10, 50)
 	omega := logspace(math.Log10(wMin), math.Log10(wMax), baseN)
 
 	for _, ip := range imagPoles {
@@ -347,7 +344,7 @@ func indentContour(sys *System, w0 float64, nArc int) ([]complex128, error) {
 	epsR := 1e-4 * math.Max(1, w0)
 	arc := make([]complex128, nArc)
 
-	for i := 0; i < nArc; i++ {
+	for i := range nArc {
 		theta := math.Pi/2 - float64(i)*math.Pi/float64(nArc-1)
 
 		var s complex128
@@ -394,7 +391,7 @@ func windingNumber(contour []complex128, point complex128) int {
 
 	totalAngle := 0.0
 	n := len(contour)
-	for k := 0; k < n; k++ {
+	for k := range n {
 		z1 := contour[k] - point
 		z2 := contour[(k+1)%n] - point
 

--- a/pade.go
+++ b/pade.go
@@ -28,7 +28,7 @@ func (sys *System) Pade(order int) (*System, error) {
 	n, m, p := lft.Dims()
 
 	var delayBank *System
-	for j := 0; j < N; j++ {
+	for j := range N {
 		pd, err := PadeDelay(lft.LFT.Tau[j], order)
 		if err != nil {
 			return nil, fmt.Errorf("Pade: delay %d (tau=%v): %w", j, lft.LFT.Tau[j], err)

--- a/pade_test.go
+++ b/pade_test.go
@@ -197,7 +197,7 @@ func TestPadeDelayOrder2ExactCoeffs(t *testing.T) {
 		// Horner: evaluate descending-order polynomials
 		sn := complex(0, 0)
 		sd := complex(0, 0)
-		for k := 0; k < len(numCoeffs); k++ {
+		for k := range numCoeffs {
 			sn = sn*s + complex(numCoeffs[k], 0)
 			sd = sd*s + complex(denCoeffs[k], 0)
 		}
@@ -209,7 +209,8 @@ func TestPadeDelayOrder2ExactCoeffs(t *testing.T) {
 }
 
 // Julia: for (n, tol) in enumerate([0.05; 1e-3; 1e-5; ...])
-//   evalfr(pade(0.8, n), 1im) ≈ exp(-0.8im) atol=tol
+//
+//	evalfr(pade(0.8, n), 1im) ≈ exp(-0.8im) atol=tol
 func TestPadeDelayAccuracyByOrder(t *testing.T) {
 	tau := 0.8
 	s := complex(0, 1)

--- a/passivity.go
+++ b/passivity.go
@@ -85,8 +85,8 @@ func SpectralFactor(sys *System) (*System, error) {
 		return nil, fmt.Errorf("SpectralFactor: model must be square, got %dx%d: %w", p, m, ErrDimensionMismatch)
 	}
 	D := newDense(p, m)
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			if i != j && sys.D.At(i, j) != 0 {
 				return nil, fmt.Errorf("SpectralFactor: only diagonal positive static gains are supported: %w", ErrDimensionMismatch)
 			}
@@ -128,8 +128,8 @@ func minHermitianPart(h [][]complex128) float64 {
 	}
 	dim := 2 * n
 	sym := mat.NewSymDense(dim, nil)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			herm := (h[i][j] + cmplx.Conj(h[j][i])) / 2
 			re := real(herm)
 			im := imag(herm)

--- a/poly.go
+++ b/poly.go
@@ -51,10 +51,7 @@ func (p Poly) Add(q Poly) Poly {
 		copy(r, p)
 		return r
 	}
-	size := n
-	if m > size {
-		size = m
-	}
+	size := max(m, n)
 	r := make(Poly, size)
 	for i := range r {
 		var pv, qv float64
@@ -123,10 +120,7 @@ func (p Poly) AddTo(dst Poly, q Poly) Poly {
 	if n == 0 && m == 0 {
 		return dst[:0]
 	}
-	size := n
-	if m > size {
-		size = m
-	}
+	size := max(m, n)
 	if cap(dst) < size {
 		dst = make(Poly, size)
 	} else {
@@ -175,7 +169,7 @@ func (p Poly) Roots() ([]complex128, error) {
 
 	lead := p[0]
 	data := make([]float64, deg*deg)
-	for i := 0; i < deg; i++ {
+	for i := range deg {
 		data[i*deg+deg-1] = -p[deg-i] / lead
 		if i > 0 {
 			data[i*deg+i-1] = 1
@@ -215,10 +209,7 @@ func (p Poly) Sub(q Poly) Poly {
 		copy(r, p)
 		return r
 	}
-	size := n
-	if m > size {
-		size = m
-	}
+	size := max(m, n)
 	r := make(Poly, size)
 	for i := range r {
 		var pv, qv float64
@@ -239,7 +230,7 @@ func (p Poly) Derivative() Poly {
 	}
 	deg := len(p) - 1
 	r := make(Poly, deg)
-	for i := 0; i < deg; i++ {
+	for i := range deg {
 		r[i] = p[i] * float64(deg-i)
 	}
 	return r

--- a/polynomial_channel.go
+++ b/polynomial_channel.go
@@ -41,7 +41,7 @@ func (ch rationalChannel) eval(s complex128) complex128 {
 	h := complex(ch.gain, 0)
 
 	shared := min(nz, np)
-	for k := 0; k < shared; k++ {
+	for k := range shared {
 		h *= (s - ch.zeros[k]) / (s - ch.poles[k])
 	}
 	for k := shared; k < nz; k++ {

--- a/qr_colpivot.go
+++ b/qr_colpivot.go
@@ -23,7 +23,7 @@ func colPivotQR(m, n int, a []float64, lda int, rcond, svlmax float64) (rank int
 
 	colBuf := make([]float64, m)
 
-	for j := 0; j < n; j++ {
+	for j := range n {
 		nrm := blas64.Nrm2(blas64.Vector{N: m, Data: a[j:], Inc: lda})
 		cnorm[j] = nrm
 		cnormSave[j] = nrm

--- a/random_test.go
+++ b/random_test.go
@@ -32,7 +32,7 @@ func TestRss_Basic(t *testing.T) {
 }
 
 func TestRss_StrictStability(t *testing.T) {
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		sys, err := Rss(8, 1, 1)
 		if err != nil {
 			t.Fatal(err)
@@ -83,7 +83,7 @@ func TestDrss_Basic(t *testing.T) {
 }
 
 func TestDrss_StrictStability(t *testing.T) {
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		sys, err := Drss(6, 2, 2, 0.05)
 		if err != nil {
 			t.Fatal(err)

--- a/response.go
+++ b/response.go
@@ -262,8 +262,8 @@ func (sys *System) DCGain() (*mat.Dense, error) {
 	}
 
 	ImA := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			v := -sys.A.At(i, j)
 			if i == j {
 				v += 1
@@ -305,7 +305,7 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 	tol := dcGainMatrixTol(sys.A)
 	singular := make([]bool, n)
 	regularCount := 0
-	for k := 0; k < n; k++ {
+	for k := range n {
 		if math.Abs(sys.A.At(k, k)-target) <= tol && rowColDecoupledAt(sys.A, k, tol) {
 			singular[k] = true
 			continue
@@ -317,7 +317,7 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 	}
 
 	regular := make([]int, 0, regularCount)
-	for k := 0; k < n; k++ {
+	for k := range n {
 		if !singular[k] {
 			regular = append(regular, k)
 		}
@@ -332,10 +332,10 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 			for ci, srcCol := range regular {
 				Areg.Set(ri, ci, sys.A.At(srcRow, srcCol))
 			}
-			for j := 0; j < m; j++ {
+			for j := range m {
 				Breg.Set(ri, j, sys.B.At(srcRow, j))
 			}
-			for i := 0; i < p; i++ {
+			for i := range p {
 				Creg.Set(i, ri, sys.C.At(i, srcRow))
 			}
 		}
@@ -369,16 +369,16 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 	}
 
 	residue := mat.NewDense(p, m, nil)
-	for k := 0; k < n; k++ {
+	for k := range n {
 		if !singular[k] {
 			continue
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			c := sys.C.At(i, k)
 			if math.Abs(c) <= tol {
 				continue
 			}
-			for j := 0; j < m; j++ {
+			for j := range m {
 				coeff := c * sys.B.At(k, j)
 				if math.Abs(coeff) > tol {
 					residue.Set(i, j, residue.At(i, j)+coeff)
@@ -386,8 +386,8 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 			}
 		}
 	}
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			coeff := residue.At(i, j)
 			if math.Abs(coeff) > tol {
 				gain.Set(i, j, math.Inf(signInt(coeff)))
@@ -399,7 +399,7 @@ func (sys *System) dcGainByDecoupledSingularModes() (*mat.Dense, bool) {
 
 func rowColDecoupledAt(a *mat.Dense, k int, tol float64) bool {
 	n, _ := a.Dims()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i == k {
 			continue
 		}
@@ -421,8 +421,8 @@ func dcGainFromTransferFunction(tf *TransferFunc) *mat.Dense {
 		point = 1.0
 	}
 	gain := mat.NewDense(p, m, nil)
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			gain.Set(i, j, rationalLimitAtReal(tf.Num[i][j], tf.Den[i], point))
 		}
 	}
@@ -549,7 +549,7 @@ func Step(sys *System, tFinal float64) (*TimeResponse, error) {
 	rows := p * m
 	Y := mat.NewDense(rows, plan.steps, nil)
 
-	for j := 0; j < m; j++ {
+	for j := range m {
 		u := mat.NewDense(m, plan.steps, nil)
 		for k := 0; k < plan.steps; k++ {
 			u.Set(j, k, 1)
@@ -559,7 +559,7 @@ func Step(sys *System, tFinal float64) (*TimeResponse, error) {
 			return nil, fmt.Errorf("Step: input %d: %w", j, err)
 		}
 		if resp.Y != nil {
-			for i := 0; i < p; i++ {
+			for i := range p {
 				for k := 0; k < plan.steps; k++ {
 					Y.Set(j*p+i, k, resp.Y.At(i, k))
 				}
@@ -585,7 +585,7 @@ func Impulse(sys *System, tFinal float64) (*TimeResponse, error) {
 		amp = 1.0 / plan.dt
 	}
 
-	for j := 0; j < m; j++ {
+	for j := range m {
 		u := mat.NewDense(m, plan.steps, nil)
 		u.Set(j, 0, amp)
 		resp, err := plan.sim.Simulate(u, nil, nil)
@@ -593,7 +593,7 @@ func Impulse(sys *System, tFinal float64) (*TimeResponse, error) {
 			return nil, fmt.Errorf("Impulse: input %d: %w", j, err)
 		}
 		if resp.Y != nil {
-			for i := 0; i < p; i++ {
+			for i := range p {
 				for k := 0; k < plan.steps; k++ {
 					Y.Set(j*p+i, k, resp.Y.At(i, k))
 				}

--- a/response_info.go
+++ b/response_info.go
@@ -47,7 +47,7 @@ func StepInfo(resp *TimeResponse, opts *StepInfoOptions) (*StepInfoResult, error
 		return nil, fmt.Errorf("StepInfo: steady-state values length %d does not match response rows %d: %w", len(cfg.SteadyStateValue), rows, ErrDimensionMismatch)
 	}
 	metrics := make([]StepMetric, rows)
-	for row := 0; row < rows; row++ {
+	for row := range rows {
 		metrics[row] = stepMetricForRow(resp, row, cfg)
 	}
 	return &StepInfoResult{Metrics: metrics, OutputName: copyStringSlice(resp.OutputName)}, nil
@@ -182,7 +182,7 @@ func crossingTime(resp *TimeResponse, row int, level, direction float64) float64
 func settlingTime(resp *TimeResponse, row int, final, band float64) (float64, bool) {
 	_, cols := resp.Y.Dims()
 	lastOutside := -1
-	for k := 0; k < cols; k++ {
+	for k := range cols {
 		if math.Abs(resp.Y.At(row, k)-final) > band {
 			lastOutside = k
 		}
@@ -199,7 +199,7 @@ func settlingTime(resp *TimeResponse, row int, final, band float64) (float64, bo
 func rowUndershoot(resp *TimeResponse, row int, initial, direction, scale float64) float64 {
 	_, cols := resp.Y.Dims()
 	worst := 0.0
-	for k := 0; k < cols; k++ {
+	for k := range cols {
 		opposite := direction * (initial - resp.Y.At(row, k))
 		if opposite > worst {
 			worst = opposite

--- a/response_test.go
+++ b/response_test.go
@@ -320,7 +320,7 @@ func TestStep_SISO_Continuous(t *testing.T) {
 	}
 
 	_, steps := resp.Y.Dims()
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		tk := resp.T[k]
 		want := 1 - math.Exp(-tk)
 		got := resp.Y.At(0, k)
@@ -344,7 +344,7 @@ func TestStep_Discrete_Integrator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for k := 0; k < 5; k++ {
+	for k := range 5 {
 		got := resp.Y.At(0, k)
 		want := float64(k)
 		if math.Abs(got-want) > 1e-12 {
@@ -374,8 +374,8 @@ func TestStep_MIMO_NonSymmetricA(t *testing.T) {
 
 	dcGain, _ := sys.DCGain()
 	lastK := steps - 1
-	for j := 0; j < 2; j++ {
-		for i := 0; i < 2; i++ {
+	for j := range 2 {
+		for i := range 2 {
 			got := resp.Y.At(j*2+i, lastK)
 			want := dcGain.At(i, j)
 			if math.Abs(got-want) > 0.05 {
@@ -393,7 +393,7 @@ func TestStep_PureGain(t *testing.T) {
 	}
 
 	_, steps := resp.Y.Dims()
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		if math.Abs(resp.Y.At(0, k)-3.0) > 1e-12 {
 			t.Errorf("k=%d: got %f, want 3.0", k, resp.Y.At(0, k))
 		}
@@ -471,7 +471,7 @@ func TestInitial_SISO_Continuous(t *testing.T) {
 	}
 
 	_, steps := resp.Y.Dims()
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		tk := resp.T[k]
 		want := math.Exp(-tk)
 		got := resp.Y.At(0, k)

--- a/rlocus.go
+++ b/rlocus.go
@@ -51,15 +51,15 @@ func RootLocus(sys *System, gains []float64) (*RootLocusResult, error) {
 	bRaw := sys.B.RawMatrix()
 	cRaw := sys.C.RawMatrix()
 	bc := make([]float64, n*n)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			bc[i*n+j] = bRaw.Data[i*bRaw.Stride] * cRaw.Data[j]
 		}
 	}
 
 	aRaw := sys.A.RawMatrix()
 	aFlat := make([]float64, n*n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		copy(aFlat[i*n:i*n+n], aRaw.Data[i*aRaw.Stride:i*aRaw.Stride+n])
 	}
 
@@ -91,7 +91,7 @@ func RootLocus(sys *System, gains []float64) (*RootLocusResult, error) {
 	diff := nPoles - nZeros
 	if diff > 0 {
 		asymAngles = make([]float64, diff)
-		for k := 0; k < diff; k++ {
+		for k := range diff {
 			asymAngles[k] = float64(2*k+1) * math.Pi / float64(diff)
 		}
 		sumP := 0.0
@@ -150,7 +150,7 @@ func defaultGains() []float64 {
 	n := 200
 	gains := make([]float64, n+1)
 	gains[0] = 0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		exp := -6.0 + 12.0*float64(i)/float64(n-1)
 		gains[i+1] = math.Pow(10, exp)
 	}
@@ -176,10 +176,10 @@ func makeBranches(allEigs [][]complex128, nStates, nGains int) [][]complex128 {
 			used[i] = false
 		}
 
-		for i := 0; i < nStates; i++ {
+		for i := range nStates {
 			bestJ := -1
 			bestDist := math.Inf(1)
-			for j := 0; j < nStates; j++ {
+			for j := range nStates {
 				if used[j] {
 					continue
 				}
@@ -193,16 +193,16 @@ func makeBranches(allEigs [][]complex128, nStates, nGains int) [][]complex128 {
 			used[bestJ] = true
 		}
 		row := make([]complex128, nStates)
-		for i := 0; i < nStates; i++ {
+		for i := range nStates {
 			row[i] = cur[perm[i]]
 		}
 		ordered[gi] = row
 	}
 
 	branches := make([][]complex128, nStates)
-	for b := 0; b < nStates; b++ {
+	for b := range nStates {
 		branches[b] = make([]complex128, nGains)
-		for gi := 0; gi < nGains; gi++ {
+		for gi := range nGains {
 			branches[b][gi] = ordered[gi][b]
 		}
 	}

--- a/rq_rowpivot.go
+++ b/rq_rowpivot.go
@@ -18,7 +18,7 @@ func rowPivotRQ(m, n int, a []float64, lda int, rcond, svlmax float64) (rank int
 	tolz := math.Sqrt(eps())
 
 	norms := make([]float64, 2*m)
-	for i := 0; i < m; i++ {
+	for i := range m {
 		norms[i] = blas64.Nrm2(blas64.Vector{N: n, Data: a[i*lda:], Inc: 1})
 		norms[m+i] = norms[i]
 		jpvt[i] = i
@@ -84,7 +84,7 @@ func rowPivotRQ(m, n int, a []float64, lda int, rcond, svlmax float64) (rank int
 				impl.Dlarf(blas.Right, row, nki, a[row*lda:], 1, tau[tauIdx], a, lda, work[:row])
 				a[row*lda+col] = aii
 
-				for j := 0; j < row; j++ {
+				for j := range row {
 					if norms[j] != 0 {
 						temp := math.Abs(a[j*lda+col]) / norms[j]
 						temp = math.Max((1+temp)*(1-temp), 0)

--- a/safe_feedback.go
+++ b/safe_feedback.go
@@ -134,7 +134,7 @@ func buildDiagWithPade(channel, size int, pade *System) (*System, error) {
 	B := mat.NewDense(n, size, nil)
 	C := mat.NewDense(size, n, nil)
 	dData := make([]float64, size*size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		dData[i*size+i] = 1
 	}
 	D := mat.NewDense(size, size, dData)
@@ -143,12 +143,12 @@ func buildDiagWithPade(channel, size int, pade *System) (*System, error) {
 		setBlock(A, 0, 0, pade.A)
 
 		padeB := pade.B.RawMatrix()
-		for i := 0; i < np; i++ {
+		for i := range np {
 			B.Set(i, channel, padeB.Data[i*padeB.Stride])
 		}
 
 		padeC := pade.C.RawMatrix()
-		for j := 0; j < np; j++ {
+		for j := range np {
 			C.Set(channel, j, padeC.Data[j])
 		}
 	}

--- a/signal_metadata.go
+++ b/signal_metadata.go
@@ -96,7 +96,7 @@ func fohStateMetadata(src *System, n, m int) []string {
 	if src.StateName != nil {
 		copy(names, src.StateName)
 	}
-	for j := 0; j < m; j++ {
+	for j := range m {
 		if src.InputName != nil && j < len(src.InputName) {
 			names[n+j] = src.InputName[j] + "_prev"
 		}

--- a/simulate.go
+++ b/simulate.go
@@ -171,13 +171,13 @@ func (sys *System) simulateNoDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simulat
 			bGen := sys.B.RawMatrix()
 			uColVec := blas64.Vector{N: m, Inc: 1, Data: uColData}
 
-			for k := 0; k < steps; k++ {
+			for k := range steps {
 				blas64.Gemv(blas.NoTrans, 1, cGen, xVec, 0, ykVec)
-				for i := 0; i < p; i++ {
+				for i := range p {
 					yRaw.Data[i*yRaw.Stride+k] = ykData[i]
 				}
 
-				for j := 0; j < m; j++ {
+				for j := range m {
 					uColData[j] = uRaw.Data[j*uRaw.Stride+k]
 				}
 				blas64.Gemv(blas.NoTrans, 1, aGen, xVec, 0, tmpVec)
@@ -186,9 +186,9 @@ func (sys *System) simulateNoDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simulat
 				xVec, tmpVec = tmpVec, xVec
 			}
 		} else {
-			for k := 0; k < steps; k++ {
+			for k := range steps {
 				blas64.Gemv(blas.NoTrans, 1, cGen, xVec, 0, ykVec)
-				for i := 0; i < p; i++ {
+				for i := range p {
 					yRaw.Data[i*yRaw.Stride+k] = ykData[i]
 				}
 
@@ -240,9 +240,9 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simul
 		yk := mat.NewVecDense(p, nil)
 		yAutoRaw := Y.RawMatrix()
 		ykRaw := yk.RawVector()
-		for k := 0; k < steps; k++ {
+		for k := range steps {
 			yk.MulVec(sys.C, x)
-			for i := 0; i < p; i++ {
+			for i := range p {
 				yAutoRaw.Data[i*yAutoRaw.Stride+k] = ykRaw.Data[i*ykRaw.Inc]
 			}
 			tmp.MulVec(sys.A, x)
@@ -261,8 +261,8 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simul
 	yRaw := Y.RawMatrix()
 
 	delayIdx := make([]int, p*m)
-	for i := 0; i < p; i++ {
-		for j := 0; j < m; j++ {
+	for i := range p {
+		for j := range m {
 			d := int(math.Round(delayRaw.Data[i*delayRaw.Stride+j]))
 			if d < 0 {
 				return nil, fmt.Errorf("%w: delay(%d,%d) = %d", ErrNegativeDelay, i, j, d)
@@ -282,7 +282,7 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simul
 		bRaw = sys.B.RawMatrix()
 	}
 
-	for k := 0; k < steps; k++ {
+	for k := range steps {
 		var nextRaw blas64.General
 		if n > 0 {
 			yForced.Mul(sys.C, xCols)
@@ -292,7 +292,7 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simul
 			yForced.Zero()
 		}
 
-		for j := 0; j < m; j++ {
+		for j := range m {
 			uk := uRaw.Data[j*uRaw.Stride+k]
 			if n > 0 && uk != 0 {
 				blas64.Axpy(uk,
@@ -300,7 +300,7 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simul
 					blas64.Vector{N: n, Inc: nextRaw.Stride, Data: nextRaw.Data[j:]},
 				)
 			}
-			for i := 0; i < p; i++ {
+			for i := range p {
 				outIdx := k + delayIdx[i*m+j]
 				if outIdx >= steps {
 					continue
@@ -318,9 +318,9 @@ func (sys *System) simulateWithDelay(u *mat.Dense, x0 *mat.VecDense, opts *Simul
 	if xFinal != nil {
 		xRaw := xCols.RawMatrix()
 		xFinalRaw := xFinal.RawVector()
-		for i := 0; i < n; i++ {
+		for i := range n {
 			sum := xFinalRaw.Data[i*xFinalRaw.Inc]
-			for j := 0; j < m; j++ {
+			for j := range m {
 				sum += xRaw.Data[i*xRaw.Stride+j]
 			}
 			xFinalRaw.Data[i*xFinalRaw.Inc] = sum
@@ -341,7 +341,7 @@ func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense, opt
 
 	delays := make([]int, N)
 	maxDelay := 0
-	for j := 0; j < N; j++ {
+	for j := range N {
 		delays[j] = int(math.Round(sys.LFT.Tau[j]))
 		if delays[j] > maxDelay {
 			maxDelay = delays[j]
@@ -414,8 +414,8 @@ func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense, opt
 	zVec := blas64.Vector{N: N, Inc: 1, Data: zData}
 	uColVec := blas64.Vector{N: m, Inc: 1, Data: uColData}
 
-	for k := 0; k < steps; k++ {
-		for j := 0; j < N; j++ {
+	for k := range steps {
+		for j := range N {
 			dj := delays[j]
 			if dj == 0 {
 				if k == 0 {
@@ -431,7 +431,7 @@ func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense, opt
 		}
 
 		if m > 0 {
-			for i := 0; i < m; i++ {
+			for i := range m {
 				uColData[i] = uData[i*uStride+k]
 			}
 		}
@@ -449,7 +449,7 @@ func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense, opt
 		if N > 0 {
 			blas64.Gemv(blas.NoTrans, 1, d12Gen, wVec, 1, ykVec)
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			yRaw.Data[i*yRaw.Stride+k] = ykData[i]
 		}
 
@@ -467,7 +467,7 @@ func (sys *System) simulateWithInternalDelay(u *mat.Dense, x0 *mat.VecDense, opt
 			blas64.Gemv(blas.NoTrans, 1, d22Gen, wVec, 1, zVec)
 
 			idx := k % (bufSize + 1)
-			for j := 0; j < N; j++ {
+			for j := range N {
 				zBuf[j*(bufSize+1)+idx] = zData[j]
 			}
 		}

--- a/simulate_test.go
+++ b/simulate_test.go
@@ -57,7 +57,7 @@ func TestSimulateManualPropagation(t *testing.T) {
 	wantY := make([]float64, 3)
 	wantX := make([]float64, 2)
 
-	for k := 0; k < 3; k++ {
+	for k := range 3 {
 		wantY[k] = 1*x[0] + 0*x[1] + 0.5*uu[k]
 		nx0 := 0.9*x[0] + 0.1*x[1] + 1*uu[k]
 		nx1 := 0.0*x[0] + 0.8*x[1] + 0*uu[k]
@@ -106,13 +106,13 @@ func TestSimulateChaining(t *testing.T) {
 	}
 
 	// r1.Y columns 0..2 should match rAll.Y columns 0..2
-	for k := 0; k < 3; k++ {
+	for k := range 3 {
 		if math.Abs(r1.Y.At(0, k)-rAll.Y.At(0, k)) > 1e-12 {
 			t.Errorf("chaining mismatch at step %d: r1=%f rAll=%f", k, r1.Y.At(0, k), rAll.Y.At(0, k))
 		}
 	}
 	// r2.Y columns 0..1 should match rAll.Y columns 3..4
-	for k := 0; k < 2; k++ {
+	for k := range 2 {
 		if math.Abs(r2.Y.At(0, k)-rAll.Y.At(0, k+3)) > 1e-12 {
 			t.Errorf("chaining mismatch at step %d: r2=%f rAll=%f", k+3, r2.Y.At(0, k), rAll.Y.At(0, k+3))
 		}
@@ -442,7 +442,7 @@ func TestSimulate_WithInputDelay(t *testing.T) {
 	ref.Delay = mat.NewDense(1, 1, []float64{3})
 
 	u := mat.NewDense(1, 10, nil)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		u.Set(0, i, 1)
 	}
 
@@ -479,7 +479,7 @@ func TestSimulate_WithOutputDelay(t *testing.T) {
 	ref.Delay = mat.NewDense(1, 1, []float64{3})
 
 	u := mat.NewDense(1, 10, nil)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		u.Set(0, i, 1)
 	}
 
@@ -517,7 +517,7 @@ func TestSimulate_WithCombinedDelays(t *testing.T) {
 	ref.Delay = mat.NewDense(1, 1, []float64{3})
 
 	u := mat.NewDense(1, 10, nil)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		u.Set(0, i, 1)
 	}
 
@@ -554,7 +554,7 @@ func TestSimulate_WithMIMOInputDelay(t *testing.T) {
 	ref.Delay = mat.NewDense(2, 2, []float64{1, 3, 1, 3})
 
 	u := mat.NewDense(2, 8, nil)
-	for j := 0; j < 8; j++ {
+	for j := range 8 {
 		u.Set(0, j, 1)
 		u.Set(1, j, 0.5)
 	}
@@ -592,7 +592,7 @@ func TestSimulate_WithMIMOOutputDelay(t *testing.T) {
 	ref.Delay = mat.NewDense(2, 2, []float64{2, 2, 0, 0})
 
 	u := mat.NewDense(2, 8, nil)
-	for j := 0; j < 8; j++ {
+	for j := range 8 {
 		u.Set(0, j, 1)
 		u.Set(1, j, 0.5)
 	}
@@ -632,7 +632,7 @@ func TestSimulate_WithAllDelayTypes(t *testing.T) {
 	ref.Delay = mat.NewDense(2, 2, []float64{1, 1, 4, 2})
 
 	u := mat.NewDense(2, 10, nil)
-	for j := 0; j < 10; j++ {
+	for j := range 10 {
 		u.Set(0, j, 1)
 		u.Set(1, j, 0.5)
 	}
@@ -676,7 +676,7 @@ func TestSimulate_InternalDelay_SISO(t *testing.T) {
 	}
 
 	u := mat.NewDense(1, 15, nil)
-	for i := 0; i < 15; i++ {
+	for i := range 15 {
 		u.Set(0, i, float64(i+1)*0.1)
 	}
 
@@ -721,7 +721,7 @@ func TestSimulate_InternalDelay_MultipleDelays(t *testing.T) {
 	}
 
 	u := mat.NewDense(2, 12, nil)
-	for j := 0; j < 12; j++ {
+	for j := range 12 {
 		u.Set(0, j, 1.0)
 		u.Set(1, j, 0.5)
 	}
@@ -767,7 +767,7 @@ func TestSimulate_InternalDelay_WithX0(t *testing.T) {
 
 	x0 := mat.NewVecDense(2, []float64{1.0, -0.5})
 	u := mat.NewDense(1, 10, nil)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		u.Set(0, i, 1.0)
 	}
 
@@ -803,7 +803,7 @@ func TestSimulate_InternalDelay_D22Nonzero(t *testing.T) {
 	}
 
 	u := mat.NewDense(1, 8, nil)
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		u.Set(0, i, 1.0)
 	}
 
@@ -816,7 +816,7 @@ func TestSimulate_InternalDelay_D22Nonzero(t *testing.T) {
 	wantY := make([]float64, 8)
 	zHist := make([]float64, 8)
 
-	for k := 0; k < 8; k++ {
+	for k := range 8 {
 		wk := 0.0
 		if k >= 2 {
 			wk = zHist[k-2]
@@ -860,7 +860,7 @@ func TestSimulate_InternalDelay_NonUnitDt(t *testing.T) {
 	}
 
 	u := mat.NewDense(1, 10, nil)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		u.Set(0, i, 1.0)
 	}
 

--- a/ss.go
+++ b/ss.go
@@ -2,6 +2,7 @@ package controlsys
 
 import (
 	"fmt"
+	"slices"
 
 	"gonum.org/v1/gonum/mat"
 )
@@ -91,10 +92,8 @@ func (sys *System) Validate() error {
 		if err := validateSliceDelay(sys.LFT.Tau, N, sys.Dt); err != nil {
 			return err
 		}
-		for _, v := range sys.LFT.Tau {
-			if v == 0 {
-				return ErrZeroInternalDelay
-			}
+		if slices.Contains(sys.LFT.Tau, 0) {
+			return ErrZeroInternalDelay
 		}
 		if err := validateLFTDims(n, m, p, N, sys.LFT.B2, sys.LFT.C2, sys.LFT.D12, sys.LFT.D21, sys.LFT.D22); err != nil {
 			return err

--- a/ssbal.go
+++ b/ssbal.go
@@ -37,22 +37,22 @@ func Ssbal(sys *System) (*SsbalResult, error) {
 	// Iterative diagonal balancing
 	const maxIter = 20
 	const beta = 2.0
-	for iter := 0; iter < maxIter; iter++ {
+	for range maxIter {
 		changed := false
-		for i := 0; i < n; i++ {
+		for i := range n {
 			rowNorm := 0.0
 			colNorm := 0.0
 
-			for j := 0; j < n; j++ {
+			for j := range n {
 				rowNorm += math.Abs(aRaw.Data[i*aRaw.Stride+j]) * d[j]
 				colNorm += math.Abs(aRaw.Data[j*aRaw.Stride+i]) * d[j]
 			}
 
-			for j := 0; j < m; j++ {
+			for j := range m {
 				rowNorm += math.Abs(bRaw.Data[i*bRaw.Stride+j])
 			}
 
-			for j := 0; j < p; j++ {
+			for j := range p {
 				colNorm += math.Abs(cRaw.Data[j*cRaw.Stride+i])
 			}
 
@@ -85,22 +85,22 @@ func Ssbal(sys *System) (*SsbalResult, error) {
 	}
 
 	Anew := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			Anew.Set(i, j, (d[i]/d[j])*aRaw.Data[i*aRaw.Stride+j])
 		}
 	}
 
 	Bnew := mat.NewDense(n, m, nil)
-	for i := 0; i < n; i++ {
-		for j := 0; j < m; j++ {
+	for i := range n {
+		for j := range m {
 			Bnew.Set(i, j, d[i]*bRaw.Data[i*bRaw.Stride+j])
 		}
 	}
 
 	Cnew := mat.NewDense(p, n, nil)
-	for i := 0; i < p; i++ {
-		for j := 0; j < n; j++ {
+	for i := range p {
+		for j := range n {
 			Cnew.Set(i, j, cRaw.Data[i*cRaw.Stride+j]/d[j])
 		}
 	}
@@ -108,7 +108,7 @@ func Ssbal(sys *System) (*SsbalResult, error) {
 	Dnew := denseCopy(sys.D)
 
 	T := mat.NewDense(n, n, nil)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		T.Set(i, i, d[i])
 	}
 

--- a/ssbal_test.go
+++ b/ssbal_test.go
@@ -54,7 +54,7 @@ func TestSsbal_AlreadyBalanced(t *testing.T) {
 	}
 
 	n, _, _ := sys.Dims()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		d := res.T.At(i, i)
 		if math.Abs(d-1) > 1 {
 			t.Errorf("T[%d,%d] = %g, expected near 1 for already balanced system", i, i, d)
@@ -101,8 +101,8 @@ func TestSsbal_TransformIsDiagonal(t *testing.T) {
 	}
 
 	n, _, _ := sys.Dims()
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			if i != j && res.T.At(i, j) != 0 {
 				t.Errorf("T[%d,%d] = %g, want 0 (T should be diagonal)", i, j, res.T.At(i, j))
 			}

--- a/staircase_test.go
+++ b/staircase_test.go
@@ -138,7 +138,7 @@ func TestStaircaseOrthogonalSimilarity(t *testing.T) {
 
 	_, bCols := res.B.Dims()
 	for i := res.NCont; i < 3; i++ {
-		for j := 0; j < bCols; j++ {
+		for j := range bCols {
 			if v := math.Abs(res.B.At(i, j)); v > 1e-10 {
 				t.Errorf("B[%d,%d] = %g, expected ~0 in uncontrollable rows", i, j, res.B.At(i, j))
 			}

--- a/state_space_utils.go
+++ b/state_space_utils.go
@@ -91,7 +91,7 @@ func (sys *System) FixedInputReduction(fixed map[int]float64, offsetName string)
 		}
 		fixedSeen[idx] = true
 	}
-	for j := 0; j < m; j++ {
+	for j := range m {
 		if !fixedSeen[j] {
 			keep = append(keep, j)
 		}
@@ -105,19 +105,19 @@ func (sys *System) FixedInputReduction(fixed map[int]float64, offsetName string)
 	srcBRaw := sys.B.RawMatrix()
 	srcDRaw := sys.D.RawMatrix()
 	for outCol, inCol := range keep {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			bRaw.Data[i*bRaw.Stride+outCol] = srcBRaw.Data[i*srcBRaw.Stride+inCol]
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			dRaw.Data[i*dRaw.Stride+outCol] = srcDRaw.Data[i*srcDRaw.Stride+inCol]
 		}
 	}
 	offsetCol := len(keep)
 	for inCol, value := range fixed {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			bRaw.Data[i*bRaw.Stride+offsetCol] += srcBRaw.Data[i*srcBRaw.Stride+inCol] * value
 		}
-		for i := 0; i < p; i++ {
+		for i := range p {
 			dRaw.Data[i*dRaw.Stride+offsetCol] += srcDRaw.Data[i*srcDRaw.Stride+inCol] * value
 		}
 	}
@@ -192,7 +192,7 @@ func selectInputDelayWithOffset(delay *mat.Dense, inputs []int, p, mNew int) *ma
 		return nil
 	}
 	out := mat.NewDense(p, mNew, nil)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		for j, idx := range inputs {
 			out.Set(i, j, delay.At(i, idx))
 		}
@@ -206,7 +206,7 @@ func selectLFTD12Columns(D12 *mat.Dense, inputs []int) *mat.Dense {
 	}
 	r, _ := D12.Dims()
 	out := mat.NewDense(r, len(inputs)+1, nil)
-	for i := 0; i < r; i++ {
+	for i := range r {
 		for j, idx := range inputs {
 			out.Set(i, j, D12.At(i, idx))
 		}

--- a/sumblk.go
+++ b/sumblk.go
@@ -298,11 +298,8 @@ func (p *parsedSumBlock) directMatrix() *mat.Dense {
 		for name, coeff := range merged {
 			col0 := inputColStart[name]
 			wIn := p.widths[name]
-			diag := w
-			if wIn < diag {
-				diag = wIn
-			}
-			for k := 0; k < diag; k++ {
+			diag := min(wIn, w)
+			for k := range diag {
 				D.Set(rowOff+k, col0+k, coeff)
 			}
 		}

--- a/sysid.go
+++ b/sysid.go
@@ -31,19 +31,19 @@ func ERA(markov []*mat.Dense, order int, dt float64) (*ERAResult, error) {
 	h0Data := make([]float64, h0Rows*h0Cols)
 	h1Data := make([]float64, h0Rows*h0Cols)
 
-	for i := 0; i < r; i++ {
-		for j := 0; j < r; j++ {
+	for i := range r {
+		for j := range r {
 			idx0 := i + j + 1
 			idx1 := i + j + 2
 			mk0 := markov[idx0].RawMatrix()
-			for bi := 0; bi < p; bi++ {
+			for bi := range p {
 				srcOff := bi * mk0.Stride
 				dstOff := (i*p+bi)*h0Cols + j*m
 				copy(h0Data[dstOff:dstOff+m], mk0.Data[srcOff:srcOff+m])
 			}
 			if idx1 < len(markov) {
 				mk1 := markov[idx1].RawMatrix()
-				for bi := 0; bi < p; bi++ {
+				for bi := range p {
 					srcOff := bi * mk1.Stride
 					dstOff := (i*p+bi)*h0Cols + j*m
 					copy(h1Data[dstOff:dstOff+m], mk1.Data[srcOff:srcOff+m])
@@ -78,7 +78,7 @@ func ERA(markov []*mat.Dense, order int, dt float64) (*ERAResult, error) {
 
 	snHalfInvData := make([]float64, order)
 	snHalfData := make([]float64, order)
-	for i := 0; i < order; i++ {
+	for i := range order {
 		s := allSigma[i]
 		sq := math.Sqrt(s)
 		snHalfData[i] = sq
@@ -93,8 +93,8 @@ func ERA(markov []*mat.Dense, order int, dt float64) (*ERAResult, error) {
 
 	aData := make([]float64, order*order)
 	utH1VRaw := utH1V.RawMatrix()
-	for i := 0; i < order; i++ {
-		for j := 0; j < order; j++ {
+	for i := range order {
+		for j := range order {
 			aData[i*order+j] = snHalfInvData[i] * utH1VRaw.Data[i*utH1VRaw.Stride+j] * snHalfInvData[j]
 		}
 	}
@@ -103,8 +103,8 @@ func ERA(markov []*mat.Dense, order int, dt float64) (*ERAResult, error) {
 	// B = first m columns of Sn^{1/2} * Vn'
 	bData := make([]float64, order*m)
 	vnRaw := vn.RawMatrix()
-	for i := 0; i < order; i++ {
-		for j := 0; j < m; j++ {
+	for i := range order {
+		for j := range m {
 			bData[i*m+j] = snHalfData[i] * vnRaw.Data[j*vnRaw.Stride+i]
 		}
 	}
@@ -113,8 +113,8 @@ func ERA(markov []*mat.Dense, order int, dt float64) (*ERAResult, error) {
 	// C = first p rows of Un * Sn^{1/2}
 	cData := make([]float64, p*order)
 	unRaw := un.RawMatrix()
-	for i := 0; i < p; i++ {
-		for j := 0; j < order; j++ {
+	for i := range p {
+		for j := range order {
 			cData[i*order+j] = unRaw.Data[i*unRaw.Stride+j] * snHalfData[j]
 		}
 	}

--- a/sysid_test.go
+++ b/sysid_test.go
@@ -15,7 +15,7 @@ func impulseMarkov(t *testing.T, sys *System, steps int) []*mat.Dense {
 	_, m, p := sys.Dims()
 	markov := make([]*mat.Dense, steps)
 
-	for ch := 0; ch < m; ch++ {
+	for ch := range m {
 		uData := make([]float64, m*steps)
 		uData[ch*steps] = 1.0
 		u := mat.NewDense(m, steps, uData)
@@ -24,12 +24,12 @@ func impulseMarkov(t *testing.T, sys *System, steps int) []*mat.Dense {
 			t.Fatal(err)
 		}
 		yRaw := resp.Y.RawMatrix()
-		for k := 0; k < steps; k++ {
+		for k := range steps {
 			if markov[k] == nil {
 				markov[k] = mat.NewDense(p, m, nil)
 			}
 			raw := markov[k].RawMatrix()
-			for i := 0; i < p; i++ {
+			for i := range p {
 				raw.Data[i*raw.Stride+ch] = yRaw.Data[i*yRaw.Stride+k]
 			}
 		}
@@ -182,7 +182,7 @@ func TestERA_OrderSelection(t *testing.T) {
 
 	uTest := mat.NewDense(1, 50, nil)
 	uRaw := uTest.RawMatrix()
-	for k := 0; k < 50; k++ {
+	for k := range 50 {
 		uRaw.Data[k] = math.Sin(float64(k) * 0.2)
 	}
 
@@ -204,17 +204,11 @@ func TestERA_OrderSelection(t *testing.T) {
 func matDiffNorm(a, b *mat.Dense) float64 {
 	ra, ca := a.Dims()
 	rb, cb := b.Dims()
-	rows := ra
-	if rb < rows {
-		rows = rb
-	}
-	cols := ca
-	if cb < cols {
-		cols = cb
-	}
+	rows := min(rb, ra)
+	cols := min(cb, ca)
 	sum := 0.0
-	for i := 0; i < rows; i++ {
-		for j := 0; j < cols; j++ {
+	for i := range rows {
+		for j := range cols {
 			d := a.At(i, j) - b.At(i, j)
 			sum += d * d
 		}

--- a/thiran_test.go
+++ b/thiran_test.go
@@ -112,13 +112,7 @@ func TestThiranDelayInvalidOrder(t *testing.T) {
 func TestThiranDelayStability(t *testing.T) {
 	dt := 1.0
 	for _, D := range []float64{0.6, 1.5, 2.7, 3.7, 5.1} {
-		order := int(math.Floor(D))
-		if order < 1 {
-			order = 1
-		}
-		if order > 10 {
-			order = 10
-		}
+		order := min(max(int(math.Floor(D)), 1), 10)
 		sys, err := ThiranDelay(D*dt, order, dt)
 		if err != nil {
 			t.Fatalf("D=%v order=%d: %v", D, order, err)

--- a/time_domain.go
+++ b/time_domain.go
@@ -70,8 +70,8 @@ func (td timeDomain) convertDelayMatrixToDiscrete(delay *mat.Dense) (*mat.Dense,
 	out := mat.NewDense(r, c, nil)
 	inRaw := delay.RawMatrix()
 	outRaw := out.RawMatrix()
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			tau := inRaw.Data[i*inRaw.Stride+j]
 			samples, err := td.discreteDelaySamples(tau)
 			if err != nil {
@@ -89,8 +89,8 @@ func (td timeDomain) convertDelayMatrixToContinuous(delay *mat.Dense) *mat.Dense
 	out := mat.NewDense(r, c, nil)
 	inRaw := delay.RawMatrix()
 	outRaw := out.RawMatrix()
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			outRaw.Data[i*outRaw.Stride+j] = td.continuousDelay(inRaw.Data[i*inRaw.Stride+j])
 		}
 	}

--- a/transfer.go
+++ b/transfer.go
@@ -37,10 +37,10 @@ func (tf *TransferFunc) validateShape() (p, m int, err error) {
 func (tf *TransferFunc) Eval(s complex128) [][]complex128 {
 	p, m := tf.Dims()
 	result := make([][]complex128, p)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		result[i] = make([]complex128, m)
 		dv := Poly(tf.Den[i]).Eval(s)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			nv := Poly(tf.Num[i][j]).Eval(s)
 			h := nv / dv
 			if tf.Delay != nil && tf.Delay[i][j] != 0 {
@@ -49,7 +49,7 @@ func (tf *TransferFunc) Eval(s complex128) [][]complex128 {
 					h *= cmplx.Exp(-s * complex(tau, 0))
 				} else {
 					d := int(math.Round(tau))
-					for k := 0; k < d; k++ {
+					for range d {
 						h /= s
 					}
 				}
@@ -62,9 +62,9 @@ func (tf *TransferFunc) Eval(s complex128) [][]complex128 {
 
 func (tf *TransferFunc) evalInto(s complex128, dst []complex128) {
 	p, m := tf.Dims()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		dv := Poly(tf.Den[i]).Eval(s)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			h := Poly(tf.Num[i][j]).Eval(s) / dv
 			if tf.Delay != nil && tf.Delay[i][j] != 0 {
 				tau := tf.Delay[i][j]
@@ -72,7 +72,7 @@ func (tf *TransferFunc) evalInto(s complex128, dst []complex128) {
 					h *= cmplx.Exp(-s * complex(tau, 0))
 				} else {
 					d := int(math.Round(tau))
-					for k := 0; k < d; k++ {
+					for range d {
 						h /= s
 					}
 				}
@@ -255,8 +255,8 @@ func newTFWorkspace(n, m int) *tfWorkspace {
 func formDualSIMO(Ac, Bc, Cc *mat.Dense, row, n, m int, ws *tfWorkspace) {
 	aData := ws.aData
 	acRaw := Ac.RawMatrix()
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			aData[i*n+j] = acRaw.Data[j*acRaw.Stride+i]
 		}
 	}
@@ -264,8 +264,8 @@ func formDualSIMO(Ac, Bc, Cc *mat.Dense, row, n, m int, ws *tfWorkspace) {
 	copy(ws.bsimo, ccRaw.Data[row*ccRaw.Stride:row*ccRaw.Stride+n])
 	cData := ws.cData
 	bcRaw := Bc.RawMatrix()
-	for i := 0; i < m; i++ {
-		for j := 0; j < n; j++ {
+	for i := range m {
+		for j := range n {
 			cData[i*n+j] = bcRaw.Data[j*bcRaw.Stride+i]
 		}
 	}
@@ -359,7 +359,7 @@ func observabilityReduction(n, m int, ws *tfWorkspace, obsTol float64) (nobs int
 		impl.Dormhr(blas.Right, blas.NoTrans, m, n, 0, n-1, aData, n, tauHrd, cData, n, ws.workOrm, len(ws.workOrm))
 	}
 
-	for j := 0; j < n; j++ {
+	for j := range n {
 		for i := j + 2; i < n; i++ {
 			aData[i*n+j] = 0
 		}
@@ -427,9 +427,9 @@ func computeNumerators(cData []float64, n, nobs, m int, scale []float64, wPolys 
 	nums := make([][]float64, m)
 	scaleBuf := make(Poly, 0, nobs+1)
 	addBuf := make(Poly, 0, nobs+2)
-	for j := 0; j < m; j++ {
+	for j := range m {
 		var num Poly
-		for k := 0; k < nobs; k++ {
+		for k := range nobs {
 			coeff := cData[j*n+k] * scale[k]
 			if coeff != 0 {
 				scaleBuf = wPolys[nobs-1-k].ScaleTo(scaleBuf, coeff)
@@ -454,7 +454,7 @@ func ssToTFRow(Ac, Bc, Cc *mat.Dense, row, ncont, m int, obsTol float64, ws *tfW
 	zeroReturn := func() (int, []float64, [][]float64) {
 		den := []float64{1}
 		nums := make([][]float64, m)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			nums[j] = []float64{0}
 		}
 		return 0, den, nums
@@ -482,7 +482,7 @@ func ssToTFRow(Ac, Bc, Cc *mat.Dense, row, ncont, m int, obsTol float64, ws *tfW
 	}
 
 	// Scale upper triangle so V-poly recurrence works on monic form
-	for i := 0; i < nobs; i++ {
+	for i := range nobs {
 		for j := i + 1; j < nobs; j++ {
 			aData[i*n+j] *= scale[j] / scale[i]
 		}
@@ -524,7 +524,7 @@ func (tf *TransferFunc) StateSpace(opts *StateSpaceOpts) (*StateSpaceResult, err
 
 	degrees := make([]int, p)
 	totalN := 0
-	for i := 0; i < p; i++ {
+	for i := range p {
 		degrees[i] = len(tf.Den[i]) - 1
 		totalN += degrees[i]
 	}
@@ -532,9 +532,9 @@ func (tf *TransferFunc) StateSpace(opts *StateSpaceOpts) (*StateSpaceResult, err
 	if totalN == 0 {
 		D := mat.NewDense(p, m, nil)
 		dRaw := D.RawMatrix()
-		for i := 0; i < p; i++ {
+		for i := range p {
 			scale := 1.0 / tf.Den[i][0]
-			for j := 0; j < m; j++ {
+			for j := range m {
 				dRaw.Data[i*dRaw.Stride+j] = scale * tf.Num[i][j][0]
 			}
 		}
@@ -558,11 +558,11 @@ func (tf *TransferFunc) StateSpace(opts *StateSpaceOpts) (*StateSpaceResult, err
 	dRaw := D.RawMatrix()
 
 	ja := 0
-	for i := 0; i < p; i++ {
+	for i := range p {
 		di := degrees[i]
 		if di == 0 {
 			scale := 1.0 / tf.Den[i][0]
-			for j := 0; j < m; j++ {
+			for j := range m {
 				dRaw.Data[i*dRaw.Stride+j] = scale * tf.Num[i][j][0]
 			}
 			continue
@@ -575,7 +575,7 @@ func (tf *TransferFunc) StateSpace(opts *StateSpaceOpts) (*StateSpaceResult, err
 		}
 
 		umax := 0.0
-		for j := 0; j < m; j++ {
+		for j := range m {
 			if v := math.Abs(tf.Num[i][j][0]); v > umax {
 				umax = v
 			}
@@ -611,22 +611,22 @@ func (tf *TransferFunc) StateSpace(opts *StateSpaceOpts) (*StateSpaceResult, err
 
 		// Pad numerator to di+1 coefficients (left-pad with zeros)
 		padNum := make([][]float64, m)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			padNum[j] = make([]float64, di+1)
 			nj := len(tf.Num[i][j])
 			off := di + 1 - nj
-			for idx := 0; idx < nj; idx++ {
+			for idx := range nj {
 				if off+idx >= 0 {
 					padNum[j][off+idx] = tf.Num[i][j][idx]
 				}
 			}
 		}
 
-		for k := 0; k < di; k++ {
+		for k := range di {
 			row := ja + di - 1 - k
 			temp := -scale * tf.Den[i][k+1]
 			aRaw.Data[row*aRaw.Stride+(ja+di-1)] = temp
-			for j := 0; j < m; j++ {
+			for j := range m {
 				bRaw.Data[row*bRaw.Stride+j] = padNum[j][k+1] + temp*padNum[j][0]
 			}
 		}
@@ -635,7 +635,7 @@ func (tf *TransferFunc) StateSpace(opts *StateSpaceOpts) (*StateSpaceResult, err
 			aRaw.Data[(ja+di)*aRaw.Stride+(ja+di-1)] = 0
 		}
 
-		for j := 0; j < m; j++ {
+		for j := range m {
 			dRaw.Data[i*dRaw.Stride+j] = scale * padNum[j][0]
 		}
 
@@ -669,9 +669,9 @@ func (sys *System) Isproper() bool {
 
 func (tf *TransferFunc) Isproper() bool {
 	p, m := tf.Dims()
-	for i := 0; i < p; i++ {
+	for i := range p {
 		denDeg := len(tf.Den[i]) - 1
-		for j := 0; j < m; j++ {
+		for j := range m {
 			numDeg := len(tf.Num[i][j]) - 1
 			if numDeg > denDeg {
 				return false

--- a/transfer_test.go
+++ b/transfer_test.go
@@ -149,8 +149,8 @@ func TestTransferFunctionRoundtrip(t *testing.T) {
 	freqs := []complex128{1i, 0.5i, complex(1, 2)}
 	for _, s := range freqs {
 		tfMat := res.TF.Eval(s)
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				ssVal := evalSSij(sys, s, i, j)
 				if cmplx.Abs(tfMat[i][j]-ssVal) > 1e-6 {
 					t.Errorf("at s=%v [%d][%d]: TF=%v, SS=%v", s, i, j, tfMat[i][j], ssVal)
@@ -173,11 +173,11 @@ func TestTransferFunctionPureGain(t *testing.T) {
 	if res.MinimalOrder != 0 {
 		t.Fatalf("MinimalOrder = %d, want 0", res.MinimalOrder)
 	}
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		if len(res.TF.Den[i]) != 1 || res.TF.Den[i][0] != 1 {
 			t.Errorf("Den[%d] = %v, want [1]", i, res.TF.Den[i])
 		}
-		for j := 0; j < 2; j++ {
+		for j := range 2 {
 			want := D.At(i, j)
 			if len(res.TF.Num[i][j]) != 1 || math.Abs(res.TF.Num[i][j][0]-want) > 1e-15 {
 				t.Errorf("Num[%d][%d] = %v, want [%v]", i, j, res.TF.Num[i][j], want)
@@ -373,7 +373,7 @@ func TestTransferFunctionNonSymmetricSIMO(t *testing.T) {
 	freqs := []complex128{1i, 2i, complex(0.5, 1)}
 	for _, s := range freqs {
 		tfMat := res.TF.Eval(s)
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			ssVal := evalSSij(sys, s, i, 0)
 			if cmplx.Abs(tfMat[i][0]-ssVal) > 1e-8 {
 				t.Errorf("at s=%v [%d][0]: TF=%v, SS=%v", s, i, tfMat[i][0], ssVal)
@@ -409,7 +409,7 @@ func TestTransferFunctionNonSymmetricMISO(t *testing.T) {
 	freqs := []complex128{1i, 2i, complex(0.5, 1)}
 	for _, s := range freqs {
 		tfMat := res.TF.Eval(s)
-		for j := 0; j < 2; j++ {
+		for j := range 2 {
 			ssVal := evalSSij(sys, s, 0, j)
 			if cmplx.Abs(tfMat[0][j]-ssVal) > 1e-8 {
 				t.Errorf("at s=%v [0][%d]: TF=%v, SS=%v", s, j, tfMat[0][j], ssVal)
@@ -451,8 +451,8 @@ func TestTransferFunctionNonSymmetricMIMO(t *testing.T) {
 	freqs := []complex128{1i, 2i, complex(0.5, 1)}
 	for _, s := range freqs {
 		tfMat := res.TF.Eval(s)
-		for i := 0; i < 2; i++ {
-			for j := 0; j < 2; j++ {
+		for i := range 2 {
+			for j := range 2 {
 				ssVal := evalSSij(sys, s, i, j)
 				if cmplx.Abs(tfMat[i][j]-ssVal) > 1e-8 {
 					t.Errorf("at s=%v [%d][%d]: TF=%v, SS=%v", s, i, j, tfMat[i][j], ssVal)
@@ -471,8 +471,8 @@ func evalSS(sys *System, s complex128) complex128 {
 
 	// Build sI - A as complex matrix, solve
 	sIA := make([]complex128, n*n)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			sIA[i*n+j] = -complex(sys.A.At(i, j), 0)
 		}
 		sIA[i*n+i] += s
@@ -480,14 +480,14 @@ func evalSS(sys *System, s complex128) complex128 {
 
 	// Solve (sI - A) * x = B for x, then y = C*x + D
 	bVec := make([]complex128, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		bVec[i] = complex(sys.B.At(i, 0), 0)
 	}
 
 	x := complexSolve(sIA, bVec, n)
 
 	result := complex(sys.D.At(0, 0), 0)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		result += complex(sys.C.At(0, i), 0) * x[i]
 	}
 	return result
@@ -501,8 +501,8 @@ func evalSSij(sys *System, s complex128, oi, ij int) complex128 {
 	}
 
 	sIA := make([]complex128, n*n)
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			sIA[i*n+j] = -complex(sys.A.At(i, j), 0)
 		}
 		sIA[i*n+i] += s
@@ -510,13 +510,13 @@ func evalSSij(sys *System, s complex128, oi, ij int) complex128 {
 
 	// Solve for column ij of B
 	bVec := make([]complex128, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		bVec[i] = complex(sys.B.At(i, ij), 0)
 	}
 	x := complexSolve(sIA, bVec, n)
 
 	result := complex(sys.D.At(oi, ij), 0)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		result += complex(sys.C.At(oi, i), 0) * x[i]
 	}
 	return result
@@ -529,7 +529,7 @@ func complexSolve(A []complex128, b []complex128, n int) []complex128 {
 	x := make([]complex128, n)
 	copy(x, b)
 
-	for k := 0; k < n; k++ {
+	for k := range n {
 		// Partial pivoting
 		maxVal := cmplx.Abs(a[k*n+k])
 		maxRow := k
@@ -540,7 +540,7 @@ func complexSolve(A []complex128, b []complex128, n int) []complex128 {
 			}
 		}
 		if maxRow != k {
-			for j := 0; j < n; j++ {
+			for j := range n {
 				a[k*n+j], a[maxRow*n+j] = a[maxRow*n+j], a[k*n+j]
 			}
 			x[k], x[maxRow] = x[maxRow], x[k]

--- a/tuning.go
+++ b/tuning.go
@@ -2,6 +2,7 @@ package controlsys
 
 import (
 	"fmt"
+	"maps"
 	"math"
 )
 
@@ -159,8 +160,6 @@ func parameterGrid(param *TunableReal, points int) []float64 {
 
 func copyStringFloatMap(src map[string]float64) map[string]float64 {
 	out := make(map[string]float64, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
+	maps.Copy(out, src)
 	return out
 }

--- a/tuning_goal.go
+++ b/tuning_goal.go
@@ -212,8 +212,8 @@ func maxDCErrorFromOne(dc interface {
 }) float64 {
 	r, c := dc.Dims()
 	maxErr := 0.0
-	for i := 0; i < r; i++ {
-		for j := 0; j < c; j++ {
+	for i := range r {
+		for j := range c {
 			want := 0.0
 			if i == j {
 				want = 1

--- a/utils_test.go
+++ b/utils_test.go
@@ -18,8 +18,8 @@ func matClose(a, b *mat.Dense, tol float64) bool {
 	}
 	aRaw := a.RawMatrix()
 	bRaw := b.RawMatrix()
-	for i := 0; i < ar; i++ {
-		for j := 0; j < ac; j++ {
+	for i := range ar {
+		for j := range ac {
 			if math.Abs(aRaw.Data[i*aRaw.Stride+j]-bRaw.Data[i*bRaw.Stride+j]) > tol {
 				return false
 			}

--- a/zeros.go
+++ b/zeros.go
@@ -103,7 +103,7 @@ func mimoZeros(sys *System) (*ZerosResult, error) {
 
 	betaTol := float64(nu) * eps()
 	var zeros []complex128
-	for j := 0; j < nu; j++ {
+	for j := range nu {
 		if math.Abs(beta[j]) <= betaTol {
 			continue
 		}
@@ -182,8 +182,8 @@ func zerosStaircase(A, B, C, D *mat.Dense, n, m, p int) (afOut, bfOut []float64,
 		afStride = 1
 	}
 	af := make([]float64, mnu*afStride)
-	for r := 0; r < mnu; r++ {
-		for c := 0; c < numu; c++ {
+	for r := range mnu {
+		for c := range numu {
 			af[r*afStride+c] = bf[(numu-1-c)*stride+(mnu-1-r)]
 		}
 	}
@@ -346,7 +346,7 @@ func zerosStaircasePass(n, m, p, ro, sigma int, svlmax float64, abcd []float64, 
 					abcd[0:], stride, work)
 
 				// Zero out
-				for r := 0; r < rank2; r++ {
+				for r := range rank2 {
 					for c := 0; c < nu-rank2; c++ {
 						abcd[(irow2+r)*stride+mm1+c] = 0
 					}

--- a/zpk.go
+++ b/zpk.go
@@ -47,7 +47,7 @@ func NewZPKMIMO(zeros, poles [][][]complex128, gain [][]float64, dt float64) (*Z
 	if len(zeros) != p || len(poles) != p {
 		return nil, ErrDimensionMismatch
 	}
-	for i := 0; i < p; i++ {
+	for i := range p {
 		if len(gain[i]) != m || len(zeros[i]) != m || len(poles[i]) != m {
 			return nil, ErrDimensionMismatch
 		}
@@ -56,12 +56,12 @@ func NewZPKMIMO(zeros, poles [][][]complex128, gain [][]float64, dt float64) (*Z
 	zCopy := make([][][]complex128, p)
 	pCopy := make([][][]complex128, p)
 	gCopy := make([][]float64, p)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		zCopy[i] = make([][]complex128, m)
 		pCopy[i] = make([][]complex128, m)
 		gCopy[i] = make([]float64, m)
 		copy(gCopy[i], gain[i])
-		for j := 0; j < m; j++ {
+		for j := range m {
 			if err := validatePoles(zeros[i][j]); err != nil {
 				return nil, err
 			}
@@ -93,9 +93,9 @@ func (z *ZPK) IsDiscrete() bool   { return z.Dt > 0 }
 func (z *ZPK) Eval(s complex128) [][]complex128 {
 	p, m := z.Dims()
 	result := make([][]complex128, p)
-	for i := 0; i < p; i++ {
+	for i := range p {
 		result[i] = make([]complex128, m)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			result[i][j] = zpkEvalChannel(s, z.Zeros[i][j], z.Poles[i][j], z.Gain[i][j])
 		}
 	}
@@ -122,8 +122,8 @@ func (z *ZPK) FreqResponse(omega []float64) (*FreqResponseMatrix, error) {
 			s = cmplx.Exp(complex(0, w*dt))
 		}
 		off := k * p * m
-		for i := 0; i < p; i++ {
-			for j := 0; j < m; j++ {
+		for i := range p {
+			for j := range m {
 				data[off+i*m+j] = zpkEvalChannel(s, z.Zeros[i][j], z.Poles[i][j], z.Gain[i][j])
 			}
 		}
@@ -142,11 +142,11 @@ func (z *ZPK) TransferFunction() (*TransferFunc, error) {
 		Dt:  z.Dt,
 	}
 
-	for i := 0; i < p; i++ {
+	for i := range p {
 		commonPoles := commonDenomPoles(z.Poles[i])
 		tf.Den[i] = []float64(polyFromComplexRoots(sortConjugatePairs(commonPoles)))
 		tf.Num[i] = make([][]float64, m)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			ch := newRationalChannel(z.Zeros[i][j], z.Poles[i][j], z.Gain[i][j])
 			tf.Num[i][j] = ch.numeratorForCommonPoles(commonPoles)
 		}
@@ -168,11 +168,11 @@ func (tf *TransferFunc) ZPK() (*ZPK, error) {
 		Dt:    tf.Dt,
 	}
 
-	for i := 0; i < p; i++ {
+	for i := range p {
 		z.Zeros[i] = make([][]complex128, m)
 		z.Poles[i] = make([][]complex128, m)
 		z.Gain[i] = make([]float64, m)
-		for j := 0; j < m; j++ {
+		for j := range m {
 			ch, err := rationalChannelFromPolynomials(tf.Num[i][j], tf.Den[i])
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary
- upgrade the module Go directive from 1.25.3 to 1.26.3
- run `go fix ./...` with Go 1.26.3, applying the generated modernizer rewrites
- document `go fix ./...` alongside `go vet ./...` in AGENTS.md static checks

## Validation
- `go fix ./... && go vet ./...`
- `go test -v -count=1`
- baseline: `go test -bench=. -benchmem -run '^$' -count=6 > /tmp/controlsys-before.txt`
- after: `go test -bench=. -benchmem -run '^$' -count=6 > /tmp/controlsys-after.txt`
- `benchstat /tmp/controlsys-before.txt /tmp/controlsys-after.txt > /tmp/controlsys-benchstat.txt`

Benchmark summary: sec/op geomean `39.95µ -> 40.42µ` (`+1.18%`), B/op geomean `-0.01%`, allocs/op geomean `-0.00%`. Individual timings moved both directions; allocations stayed effectively flat.

## References
- https://go.dev/blog/gofix
- https://go.dev/dl/
