### PR TITLE
[codex] Harden CI release checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+env:
+  GO_VERSION: '1.26.3'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -7,6 +9,46 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: ${{ env.GO_VERSION }}
+      - run: go fix ./...
+      - run: git diff --exit-code
       - run: go vet ./...
       - run: go test -v -count=1 -race ./...
+  downstream-consumer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Build external consumer with documented replaces
+        run: |
+          tmp="$(mktemp -d)"
+          cd "$tmp"
+          go mod init example.com/controlsys-consumer
+          go mod edit -require=github.com/jamestjsp/controlsys@v0.0.0
+          go mod edit -replace=github.com/jamestjsp/controlsys="$GITHUB_WORKSPACE"
+          go mod edit -replace=gonum.org/v1/gonum=github.com/jamestjsp/gonum@v0.17.3-fork
+          cat > controlsys_consumer_test.go <<'EOF'
+          package controlsysconsumer
+
+          import (
+            "testing"
+
+            "github.com/jamestjsp/controlsys"
+            "gonum.org/v1/gonum/mat"
+          )
+
+          func TestConsumerCanConstructModel(t *testing.T) {
+            sys, err := controlsys.NewGain(mat.NewDense(1, 1, []float64{2}), 0)
+            if err != nil {
+              t.Fatal(err)
+            }
+            _, m, p := sys.Dims()
+            if m != 1 || p != 1 {
+              t.Fatalf("dims = inputs %d outputs %d, want 1x1", m, p)
+            }
+          }
+          EOF
+          go mod tidy
+          go test ./...

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ This package is intended to be usable in production control and estimation code,
 - Pin both `controlsys` and the required gonum fork to explicit versions.
 - Validate mission-critical models against an external reference, especially for ill-conditioned realizations and delay-heavy systems.
 - `System` values are mutable. Use `Copy` before sharing a model across goroutines that may mutate names, delays, notes, or other receiver state. Use `Validate` after direct field edits.
-- The repository CI runs `go vet ./...` and `go test -v -count=1 -race ./...`; those are the recommended baseline checks for downstream integrations. Run `go fix ./...` before `go vet ./...` when updating code.
+- The repository CI runs `go fix ./...`, `go vet ./...`, `go test -v -count=1 -race ./...`, and a downstream consumer import check; those are the recommended baseline checks for downstream integrations.
+- Public API and mutation semantics are tracked in [docs/api-mutation-audit.md](docs/api-mutation-audit.md).
 
 ## Features
 

--- a/docs/api-mutation-audit.md
+++ b/docs/api-mutation-audit.md
@@ -1,0 +1,53 @@
+# API and Mutation Audit
+
+This checklist records production-readiness work for the public API surface.
+The package is a toolbox-style control-system package, so a broad public API and
+a central state-space model are expected. The audit target is consistency, not
+shrinking the toolbox shape.
+
+## Method Semantics
+
+Public APIs should make receiver ownership clear:
+
+- Constructors copy caller-owned matrices and slices unless documented otherwise.
+- Transformations that return `*System` should leave the receiver unchanged.
+- Configuration methods that mutate the receiver should use imperative names such
+  as `SetDelay`, `SetInputDelay`, or `SetOutputName`.
+- Any method returning shared workspace-backed storage must document that callers
+  should copy results they keep across calls.
+- Direct field edits remain supported for expert users, but users should call
+  `Validate` after edits.
+
+## API Consistency
+
+Review public additions against these rules before release:
+
+- Prefer typed option structs over free-form strings for new APIs.
+- Keep nil options as the default behavior for analysis and design routines.
+- Return sentinel-wrapped errors for unsupported model families such as
+  non-SISO, descriptor, delay, or wrong-time-domain cases.
+- Use the project vocabulary from `CONTEXT.md`: model, state-space model,
+  feedthrough, sample time, and delay.
+- Keep continuous-time and discrete-time behavior explicit in names,
+  documentation, or validation errors.
+
+## Release Gates
+
+Before tagging a production release:
+
+- CI must run `go fix ./...`, `go vet ./...`, and `go test -v -count=1 -race ./...`.
+- CI must build a downstream module that imports `github.com/jamestjsp/controlsys`
+  and applies the documented Gonum fork replacement.
+- Public API changes should update `README.md`, `doc.go`, examples, or this audit
+  when behavior or ownership expectations change.
+- Numerically sensitive changes should include external-reference tests using
+  MATLAB or python-control fixtures when possible.
+
+## Current Follow-Up Items
+
+- Audit every exported `*System` method and classify it as mutating,
+  non-mutating, or workspace-backed.
+- Replace string method selectors with typed constants where that can be done
+  without breaking existing users.
+- Track required routines from the Gonum fork and upstream them or document why
+  each remains fork-only.


### PR DESCRIPTION
## Summary

- Align CI with the module Go toolchain version through a single `GO_VERSION` value.
- Add `go fix ./...` plus clean-diff enforcement before vet and race tests.
- Add a downstream consumer import check that applies the documented Gonum fork replacement.
- Document API and mutation-semantics release gates in `docs/api-mutation-audit.md` and link them from the README.

## Why

The production-readiness checks previously missed two release risks: CI was using a different Go version than the module, and no automated check proved that a fresh downstream module could import `controlsys` with the required Gonum replacement.

## Validation

- `gopls` diagnostics: no diagnostics
- `/opt/homebrew/bin/go vet ./...`
- `/opt/homebrew/bin/go test -v -count=1 ./...`
- `/opt/homebrew/bin/go test -v -count=1 -race ./...`
- Temporary downstream consumer module with documented replaces: `go test ./...`
- `git diff --check`
- Workflow YAML parse check